### PR TITLE
Fix for Case Predicate Bug

### DIFF
--- a/cases/src/org/commcare/cases/util/StorageBackedTreeRoot.java
+++ b/cases/src/org/commcare/cases/util/StorageBackedTreeRoot.java
@@ -17,6 +17,8 @@ import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.Vector;
 
+import javax.xml.xpath.XPath;
+
 
 /**
  * @author ctsims
@@ -76,7 +78,7 @@ public abstract class StorageBackedTreeRoot<T extends AbstractTreeElement> imple
             XPathExpression xpe = predicates.elementAt(i);
             //what we want here is a static evaluation of the expression to see if it consists of evaluating
             //something we index with something static.
-            if (xpe instanceof XPathEqExpr) {
+            if (xpe instanceof XPathEqExpr && ((XPathEqExpr)xpe).op == XPathEqExpr.EQ) {
                 XPathExpression left = ((XPathEqExpr)xpe).a;
                 if (left instanceof XPathPathExpr) {
                     for (Enumeration en = indices.keys(); en.hasMoreElements(); ) {

--- a/cases/src/org/commcare/cases/util/StorageBackedTreeRoot.java
+++ b/cases/src/org/commcare/cases/util/StorageBackedTreeRoot.java
@@ -17,9 +17,6 @@ import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.Vector;
 
-import javax.xml.xpath.XPath;
-
-
 /**
  * @author ctsims
  */


### PR DESCRIPTION
Fix for http://manage.dimagi.com/default.asp?233382

The db backed storage optimizations were resulting in 

[a = b]
being treated the same as 
[a != b]

cross-request: https://github.com/dimagi/commcare-android/pull/1427