### PR TITLE
allow type to be null in serialization

### DIFF
--- a/backend/src/org/commcare/suite/model/Callout.java
+++ b/backend/src/org/commcare/suite/model/Callout.java
@@ -97,7 +97,7 @@ public class Callout implements Externalizable, DetailTemplate {
         extras = (Hashtable<String, String>)ExtUtil.read(in, new ExtWrapMap(String.class, String.class));
         responses = (Vector<String>)ExtUtil.read(in, new ExtWrapList(String.class), pf);
         responseDetail = (DetailField)ExtUtil.read(in, new ExtWrapNullable(DetailField.class), pf);
-        type = ExtUtil.readString(in);
+        type = (String)ExtUtil.read(in, new ExtWrapNullable(String.class));
         isAutoLaunching = ExtUtil.readBool(in);
     }
 
@@ -109,7 +109,7 @@ public class Callout implements Externalizable, DetailTemplate {
         ExtUtil.write(out, new ExtWrapMap(extras));
         ExtUtil.write(out, new ExtWrapList(responses));
         ExtUtil.write(out, new ExtWrapNullable(responseDetail));
-        ExtUtil.writeString(out, type);
+        ExtUtil.write(out, new ExtWrapNullable(type));
         ExtUtil.writeBool(out, isAutoLaunching);
     }
 


### PR DESCRIPTION
Was seeing this error running the CLI:

java.lang.NullPointerException
	at java.io.DataOutputStream.writeUTF(DataOutputStream.java:347)
	at java.io.DataOutputStream.writeUTF(DataOutputStream.java:323)
	at org.javarosa.core.util.externalizable.ExtUtil.writeString(ExtUtil.java:130)
	at org.commcare.suite.model.Callout.writeExternal(Callout.java:112)
	at org.javarosa.core.util.externalizable.ExtUtil.write(ExtUtil.java:81)
	at org.javarosa.core.util.externalizable.ExtWrapNullable.writeExternal(ExtWrapNullable.java:70)
	at org.javarosa.core.util.externalizable.ExtUtil.write(ExtUtil.java:81)
	at org.commcare.suite.model.Detail.writeExternal(Detail.java:209)
	at org.javarosa.core.util.externalizable.ExtUtil.write(ExtUtil.java:81)
	at org.javarosa.core.util.externalizable.ExtWrapMap.writeExternal(ExtWrapMap.java:109)
	at org.javarosa.core.util.externalizable.ExtUtil.write(ExtUtil.java:81)
	at org.commcare.suite.model.Suite.writeExternal(Suite.java:114)
	at org.javarosa.core.services.storage.util.DummyIndexedStorageUtility.readBytes(DummyIndexedStorageUtility.java:164)
	at org.javarosa.core.services.storage.util.DummyIndexedStorageUtility.read(DummyIndexedStorageUtility.java:152)
	at org.javarosa.core.services.storage.util.DummyIndexedStorageUtility.read(DummyIndexedStorageUtility.java:27)
	at org.commcare.resources.model.installers.SuiteInstaller.initialize(SuiteInstaller.java:33)
	at org.commcare.resources.model.ResourceTable.initializeResources(ResourceTable.java:903)
	at org.commcare.util.CommCareConfigEngine.initEnvironment(CommCareConfigEngine.java:213)
	at org.commcare.util.cli.CliCommand.configureApp(CliCommand.java:76)
	at org.commcare.util.cli.CliPlayCommand.handle(CliPlayCommand.java:49)
	at org.commcare.util.cli.CliMain.main(CliMain.java:64)