### PR TITLE
Create new object when reading from CLI storage

### DIFF
--- a/backend/src/org/commcare/resources/model/installers/LocaleFileInstaller.java
+++ b/backend/src/org/commcare/resources/model/installers/LocaleFileInstaller.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package org.commcare.resources.model.installers;
 
 import org.commcare.resources.model.MissingMediaException;
@@ -20,7 +17,6 @@ import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.services.locale.LocalizationUtils;
 import org.javarosa.core.services.locale.TableLocaleSource;
-import org.javarosa.core.util.OrderedHashtable;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.ExtWrapMap;
@@ -267,7 +263,7 @@ public class LocaleFileInstaller implements ResourceInstaller<CommCareInstance> 
             throws IOException, DeserializationException {
         locale = ExtUtil.readString(in);
         localReference = ExtUtil.readString(in);
-        cache = (OrderedHashtable)ExtUtil.nullIfEmpty((OrderedHashtable)ExtUtil.read(in, new ExtWrapMap(String.class, String.class), pf));
+        cache = (Hashtable)ExtUtil.nullIfEmpty((Hashtable)ExtUtil.read(in, new ExtWrapMap(String.class, String.class), pf));
     }
 
     @Override

--- a/javarosa/src/main/java/org/javarosa/core/services/storage/util/DummyIndexedStorageUtility.java
+++ b/javarosa/src/main/java/org/javarosa/core/services/storage/util/DummyIndexedStorageUtility.java
@@ -30,14 +30,11 @@ import java.util.Vector;
 public class DummyIndexedStorageUtility<T extends Persistable> implements IStorageUtilityIndexed<T> {
 
     private final Hashtable<String, Hashtable<Object, Vector<Integer>>> meta;
-
     private final Hashtable<Integer, T> data;
-
-    int curCount;
-
-    final Class<T> prototype;
-    
-    final PrototypeFactory mFactory;
+    private int curCount;
+    private final Class<T> prototype;
+    private final PrototypeFactory mFactory;
+    private final Vector<String> dynamicIndices = new Vector<>();
 
     public DummyIndexedStorageUtility(Class<T> prototype, PrototypeFactory factory) {
         meta = new Hashtable<>();
@@ -52,9 +49,9 @@ public class DummyIndexedStorageUtility<T extends Persistable> implements IStora
         Persistable p;
         try {
             p = prototype.newInstance();
-        } catch (java.lang.InstantiationException e) {
+        } catch (InstantiationException e) {
             throw new RuntimeException("Couldn't create a serializable class for storage!" + prototype.getName());
-        } catch (java.lang.IllegalAccessException e) {
+        } catch (IllegalAccessException e) {
             throw new RuntimeException("Couldn't create a serializable class for storage!" + prototype.getName());
         }
 
@@ -74,10 +71,7 @@ public class DummyIndexedStorageUtility<T extends Persistable> implements IStora
         }
     }
 
-
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtilityIndexed#getIDsForValue(java.lang.String, java.lang.Object)
-     */
+    @Override
     public Vector getIDsForValue(String fieldName, Object value) {
         //We don't support all index types
         if(meta.get(fieldName) == null) {
@@ -89,9 +83,7 @@ public class DummyIndexedStorageUtility<T extends Persistable> implements IStora
         return meta.get(fieldName).get(value);
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtilityIndexed#getRecordForValue(java.lang.String, java.lang.Object)
-     */
+    @Override
     public T getRecordForValue(String fieldName, Object value) throws NoSuchElementException, InvalidIndexException {
         if (meta.get(fieldName) == null) {
             throw new NoSuchElementException("No record matching meta index " + fieldName + " with value " + value);
@@ -109,9 +101,7 @@ public class DummyIndexedStorageUtility<T extends Persistable> implements IStora
         return data.get(matches.elementAt(0));
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#add(org.javarosa.core.util.externalizable.Externalizable)
-     */
+    @Override
     public int add(T e) {
         data.put(DataUtil.integer(curCount), e);
 
@@ -139,31 +129,23 @@ public class DummyIndexedStorageUtility<T extends Persistable> implements IStora
 
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#exists(int)
-     */
+    @Override
     public boolean exists(int id) {
         return data.containsKey(DataUtil.integer(id));
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#getAccessLock()
-     */
+    @Override
     public Object getAccessLock() {
         // TODO Auto-generated method stub
         return null;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#getNumRecords()
-     */
+    @Override
     public int getNumRecords() {
         return data.size();
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#getRecordSize(int)
-     */
+    @Override
     public int getRecordSize(int id) {
         //serialize and test blah blah.
         return 0;
@@ -177,48 +159,30 @@ public class DummyIndexedStorageUtility<T extends Persistable> implements IStora
         return 0;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#isEmpty()
-     */
+    @Override
     public boolean isEmpty() {
         return data.size() > 0;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#iterate()
-     */
+    @Override
     public IStorageIterator<T> iterate() {
         //We should really find a way to invalidate old iterators first here
         return new DummyStorageIterator<>(data);
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#read(int)
-     */
+    @Override
     public T read(int id) {
-        //return data.get(DataUtil.integer(id));
         try {
             T t = prototype.newInstance();
             t.readExternal(new DataInputStream(new ByteArrayInputStream(readBytes(id))), mFactory);
             return t;
-        } catch (InstantiationException e) {
-            e.printStackTrace();
-            throw new RuntimeException(e.getMessage());
-        } catch (IllegalAccessException e) {
-            e.printStackTrace();
-            throw new RuntimeException(e.getMessage());
-        } catch (IOException e) {
-            e.printStackTrace();
-            throw new RuntimeException(e.getMessage());
-        } catch (DeserializationException e) {
+        } catch (IllegalAccessException | InstantiationException | IOException | DeserializationException e) {
             e.printStackTrace();
             throw new RuntimeException(e.getMessage());
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#readBytes(int)
-     */
+    @Override
     public byte[] readBytes(int id) {
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
         try {
@@ -229,25 +193,19 @@ public class DummyIndexedStorageUtility<T extends Persistable> implements IStora
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#remove(int)
-     */
+    @Override
     public void remove(int id) {
         data.remove(DataUtil.integer(id));
 
         syncMeta();
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#remove(org.javarosa.core.services.storage.Persistable)
-     */
+    @Override
     public void remove(Persistable p) {
         this.read(p.getID());
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#removeAll()
-     */
+    @Override
     public void removeAll() {
         data.clear();
 
@@ -255,9 +213,7 @@ public class DummyIndexedStorageUtility<T extends Persistable> implements IStora
         initMeta();
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#removeAll(org.javarosa.core.services.storage.EntityFilter)
-     */
+    @Override
     public Vector<Integer> removeAll(EntityFilter ef) {
         Vector<Integer> removed = new Vector<>();
         for (Enumeration en = data.keys(); en.hasMoreElements(); ) {
@@ -296,17 +252,13 @@ public class DummyIndexedStorageUtility<T extends Persistable> implements IStora
         //Unecessary!
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#update(int, org.javarosa.core.util.externalizable.Externalizable)
-     */
+    @Override
     public void update(int id, T e) {
         data.put(DataUtil.integer(id), e);
         syncMeta();
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#write(org.javarosa.core.services.storage.Persistable)
-     */
+    @Override
     public void write(Persistable p) {
         if (p.getID() != -1) {
             this.data.put(DataUtil.integer(p.getID()), (T)p);
@@ -351,9 +303,7 @@ public class DummyIndexedStorageUtility<T extends Persistable> implements IStora
         //TODO: This should have a clear contract.
     }
 
-
-    final Vector<String> dynamicIndices = new Vector<>();
-
+    @Override
     public void registerIndex(String filterIndex) {
         dynamicIndices.addElement(filterIndex);
         syncMeta();

--- a/javarosa/src/main/java/org/javarosa/core/services/storage/util/DummyIndexedStorageUtility.java
+++ b/javarosa/src/main/java/org/javarosa/core/services/storage/util/DummyIndexedStorageUtility.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package org.javarosa.core.services.storage.util;
 
 import org.javarosa.core.services.storage.EntityFilter;
@@ -98,7 +95,7 @@ public class DummyIndexedStorageUtility<T extends Persistable> implements IStora
             throw new InvalidIndexException("Multiple records matching meta index " + fieldName + " with value " + value, fieldName);
         }
 
-        return data.get(matches.elementAt(0));
+        return read(matches.elementAt(0));
     }
 
     @Override
@@ -167,7 +164,7 @@ public class DummyIndexedStorageUtility<T extends Persistable> implements IStora
     @Override
     public IStorageIterator<T> iterate() {
         //We should really find a way to invalidate old iterators first here
-        return new DummyStorageIterator<>(data);
+        return new DummyStorageIterator<>(this, data);
     }
 
     @Override
@@ -202,6 +199,7 @@ public class DummyIndexedStorageUtility<T extends Persistable> implements IStora
 
     @Override
     public void remove(Persistable p) {
+        // TODO actually remove...
         this.read(p.getID());
     }
 

--- a/javarosa/src/main/java/org/javarosa/core/services/storage/util/DummyIndexedStorageUtility.java
+++ b/javarosa/src/main/java/org/javarosa/core/services/storage/util/DummyIndexedStorageUtility.java
@@ -199,8 +199,7 @@ public class DummyIndexedStorageUtility<T extends Persistable> implements IStora
 
     @Override
     public void remove(Persistable p) {
-        // TODO actually remove...
-        this.read(p.getID());
+        remove(p.getID());
     }
 
     @Override

--- a/javarosa/src/main/java/org/javarosa/core/services/storage/util/DummyStorageIterator.java
+++ b/javarosa/src/main/java/org/javarosa/core/services/storage/util/DummyStorageIterator.java
@@ -2,7 +2,6 @@ package org.javarosa.core.services.storage.util;
 
 import org.javarosa.core.services.storage.IStorageIterator;
 import org.javarosa.core.services.storage.Persistable;
-import org.javarosa.core.util.DataUtil;
 
 import java.util.Enumeration;
 import java.util.Hashtable;
@@ -11,12 +10,13 @@ import java.util.Hashtable;
  * @author ctsims
  */
 public class DummyStorageIterator<T extends Persistable> implements IStorageIterator<T> {
-    private final Hashtable<Integer, T> data;
     private int count;
     private final Integer[] keys;
+    private final DummyIndexedStorageUtility<T> dummyStorage;
 
-    public DummyStorageIterator(Hashtable<Integer, T> data) {
-        this.data = data;
+    public DummyStorageIterator(DummyIndexedStorageUtility<T> dummyStorage,
+                                Hashtable<Integer, T> data) {
+        this.dummyStorage = dummyStorage;
         keys = new Integer[data.size()];
         int i = 0;
         for (Enumeration en = data.keys(); en.hasMoreElements(); ) {
@@ -39,12 +39,12 @@ public class DummyStorageIterator<T extends Persistable> implements IStorageIter
 
     @Override
     public T nextRecord() {
-        return data.get(DataUtil.integer(nextID()));
+        return dummyStorage.read(nextID());
     }
 
     @Override
     public int numRecords() {
-        return data.size();
+        return dummyStorage.getNumRecords();
     }
 
     @Override

--- a/javarosa/src/main/java/org/javarosa/core/services/storage/util/DummyStorageIterator.java
+++ b/javarosa/src/main/java/org/javarosa/core/services/storage/util/DummyStorageIterator.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package org.javarosa.core.services.storage.util;
 
 import org.javarosa.core.services.storage.IStorageIterator;
@@ -14,10 +11,9 @@ import java.util.Hashtable;
  * @author ctsims
  */
 public class DummyStorageIterator<T extends Persistable> implements IStorageIterator<T> {
-    final Hashtable<Integer, T> data;
-    int count;
-    final Integer[] keys;
-
+    private final Hashtable<Integer, T> data;
+    private int count;
+    private final Integer[] keys;
 
     public DummyStorageIterator(Hashtable<Integer, T> data) {
         this.data = data;
@@ -30,37 +26,29 @@ public class DummyStorageIterator<T extends Persistable> implements IStorageIter
         count = 0;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageIterator#hasMore()
-     */
+    @Override
     public boolean hasMore() {
         return count < keys.length;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageIterator#nextID()
-     */
+    @Override
     public int nextID() {
         count++;
-        return keys[count - 1].intValue();
+        return keys[count - 1];
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageIterator#nextRecord()
-     */
+    @Override
     public T nextRecord() {
         return data.get(DataUtil.integer(nextID()));
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageIterator#numRecords()
-     */
+    @Override
     public int numRecords() {
         return data.size();
     }
 
+    @Override
     public int peekID() {
         return keys[count];
     }
-
 }


### PR DESCRIPTION
Jen reported a CLI issue where multiple registrations via the 'registration from case list' feature would result in cases getting overwritten. This was happening because the CLI storage layer didn't return new objects when you read from it; instead returning the same object created on initial app loading. This meant that if you filled out a form more than once, certain data wouldn't get correctly set on the second loading of the form.

Fix for http://manage.dimagi.com/default.asp?228006