### PR TITLE
remove DATUM's before popping COMMANDs

### DIFF
--- a/backend/src/org/commcare/session/CommCareSession.java
+++ b/backend/src/org/commcare/session/CommCareSession.java
@@ -344,7 +344,13 @@ public class CommCareSession {
     }
 
     public void stepBack(EvaluationContext evalContext) {
-        // Pop the first thing off of the stack frame, no matter what
+        // First peel off any data pushed onto the stack by the previous command
+        while(frame.getSteps().size() > 0 &&
+                frame.getSteps().lastElement().getType().equals(SessionFrame.STATE_DATUM_VAL)){
+            popSessionFrameStack();
+        }
+
+        // Then, pop the previous command
         popSessionFrameStack();
 
         // Keep popping things off until the value of needed data indicates that we are back to


### PR DESCRIPTION
I want to discuss this with someone so added "don't pull" for now, but this is a fix for http://manage.dimagi.com/default.asp?233398

The advanced module was pushing two extra STATE_DATUM_VALs onto the stack when the action was clicked. When you clicked back on the next screen, instead of returning to the previous command one of these data was removed, then the next, then finally we went to the previous screen on the third click. This simply peels off all datum values from the top of the stock before proceeding with removing the command. 