### PR TITLE
Remove J2ME-compat 'split'

### DIFF
--- a/javarosa/src/main/java/org/javarosa/core/util/DataUtil.java
+++ b/javarosa/src/main/java/org/javarosa/core/util/DataUtil.java
@@ -12,7 +12,6 @@ public class DataUtil {
     static Integer[] iarray;
 
     static UnionLambda unionLambda = new UnionLambda();
-    static StringSplitter stringSplitter = new StringSplitter();
 
     /**
      * Get Integer object that corresponds to int argument from a
@@ -58,91 +57,21 @@ public class DataUtil {
     }
 
     public static String[] splitOnSpaces(String s) {
-        return stringSplitter.splitOnSpaces(s);
+        if ("".equals(s)) {
+            return new String[0];
+        }
+        return s.split("[ ]+");
     }
 
     public static String[] splitOnDash(String s) {
-        return stringSplitter.splitOnDash(s);
+        return s.split("-");
     }
 
     public static String[] splitOnColon(String s) {
-        return stringSplitter.splitOnColon(s);
+        return s.split(":");
     }
 
     public static String[] splitOnPlus(String s) {
-        return stringSplitter.splitOnPlus(s);
+        return s.split("[+]");
     }
-
-    public static void setStringSplitter(StringSplitter newStringSplitter) {
-        stringSplitter = newStringSplitter;
-    }
-
-    public static class StringSplitter {
-
-        public String[] splitOnSpaces(String s) {
-            Vector<String> vectorSplit = split(s, " ", true);
-            return stringVectorToArray(vectorSplit);
-        }
-
-        public String[] splitOnDash(String s) {
-            Vector<String> vectorSplit = split(s, "-", false);
-            return stringVectorToArray(vectorSplit);
-        }
-
-        public String[] splitOnColon(String s) {
-            Vector<String> vectorSplit = split(s, ":", false);
-            return stringVectorToArray(vectorSplit);
-        }
-
-        public String[] splitOnPlus(String s) {
-            Vector<String> vectorSplit = split(s, "+", false);
-            return stringVectorToArray(vectorSplit);
-        }
-
-        private static String[] stringVectorToArray(Vector<String> v) {
-            String [] arr = new String[v.size()];
-            for (int i = 0; i < v.size(); i++) {
-                arr[i] = v.elementAt(i);
-            }
-            return arr;
-        }
-    }
-
-
-
-    /**
-     * Custom implementation of tokenizing a string based on a delimiter, for use in j2me
-     * (Java's String.split() method was not available until Java 1.4)
-     *
-     * @param str                       The string to be split
-     * @param delimiter                 The delimeter to be used
-     * @param combineMultipleDelimiters If two delimiters occur in a row,
-     *                                  remove the empty strings created by their split
-     * @return A vector of strings contained in original which were separated by the delimiter
-     */
-    public static Vector<String> split(String str, String delimiter, boolean combineMultipleDelimiters) {
-        Vector<String> pieces = new Vector<>();
-
-        int index = str.indexOf(delimiter);
-        // add all substrings, split by delimiter, to pieces.
-        while (index >= 0) {
-            pieces.addElement(str.substring(0, index));
-            str = str.substring(index + delimiter.length());
-            index = str.indexOf(delimiter);
-        }
-        pieces.addElement(str);
-
-        // remove all pieces that are empty string
-        if (combineMultipleDelimiters) {
-            for (int i = 0; i < pieces.size(); i++) {
-                if (pieces.elementAt(i).length() == 0) {
-                    pieces.removeElementAt(i);
-                    i--;
-                }
-            }
-        }
-
-        return pieces;
-    }
-
 }


### PR DESCRIPTION
Now that we don't support J2ME we can remove unneeded override abstractions added in https://github.com/dimagi/commcare-j2me/pull/304