### PR TITLE
Catch XPathException caused by misconfigured sync-post relevant expression

### DIFF
--- a/backend/src/org/commcare/session/SessionNavigator.java
+++ b/backend/src/org/commcare/session/SessionNavigator.java
@@ -62,7 +62,15 @@ public class SessionNavigator {
     public void startNextSessionStep() {
         currentSession = responder.getSessionForNavigator();
         ec = responder.getEvalContextForNavigator();
-        String needed = currentSession.getNeededData(ec);
+        String needed;
+        try {
+            needed = currentSession.getNeededData(ec);
+        } catch (XPathException e) {
+            thrownException = e;
+            sendResponse(XPATH_EXCEPTION_THROWN);
+            return;
+        }
+
         if (needed == null) {
             readyToProceed();
         } else if (needed.equals(SessionFrame.STATE_COMMAND_ID)) {

--- a/backend/src/org/commcare/session/SessionNavigator.java
+++ b/backend/src/org/commcare/session/SessionNavigator.java
@@ -71,18 +71,31 @@ public class SessionNavigator {
             return;
         }
 
+        dispatchOnNeededData(needed);
+    }
+
+    private void dispatchOnNeededData(String needed) {
         if (needed == null) {
             readyToProceed();
-        } else if (needed.equals(SessionFrame.STATE_COMMAND_ID)) {
-            sendResponse(GET_COMMAND);
-        } else if (needed.equals(SessionFrame.STATE_SYNC_REQUEST)) {
-            sendResponse(START_SYNC_REQUEST);
-        } else if (needed.equals(SessionFrame.STATE_QUERY_REQUEST)) {
-            sendResponse(PROCESS_QUERY_REQUEST);
-        } else if (needed.equals(SessionFrame.STATE_DATUM_VAL)) {
-            handleGetDatum();
-        } else if (needed.equals(SessionFrame.STATE_DATUM_COMPUTED)) {
-            handleCompute();
+            return;
+        }
+
+        switch (needed) {
+            case SessionFrame.STATE_COMMAND_ID:
+                sendResponse(GET_COMMAND);
+                break;
+            case SessionFrame.STATE_SYNC_REQUEST:
+                sendResponse(START_SYNC_REQUEST);
+                break;
+            case SessionFrame.STATE_QUERY_REQUEST:
+                sendResponse(PROCESS_QUERY_REQUEST);
+                break;
+            case SessionFrame.STATE_DATUM_VAL:
+                handleGetDatum();
+                break;
+            case SessionFrame.STATE_DATUM_COMPUTED:
+                handleCompute();
+                break;
         }
     }
 


### PR DESCRIPTION
From the ACRA crash:

```
java.lang.RuntimeException: Failure delivering result ResultInfo{who=null, request=2, result=-1, data=Intent { cmp=org.commcare.dalvik/org.commcare.activities.EntitySelectActivity (has extras) }} to activity {org.commcare.dalvik/org.commcare.activities.CommCareHomeActivity}: org.javarosa.xpath.XPathMissingInstanceException: XPath evaluation: Instance referenced by instance(casedb)/casedb/case[@case_id = instance(querysession)/session/data/case_id] does not exist
at android.app.ActivityThread.deliverResults(ActivityThread.java:3733)
at android.app.ActivityThread.handleSendResult(ActivityThread.java:3776)
at android.app.ActivityThread.-wrap16(ActivityThread.java)
at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1412)
at android.os.Handler.dispatchMessage(Handler.java:102)
at android.os.Looper.loop(Looper.java:148)
at android.app.ActivityThread.main(ActivityThread.java:5461)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
Caused by: org.javarosa.xpath.XPathMissingInstanceException: XPath evaluation: Instance referenced by instance(casedb)/casedb/case[@case_id = instance(querysession)/session/data/case_id] does not exist
at org.javarosa.xpath.expr.XPathPathExpr.evalRaw(XPathPathExpr.java:195)
at org.javarosa.xpath.expr.XPathPathExpr.evalRaw(XPathPathExpr.java:38)
at org.javarosa.xpath.expr.XPathExpression.eval(XPathExpression.java:25)
at org.javarosa.xpath.expr.XPathFuncExpr.evalRaw(XPathFuncExpr.java:184)
at org.javarosa.xpath.expr.XPathExpression.eval(XPathExpression.java:25)
at org.javarosa.xpath.expr.XPathEqExpr.evalRaw(XPathEqExpr.java:29)
at org.javarosa.xpath.expr.XPathExpression.eval(XPathExpression.java:25)
at org.javarosa.xpath.expr.XPathExpression.eval(XPathExpression.java:14)
at org.commcare.session.RemoteQuerySessionManager.evalXpathExpression(RemoteQuerySessionManager.java:88)
at org.commcare.suite.model.SyncPost.isRelevant(SyncPost.java:60)
at org.commcare.session.CommCareSession.getNeededData(CommCareSession.java:202)
at org.commcare.session.SessionNavigator.startNextSessionStep(SessionNavigator.java:65)
at org.commcare.activities.CommCareHomeActivity.startNextSessionStepSafe(CommCareHomeActivity.java:555)
at org.commcare.activities.CommCareHomeActivity.onActivityResult(CommCareHomeActivity.java:530)
```