### PR TITLE
Move case selection predicate to 1st position when loading persistent case tiles

### DIFF
--- a/backend/src/org/commcare/suite/model/EntityDatum.java
+++ b/backend/src/org/commcare/suite/model/EntityDatum.java
@@ -122,7 +122,11 @@ public class EntityDatum extends SessionDatum {
         if (predicates == null) {
             predicates = new Vector<XPathExpression>();
         }
-        predicates.addElement(new XPathEqExpr(XPathEqExpr.EQ, XPathReference.getPathExpr(this.getValue()), new XPathStringLiteral(elementId)));
+        // For speed reasons, add a case id selection as the first predicate
+        // This has potential to change outcomes if other predicates utilize 'position'
+        XPathEqExpr caseIdSelection =
+                new XPathEqExpr(XPathEqExpr.EQ, XPathReference.getPathExpr(this.getValue()), new XPathStringLiteral(elementId));
+        predicates.insertElementAt(caseIdSelection, 0);
         nodesetRef.addPredicate(nodesetRef.size() - 1, predicates);
 
         Vector<TreeReference> elements = ec.expandReference(nodesetRef);


### PR DESCRIPTION
Final fix for http://manage.dimagi.com/default.asp?221062
Reduces 26 second form load to 3.5 seconds

The idea is to put the case id selection predicate first, so it doesn't load all the cases in the db and run all the other predicates over those cases first. Case IDs are indexed in the db, so doing that first will be super fast.  