### PR TITLE
Fix Nepali date widget change on swipe... again

### DIFF
--- a/backend/src/org/commcare/xml/MenuParser.java
+++ b/backend/src/org/commcare/xml/MenuParser.java
@@ -21,9 +21,7 @@ public class MenuParser extends CommCareElementParser<Menu> {
         super(parser);
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.xml.ElementParser#parse()
-     */
+    @Override
     public Menu parse() throws InvalidStructureException, IOException, XmlPullParserException {
         checkNode("menu");
 

--- a/javarosa/src/main/java/org/javarosa/core/model/data/DateData.java
+++ b/javarosa/src/main/java/org/javarosa/core/model/data/DateData.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2009 JavaRosa
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
-
 package org.javarosa.core.model.data;
 
 import org.javarosa.core.model.utils.DateUtils;
@@ -54,11 +38,13 @@ public class DateData implements IAnswerData {
         }
     }
 
+    @Override
     public IAnswerData clone() {
         init();
         return new DateData(new Date(d.getTime()));
     }
 
+    @Override
     public void setValue(Object o) {
         //Should not ever be possible to set this to a null value
         if (o == null) {
@@ -68,37 +54,37 @@ public class DateData implements IAnswerData {
         init = false;
     }
 
+    @Override
     public Object getValue() {
         init();
         return new Date(d.getTime());
     }
 
+    @Override
     public String getDisplayText() {
         init();
         return DateUtils.formatDate(d, DateUtils.FORMAT_HUMAN_READABLE_SHORT);
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.utilities.Externalizable#readExternal(java.io.DataInputStream)
-     */
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         setValue(ExtUtil.readDate(in));
         init();
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.utilities.Externalizable#writeExternal(java.io.DataOutputStream)
-     */
+    @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         init();
         ExtUtil.writeDate(out, d);
     }
 
+    @Override
     public UncastData uncast() {
         init();
         return new UncastData(DateUtils.formatDate(d, DateUtils.FORMAT_ISO8601));
     }
 
+    @Override
     public DateData cast(UncastData data) throws IllegalArgumentException {
         Date ret = DateUtils.parseDate(data.value);
         if (ret != null) {

--- a/javarosa/src/main/java/org/javarosa/xform/util/CalendarUtils.java
+++ b/javarosa/src/main/java/org/javarosa/xform/util/CalendarUtils.java
@@ -276,12 +276,20 @@ public class CalendarUtils {
         );
     }
 
+    /**
+     * @param millisFromJavaEpoch Argument must be normalized to UTC to prevent
+     *                            timezone issues when casting to a calendar date
+     */
     public static UniversalDate fromMillis(long millisFromJavaEpoch, TimeZone currentTimeZone) {
-        // Since epoch calculations are relative to GMT, take current timezone
+        // Since epoch calculations are relative to UTC, take current timezone
         // into account. This prevents two time values that lie on the same day
         // in the given timezone from falling on different GMT days.
-        int timezoneOffsetFromGMT = currentTimeZone.getOffset(millisFromJavaEpoch);
-        long millisFromMinDay = timezoneOffsetFromGMT + millisFromJavaEpoch - MIN_MILLIS_FROM_JAVA_EPOCH;
+        int timezoneOffsetFromUTC = currentTimeZone.getOffset(millisFromJavaEpoch);
+        // The 'millis since epoch' will be converted into a date in the
+        // context of the current timezone, so add that offset in, ensuring
+        // the date lies on the correct day
+        long millisWithTimezoneOffset = timezoneOffsetFromUTC + millisFromJavaEpoch;
+        long millisFromMinDay = millisWithTimezoneOffset - MIN_MILLIS_FROM_JAVA_EPOCH;
         long daysFromMinDay = millisFromMinDay / UniversalDate.MILLIS_IN_DAY;
 
         int days = -1;

--- a/javarosa/src/main/java/org/javarosa/xform/util/CalendarUtils.java
+++ b/javarosa/src/main/java/org/javarosa/xform/util/CalendarUtils.java
@@ -250,7 +250,7 @@ public class CalendarUtils {
                 year,
                 month,
                 day,
-                toMillisFromJavaEpoch(year, month, day, date.millisFromJavaEpoch % UniversalDate.MILLIS_IN_DAY)
+                toMillisFromJavaEpoch(year, month, day)
         );
     }
 
@@ -272,7 +272,7 @@ public class CalendarUtils {
                 year,
                 month,
                 day,
-                toMillisFromJavaEpoch(year, month, day, date.millisFromJavaEpoch % UniversalDate.MILLIS_IN_DAY)
+                toMillisFromJavaEpoch(year, month, day)
         );
     }
 
@@ -337,7 +337,7 @@ public class CalendarUtils {
                 year,
                 month,
                 day,
-                toMillisFromJavaEpoch(year, month, day, date.millisFromJavaEpoch % UniversalDate.MILLIS_IN_DAY)
+                toMillisFromJavaEpoch(year, month, day)
         );
     }
 
@@ -359,14 +359,19 @@ public class CalendarUtils {
                 year,
                 month,
                 day,
-                toMillisFromJavaEpoch(year, month, day, date.millisFromJavaEpoch % UniversalDate.MILLIS_IN_DAY)
+                toMillisFromJavaEpoch(year, month, day)
         );
     }
 
-    public static long toMillisFromJavaEpoch(int year, int month, int day, long millisOffset) {
+    public static long toMillisFromJavaEpoch(int year, int month, int day) {
+        return toMillisFromJavaEpoch(year, month, day, TimeZone.getDefault());
+    }
+
+    public static long toMillisFromJavaEpoch(int year, int month, int day, TimeZone currentTimeZone) {
         int daysFromMinDay = countDaysFromMinDay(year, month, day);
         long millisFromMinDay = daysFromMinDay * UniversalDate.MILLIS_IN_DAY;
-        return millisFromMinDay + MIN_MILLIS_FROM_JAVA_EPOCH + millisOffset;
+        int timezoneOffsetFromGMT = currentTimeZone.getOffset(millisFromMinDay);
+        return millisFromMinDay + MIN_MILLIS_FROM_JAVA_EPOCH - timezoneOffsetFromGMT;
     }
 
     public static String[] getMonthsArray(String key){

--- a/javarosa/src/main/java/org/javarosa/xform/util/CalendarUtils.java
+++ b/javarosa/src/main/java/org/javarosa/xform/util/CalendarUtils.java
@@ -370,8 +370,9 @@ public class CalendarUtils {
     public static long toMillisFromJavaEpoch(int year, int month, int day, TimeZone currentTimeZone) {
         int daysFromMinDay = countDaysFromMinDay(year, month, day);
         long millisFromMinDay = daysFromMinDay * UniversalDate.MILLIS_IN_DAY;
-        int timezoneOffsetFromGMT = currentTimeZone.getOffset(millisFromMinDay);
-        return millisFromMinDay + MIN_MILLIS_FROM_JAVA_EPOCH - timezoneOffsetFromGMT;
+        int timezoneOffsetFromUTC = currentTimeZone.getOffset(millisFromMinDay);
+        long millisNormalizedToUTC = millisFromMinDay - timezoneOffsetFromUTC;
+        return millisNormalizedToUTC + MIN_MILLIS_FROM_JAVA_EPOCH;
     }
 
     public static String[] getMonthsArray(String key){

--- a/javarosa/src/test/java/org/javarosa/xform/util/test/CalendarTests.java
+++ b/javarosa/src/test/java/org/javarosa/xform/util/test/CalendarTests.java
@@ -1,0 +1,86 @@
+package org.javarosa.xform.util.test;
+
+import org.javarosa.xform.util.CalendarUtils;
+import org.javarosa.xform.util.UniversalDate;
+import org.junit.Test;
+
+import java.util.Calendar;
+import java.util.TimeZone;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Phillip Mates (pmates@dimagi.com)
+ */
+public class CalendarTests {
+    @Test
+    public void testTimesFallOnSameDate() {
+        TimeZone nepaliTimeZone = TimeZone.getTimeZone("GMT+05:45");
+
+        Calendar nepaliMiddleOfDayDate = Calendar.getInstance(nepaliTimeZone);
+        nepaliMiddleOfDayDate.set(2007, Calendar.JULY, 7, 18, 46);
+
+        Calendar nepaliBeginningOfDayDate = Calendar.getInstance(nepaliTimeZone);
+        nepaliBeginningOfDayDate.set(2007, Calendar.JULY, 7, 0, 0);
+
+        UniversalDate middleOfDay = CalendarUtils.fromMillis(nepaliMiddleOfDayDate.getTimeInMillis(), nepaliTimeZone);
+        UniversalDate beginningOfDay = CalendarUtils.fromMillis(nepaliBeginningOfDayDate.getTimeInMillis(), nepaliTimeZone);
+        assertSameDate(middleOfDay, beginningOfDay);
+
+        Calendar nepaliEndOfDayDate = Calendar.getInstance(nepaliTimeZone);
+        nepaliEndOfDayDate.set(2007, Calendar.JULY, 7, 23, 59, 59);
+        UniversalDate endOfDay = CalendarUtils.fromMillis(nepaliEndOfDayDate.getTimeInMillis(), nepaliTimeZone);
+        assertSameDate(endOfDay, beginningOfDay);
+    }
+
+    private static void assertSameDate(UniversalDate a, UniversalDate b) {
+        assertEquals(a.day, b.day);
+        assertEquals(a.month, b.month);
+        assertEquals(a.year, b.year);
+    }
+
+    @Test
+    public void testDateCalcsAreSensitiveToCurrentTimezone() {
+        TimeZone nepaliTimeZone = TimeZone.getTimeZone("GMT+05:45");
+        TimeZone mexicanTimeZone = TimeZone.getTimeZone("GMT-06:00");
+        Calendar nepalCal = Calendar.getInstance(nepaliTimeZone);
+        nepalCal.set(2007, Calendar.JULY, 7, 18, 46);
+        Calendar mexicoCal = Calendar.getInstance(mexicanTimeZone);
+        mexicoCal.set(2007, Calendar.JULY, 7, 18, 46);
+
+        UniversalDate mexicanDate = CalendarUtils.fromMillis(mexicoCal.getTimeInMillis(), mexicanTimeZone);
+        UniversalDate nepaliDate = CalendarUtils.fromMillis(nepalCal.getTimeInMillis(), nepaliTimeZone);
+        assertSameDate(nepaliDate, mexicanDate);
+    }
+
+    @Test
+    public void testUnpackingDateInDifferentTimezone() {
+        TimeZone nepaliTimeZone = TimeZone.getTimeZone("GMT+05:45");
+        TimeZone mexicanTimeZone = TimeZone.getTimeZone("GMT-06:00");
+        Calendar mexicoCal = Calendar.getInstance(mexicanTimeZone);
+        mexicoCal.set(2007, Calendar.JULY, 7, 18, 46);
+
+        UniversalDate mexicanDate = CalendarUtils.fromMillis(mexicoCal.getTimeInMillis(), mexicanTimeZone);
+        long time = CalendarUtils.toMillisFromJavaEpoch(mexicanDate.year, mexicanDate.month, mexicanDate.day, 0);
+        UniversalDate rebuiltDateInUsingDifferentTimezone = CalendarUtils.fromMillis(time, nepaliTimeZone);
+        assertSameDate(rebuiltDateInUsingDifferentTimezone, mexicanDate);
+    }
+
+    @Test
+    public void testBaseDateSerialization() {
+        TimeZone nycTimeZone = TimeZone.getTimeZone("America/New_York");
+
+        Calendar dayInNewYork = Calendar.getInstance(nycTimeZone);
+        dayInNewYork.set(2007, Calendar.JULY, 7);
+        UniversalDate nycTime = CalendarUtils.fromMillis(dayInNewYork.getTimeInMillis(), nycTimeZone);
+
+        long millisOfDayOffset = dayInNewYork.getTimeInMillis() % UniversalDate.MILLIS_IN_DAY;
+        long time = CalendarUtils.toMillisFromJavaEpoch(nycTime.year, nycTime.month, nycTime.day, millisOfDayOffset);
+        UniversalDate unpackedNycTime = CalendarUtils.fromMillis(time, nycTimeZone);
+        assertSameDate(nycTime, unpackedNycTime);
+
+        time = CalendarUtils.toMillisFromJavaEpoch(nycTime.year, nycTime.month, nycTime.day, 0);
+        unpackedNycTime = CalendarUtils.fromMillis(time, nycTimeZone);
+        assertSameDate(nycTime, unpackedNycTime);
+    }
+}

--- a/javarosa/src/test/java/org/javarosa/xform/util/test/CalendarTests.java
+++ b/javarosa/src/test/java/org/javarosa/xform/util/test/CalendarTests.java
@@ -61,7 +61,7 @@ public class CalendarTests {
         mexicoCal.set(2007, Calendar.JULY, 7, 18, 46);
 
         UniversalDate mexicanDate = CalendarUtils.fromMillis(mexicoCal.getTimeInMillis(), mexicanTimeZone);
-        long time = CalendarUtils.toMillisFromJavaEpoch(mexicanDate.year, mexicanDate.month, mexicanDate.day, 0);
+        long time = CalendarUtils.toMillisFromJavaEpoch(mexicanDate.year, mexicanDate.month, mexicanDate.day, mexicanTimeZone);
         UniversalDate rebuiltDateInUsingDifferentTimezone = CalendarUtils.fromMillis(time, nepaliTimeZone);
         assertSameDate(rebuiltDateInUsingDifferentTimezone, mexicanDate);
     }
@@ -74,12 +74,11 @@ public class CalendarTests {
         dayInNewYork.set(2007, Calendar.JULY, 7);
         UniversalDate nycTime = CalendarUtils.fromMillis(dayInNewYork.getTimeInMillis(), nycTimeZone);
 
-        long millisOfDayOffset = dayInNewYork.getTimeInMillis() % UniversalDate.MILLIS_IN_DAY;
-        long time = CalendarUtils.toMillisFromJavaEpoch(nycTime.year, nycTime.month, nycTime.day, millisOfDayOffset);
+        long time = CalendarUtils.toMillisFromJavaEpoch(nycTime.year, nycTime.month, nycTime.day, nycTimeZone);
         UniversalDate unpackedNycTime = CalendarUtils.fromMillis(time, nycTimeZone);
         assertSameDate(nycTime, unpackedNycTime);
 
-        time = CalendarUtils.toMillisFromJavaEpoch(nycTime.year, nycTime.month, nycTime.day, 0);
+        time = CalendarUtils.toMillisFromJavaEpoch(nycTime.year, nycTime.month, nycTime.day, nycTimeZone);
         unpackedNycTime = CalendarUtils.fromMillis(time, nycTimeZone);
         assertSameDate(nycTime, unpackedNycTime);
     }

--- a/javarosa/src/test/java/org/javarosa/xform/util/test/CalendarTests.java
+++ b/javarosa/src/test/java/org/javarosa/xform/util/test/CalendarTests.java
@@ -78,8 +78,9 @@ public class CalendarTests {
         UniversalDate unpackedNycTime = CalendarUtils.fromMillis(time, nycTimeZone);
         assertSameDate(nycTime, unpackedNycTime);
 
-        time = CalendarUtils.toMillisFromJavaEpoch(nycTime.year, nycTime.month, nycTime.day, nycTimeZone);
-        unpackedNycTime = CalendarUtils.fromMillis(time, nycTimeZone);
-        assertSameDate(nycTime, unpackedNycTime);
+        TimeZone nepaliTimeZone = TimeZone.getTimeZone("GMT+05:45");
+        time = CalendarUtils.toMillisFromJavaEpoch(nycTime.year, nycTime.month, nycTime.day, nepaliTimeZone);
+        UniversalDate unpackedNepaliTime = CalendarUtils.fromMillis(time, nepaliTimeZone);
+        assertSameDate(nycTime, unpackedNepaliTime);
     }
 }


### PR DESCRIPTION
My description from [an old PR](https://github.com/dimagi/commcare-android/pull/1129) sums it up pretty well:

> Currently, the Nepali date widget changes the date back one day every time you scroll to and from the widget. This is due to some sort of timezone/calendar day issue where if you are in Nepal and it is, say 10am on the 12th, and hence the 11th in Greenwich Mean Time, then restoring the stored date value restores to the 11th, not the 12th.

More specifically, I think my old PR was only a partial fix. Instead of storing an millisecond offset used to convert dates to and from millis since epoch in a timezone agnostic way, we should use the timezone offset. This is because the millisecond offset info is lost when you reload the question widget.

I've moved the calendar tests from `commcare-android` to here because the calendar code now lives at core. I added a failing test (`testBaseDateSerialization`) to expose the issue and then applied the fixing changes.

cross-request: https://github.com/dimagi/commcare-android/pull/1440