### PR TITLE
Allow case list to auto-launch search callout

### DIFF
--- a/backend/src/org/commcare/suite/model/Callout.java
+++ b/backend/src/org/commcare/suite/model/Callout.java
@@ -32,6 +32,7 @@ public class Callout implements Externalizable, DetailTemplate {
     private String type;
     private Hashtable<String, String> extras;
     private Vector<String> responses;
+    private boolean isAutoLaunching;
 
     /**
      * Allows case list intent callouts to map result data to cases. 'header'
@@ -49,7 +50,7 @@ public class Callout implements Externalizable, DetailTemplate {
 
     public Callout(String actionName, String image, String displayName,
                    Hashtable<String, String> extras, Vector<String> responses,
-                   DetailField responseDetail, String type) {
+                   DetailField responseDetail, String type, boolean isAutoLaunching) {
         this.actionName = actionName;
         this.image = image;
         this.displayName = displayName;
@@ -57,6 +58,7 @@ public class Callout implements Externalizable, DetailTemplate {
         this.responses = responses;
         this.responseDetail = responseDetail;
         this.type = type;
+        this.isAutoLaunching = isAutoLaunching;
     }
 
     @Override
@@ -96,6 +98,7 @@ public class Callout implements Externalizable, DetailTemplate {
         responses = (Vector<String>)ExtUtil.read(in, new ExtWrapList(String.class), pf);
         responseDetail = (DetailField)ExtUtil.read(in, new ExtWrapNullable(DetailField.class), pf);
         type = ExtUtil.readString(in);
+        isAutoLaunching = ExtUtil.readBool(in);
     }
 
     @Override
@@ -107,6 +110,7 @@ public class Callout implements Externalizable, DetailTemplate {
         ExtUtil.write(out, new ExtWrapList(responses));
         ExtUtil.write(out, new ExtWrapNullable(responseDetail));
         ExtUtil.writeString(out, type);
+        ExtUtil.writeBool(out, isAutoLaunching);
     }
 
     public String getImage() {
@@ -131,5 +135,9 @@ public class Callout implements Externalizable, DetailTemplate {
 
     public DetailField getResponseDetailField() {
         return responseDetail;
+    }
+
+    public boolean isAutoLaunching() {
+        return isAutoLaunching;
     }
 }

--- a/backend/src/org/commcare/xml/CalloutParser.java
+++ b/backend/src/org/commcare/xml/CalloutParser.java
@@ -28,6 +28,7 @@ public class CalloutParser extends ElementParser<Callout> {
         String image = parser.getAttributeValue(null, "image");
         String displayName = parser.getAttributeValue(null, "name");
         String type = parser.getAttributeValue(null, "type");
+        boolean isAutoLaunching = "true".equals(parser.getAttributeValue(null, "auto_launch"));
 
         Hashtable<String, String> extras = new Hashtable<>();
         Vector<String> responses = new Vector<>();
@@ -43,6 +44,6 @@ public class CalloutParser extends ElementParser<Callout> {
                 responseDetailField = new DetailFieldParser(parser, null, "'lookup callout detail field'").parse();
             }
         }
-        return new Callout(actionName, image, displayName, extras, responses, responseDetailField, type);
+        return new Callout(actionName, image, displayName, extras, responses, responseDetailField, type, isAutoLaunching);
     }
 }


### PR DESCRIPTION
Allow the addition of `auto_launch="true"` to a case list search callout xml block. Adding this will make the case list perform a callout when it launches.

Possible Health project wants to test out enabling this feature.

```
<lookup
  auto_launch="true" 
  action="org.commcare.dalvik.fake.simprints.IDENTIFY"
  image="jr://file/commcare/image/module1_case_list_lookup.png" 
  name="Scan fingerprint">
    ...
</lookup>
```

cross-request: https://github.com/dimagi/commcare-android/pull/1373