### PR TITLE
Fix timemout constants refactor

### DIFF
--- a/core/org/commcare/core/network/ModernHttpRequester.java
+++ b/core/org/commcare/core/network/ModernHttpRequester.java
@@ -33,12 +33,12 @@ public class ModernHttpRequester implements ResponseStreamAccessor {
     /**
      * How long to wait when opening network connection in milliseconds
      */
-    public static final int CONNECTION_TIMEOUT = (int)TimeUnit.SECONDS.toMillis(2);
+    public static final int CONNECTION_TIMEOUT = (int)TimeUnit.MINUTES.toMillis(2);
 
     /**
      * How long to wait when receiving data (in milliseconds)
      */
-    public static final int CONNECTION_SO_TIMEOUT = (int)TimeUnit.SECONDS.toMillis(1);
+    public static final int CONNECTION_SO_TIMEOUT = (int)TimeUnit.MINUTES.toMillis(1);
 
     private final boolean isPostRequest;
     private final BitCacheFactory.CacheDirSetup cacheDirSetup;


### PR DESCRIPTION
Made a mistake when changing constants to be hand computed to using a helper lib in https://github.com/dimagi/commcare-core/pull/337

The contstants updated should be 1 & 2 minutes not 1 & 2 seconds