### PR TITLE
Load text/callout query info from pre-form navigation into session instance

### DIFF
--- a/backend/src/org/commcare/session/SessionInstanceBuilder.java
+++ b/backend/src/org/commcare/session/SessionInstanceBuilder.java
@@ -19,41 +19,49 @@ public class SessionInstanceBuilder {
                                                   Hashtable<String, String> userFields) {
         TreeElement sessionRoot = new TreeElement("session", 0);
 
-        addDatums(sessionRoot, frame);
-        addSessionNav(sessionRoot, frame);
+        addSessionNavData(sessionRoot, frame);
         addMetadata(sessionRoot, deviceId, appversion, username, userId);
         addUserProperties(sessionRoot, userFields);
 
         return new FormInstance(sessionRoot, "session");
     }
 
-    private static void addDatums(TreeElement sessionRoot, SessionFrame frame) {
+    private static void addSessionNavData(TreeElement sessionRoot, SessionFrame frame) {
         TreeElement sessionData = new TreeElement("data", 0);
-
+        addDatums(sessionData, frame);
+        addUserQueryData(sessionData, frame);
         sessionRoot.addChild(sessionData);
+    }
+
+    /**
+     * Add datums chosen by user to the session
+     */
+    private static void addDatums(TreeElement sessionData, SessionFrame frame) {
         for (StackFrameStep step : frame.getSteps()) {
             if (SessionFrame.STATE_DATUM_VAL.equals(step.getType())) {
                 Vector<TreeElement> matchingElements =
                         sessionData.getChildrenWithName(step.getId());
-
                 if (matchingElements.size() > 0) {
                     matchingElements.elementAt(0).setValue(new UncastData(step.getValue()));
                 } else {
-                    TreeElement datum = new TreeElement(step.getId());
-                    datum.setValue(new UncastData(step.getValue()));
-                    sessionData.addChild(datum);
+                    addData(sessionData, step.getId(), step.getValue());
                 }
             }
         }
     }
 
-    private static void addSessionNav(TreeElement sessionRoot, SessionFrame frame) {
+    /**
+     * Add data to session tracking queries user made before entering form
+     */
+    private static void addUserQueryData(TreeElement sessionData, SessionFrame frame) {
         for (StackFrameStep step : frame.getSteps()) {
             Object textSearch = step.getExtra(KEY_LAST_QUERY_STRING);
             if (textSearch != null) {
+                addData(sessionData, "stringquery", "1");
             }
             Object entitySelectCalloutSearch = step.getExtra(KEY_ENTITY_LIST_EXTRA_DATA);
             if (entitySelectCalloutSearch != null) {
+                addData(sessionData, "calloutquery", "1");
             }
         }
     }

--- a/backend/src/org/commcare/session/SessionInstanceBuilder.java
+++ b/backend/src/org/commcare/session/SessionInstanceBuilder.java
@@ -10,6 +10,9 @@ import java.util.Hashtable;
 import java.util.Vector;
 
 public class SessionInstanceBuilder {
+    public static final String KEY_LAST_QUERY_STRING = "LAST_QUERY_STRING";
+    public static final String KEY_ENTITY_LIST_EXTRA_DATA = "entity-list-data";
+
     public static FormInstance getSessionInstance(SessionFrame frame, String deviceId,
                                                   String appversion, String username,
                                                   String userId,
@@ -17,6 +20,7 @@ public class SessionInstanceBuilder {
         TreeElement sessionRoot = new TreeElement("session", 0);
 
         addDatums(sessionRoot, frame);
+        addSessionNav(sessionRoot, frame);
         addMetadata(sessionRoot, deviceId, appversion, username, userId);
         addUserProperties(sessionRoot, userFields);
 
@@ -39,6 +43,17 @@ public class SessionInstanceBuilder {
                     datum.setValue(new UncastData(step.getValue()));
                     sessionData.addChild(datum);
                 }
+            }
+        }
+    }
+
+    private static void addSessionNav(TreeElement sessionRoot, SessionFrame frame) {
+        for (StackFrameStep step : frame.getSteps()) {
+            Object textSearch = step.getExtra(KEY_LAST_QUERY_STRING);
+            if (textSearch != null) {
+            }
+            Object entitySelectCalloutSearch = step.getExtra(KEY_ENTITY_LIST_EXTRA_DATA);
+            if (entitySelectCalloutSearch != null) {
             }
         }
     }

--- a/backend/src/org/commcare/session/SessionInstanceBuilder.java
+++ b/backend/src/org/commcare/session/SessionInstanceBuilder.java
@@ -15,10 +15,18 @@ public class SessionInstanceBuilder {
                                                   String userId,
                                                   Hashtable<String, String> userFields) {
         TreeElement sessionRoot = new TreeElement("session", 0);
+
+        addDatums(sessionRoot, frame);
+        addMetadata(sessionRoot, deviceId, appversion, username, userId);
+        addUserProperties(sessionRoot, userFields);
+
+        return new FormInstance(sessionRoot, "session");
+    }
+
+    private static void addDatums(TreeElement sessionRoot, SessionFrame frame) {
         TreeElement sessionData = new TreeElement("data", 0);
 
         sessionRoot.addChild(sessionData);
-
         for (StackFrameStep step : frame.getSteps()) {
             if (SessionFrame.STATE_DATUM_VAL.equals(step.getType())) {
                 Vector<TreeElement> matchingElements =
@@ -33,7 +41,11 @@ public class SessionInstanceBuilder {
                 }
             }
         }
+    }
 
+    private static void addMetadata(TreeElement sessionRoot, String deviceId,
+                                    String appversion, String username,
+                                    String userId) {
         TreeElement sessionMeta = new TreeElement("context", 0);
 
         addData(sessionMeta, "deviceid", deviceId);
@@ -42,18 +54,20 @@ public class SessionInstanceBuilder {
         addData(sessionMeta, "userid", userId);
 
         sessionRoot.addChild(sessionMeta);
+    }
 
+    private static void addUserProperties(TreeElement sessionRoot,
+                                          Hashtable<String, String> userFields) {
         TreeElement user = new TreeElement("user", 0);
         TreeElement userData = new TreeElement("data", 0);
         user.addChild(userData);
         for (Enumeration en = userFields.keys(); en.hasMoreElements(); ) {
-            String key = (String) en.nextElement();
+            String key = (String)en.nextElement();
             addData(userData, key, userFields.get(key));
         }
 
         sessionRoot.addChild(user);
 
-        return new FormInstance(sessionRoot, "session");
     }
 
     private static void addData(TreeElement root, String name, String data) {
@@ -61,4 +75,5 @@ public class SessionInstanceBuilder {
         datum.setValue(new UncastData(data));
         root.addChild(datum);
     }
+
 }

--- a/backend/src/org/commcare/session/SessionInstanceBuilder.java
+++ b/backend/src/org/commcare/session/SessionInstanceBuilder.java
@@ -4,6 +4,7 @@ import org.commcare.suite.model.StackFrameStep;
 import org.javarosa.core.model.data.UncastData;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.TreeElement;
+import org.javarosa.core.util.OrderedHashtable;
 
 import java.util.Enumeration;
 import java.util.Hashtable;
@@ -55,16 +56,34 @@ public class SessionInstanceBuilder {
      */
     private static void addUserQueryData(TreeElement sessionData, SessionFrame frame) {
         for (StackFrameStep step : frame.getSteps()) {
-            Object textSearch = step.getExtra(KEY_LAST_QUERY_STRING);
+            String textSearch = getStringQuery(step);
             if (textSearch != null) {
-                addData(sessionData, "stringquery", "1");
+                addData(sessionData, "stringquery", textSearch);
             }
-            Object entitySelectCalloutSearch = step.getExtra(KEY_ENTITY_LIST_EXTRA_DATA);
-            if (entitySelectCalloutSearch != null) {
-                addData(sessionData, "calloutquery", "1");
+
+            String calloutResultCount = getCalloutSearchResultCount(step);
+            if (calloutResultCount != null) {
+                addData(sessionData, "fingerprintquery", calloutResultCount);
             }
         }
     }
+
+    private static String getStringQuery(StackFrameStep step) {
+        Object extra = step.getExtra(KEY_LAST_QUERY_STRING);
+        if (extra != null && extra instanceof String && !"".equals(extra)) {
+            return (String) extra;
+        }
+        return null;
+    }
+
+    private static String getCalloutSearchResultCount(StackFrameStep step) {
+        Object entitySelectCalloutSearch = step.getExtra(KEY_ENTITY_LIST_EXTRA_DATA);
+        if (entitySelectCalloutSearch != null && entitySelectCalloutSearch instanceof OrderedHashtable) {
+            return "" + ((OrderedHashtable)entitySelectCalloutSearch).keySet().size();
+        }
+        return null;
+    }
+
 
     private static void addMetadata(TreeElement sessionRoot, String deviceId,
                                     String appversion, String username,


### PR DESCRIPTION
In form entry when the user used the search bar or made a fingerprint id callout to filter the case list, make the following nodes available:

- `instance("commcaresession")/session/data/stringquery`: set to the string query
- `instance("commcaresession")/session/data/fingerprintquery`: set number of identification results

Useful for auditing purposes for projects that want to see how often fingerprint scanning is used over manual case list searching.

cross-request: https://github.com/dimagi/commcare-android/pull/1388

docs: https://confluence.dimagi.com/display/ccinternal/Auditing