### PR TITLE
Rename case claim code to not use 'sync'

### DIFF
--- a/backend/src/org/commcare/session/CommCareSession.java
+++ b/backend/src/org/commcare/session/CommCareSession.java
@@ -204,7 +204,7 @@ public class CommCareSession {
             return needDatum;
         } else if (entries.size() == 1
                 && entries.elementAt(0) instanceof RemoteRequestEntry
-                && ((RemoteRequestEntry)entries.elementAt(0)).getSyncPost().isRelevant(evalContext)) {
+                && ((RemoteRequestEntry)entries.elementAt(0)).getPostRequest().isRelevant(evalContext)) {
             return SessionFrame.STATE_SYNC_REQUEST;
         } else if (entries.size() > 1 || !entries.elementAt(0).getCommandId().equals(currentCmd)) {
             //the only other thing we can need is a form command. If there's
@@ -456,7 +456,7 @@ public class CommCareSession {
         }
 
         Entry e = platform.getMenuMap().get(command);
-        if (e.isView() || e.isSync()) {
+        if (e.isView() || e.isRemoteRequest()) {
             return null;
         } else {
             return ((FormEntry)e).getXFormNamespace();
@@ -805,9 +805,9 @@ public class CommCareSession {
         return entries.size() == 1 && entries.elementAt(0).isView();
     }
 
-    public boolean isSyncCommand(String command) {
+    public boolean isRemoteRequestCommand(String command) {
         Vector<Entry> entries = this.getEntriesForCommand(command);
-        return entries.size() == 1 && entries.elementAt(0).isSync();
+        return entries.size() == 1 && entries.elementAt(0).isRemoteRequest();
     }
 
     public void addExtraToCurrentFrameStep(String key, Object value) {

--- a/backend/src/org/commcare/session/CommCareSession.java
+++ b/backend/src/org/commcare/session/CommCareSession.java
@@ -8,11 +8,11 @@ import org.commcare.suite.model.FormEntry;
 import org.commcare.suite.model.FormIdDatum;
 import org.commcare.suite.model.Menu;
 import org.commcare.suite.model.RemoteQueryDatum;
+import org.commcare.suite.model.RemoteRequestEntry;
 import org.commcare.suite.model.SessionDatum;
 import org.commcare.suite.model.StackFrameStep;
 import org.commcare.suite.model.StackOperation;
 import org.commcare.suite.model.Suite;
-import org.commcare.suite.model.SyncEntry;
 import org.commcare.util.CommCarePlatform;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.DataInstance;
@@ -203,8 +203,8 @@ public class CommCareSession {
         if (needDatum != null) {
             return needDatum;
         } else if (entries.size() == 1
-                && entries.elementAt(0) instanceof SyncEntry
-                && ((SyncEntry)entries.elementAt(0)).getSyncPost().isRelevant(evalContext)) {
+                && entries.elementAt(0) instanceof RemoteRequestEntry
+                && ((RemoteRequestEntry)entries.elementAt(0)).getSyncPost().isRelevant(evalContext)) {
             return SessionFrame.STATE_SYNC_REQUEST;
         } else if (entries.size() > 1 || !entries.elementAt(0).getCommandId().equals(currentCmd)) {
             //the only other thing we can need is a form command. If there's

--- a/backend/src/org/commcare/suite/model/Entry.java
+++ b/backend/src/org/commcare/suite/model/Entry.java
@@ -57,7 +57,7 @@ public abstract class Entry implements Externalizable, MenuDisplayable {
         return false;
     }
 
-    public boolean isSync() {
+    public boolean isRemoteRequest() {
         return false;
     }
 

--- a/backend/src/org/commcare/suite/model/PostRequest.java
+++ b/backend/src/org/commcare/suite/model/PostRequest.java
@@ -24,17 +24,17 @@ import java.util.Hashtable;
  *
  * @author Phillip Mates (pmates@dimagi.com).
  */
-public class SyncPost implements Externalizable {
+public class PostRequest implements Externalizable {
     private URL url;
     private XPathExpression relevantExpr;
     private Hashtable<String, XPathExpression> params;
 
     @SuppressWarnings("unused")
-    public SyncPost() {
+    public PostRequest() {
     }
 
-    public SyncPost(URL url, XPathExpression relevantExpr,
-                    Hashtable<String, XPathExpression> params) {
+    public PostRequest(URL url, XPathExpression relevantExpr,
+                       Hashtable<String, XPathExpression> params) {
         this.url = url;
         this.params = params;
         this.relevantExpr = relevantExpr;

--- a/backend/src/org/commcare/suite/model/RemoteRequestEntry.java
+++ b/backend/src/org/commcare/suite/model/RemoteRequestEntry.java
@@ -18,26 +18,26 @@ import java.util.Vector;
  *
  * @author Phillip Mates (pmates@dimagi.com).
  */
-public class SyncEntry extends Entry {
-    private SyncPost post;
+public class RemoteRequestEntry extends Entry {
+    private PostRequest post;
 
     @SuppressWarnings("unused")
-    public SyncEntry() {
+    public RemoteRequestEntry() {
 
     }
 
-    public SyncEntry(String commandId, DisplayUnit display,
-                     Vector<SessionDatum> data,
-                     Hashtable<String, DataInstance> instances,
-                     Vector<StackOperation> stackOperations,
-                     AssertionSet assertions,
-                     SyncPost post) {
+    public RemoteRequestEntry(String commandId, DisplayUnit display,
+                              Vector<SessionDatum> data,
+                              Hashtable<String, DataInstance> instances,
+                              Vector<StackOperation> stackOperations,
+                              AssertionSet assertions,
+                              PostRequest post) {
         super(commandId, display, data, instances, stackOperations, assertions);
 
         this.post = post;
     }
 
-    public SyncPost getSyncPost() {
+    public PostRequest getSyncPost() {
         return post;
     }
 
@@ -51,7 +51,7 @@ public class SyncEntry extends Entry {
             throws IOException, DeserializationException {
         super.readExternal(in, pf);
 
-        post = (SyncPost)ExtUtil.read(in, SyncPost.class, pf);
+        post = (PostRequest)ExtUtil.read(in, PostRequest.class, pf);
     }
 
     @Override

--- a/backend/src/org/commcare/suite/model/RemoteRequestEntry.java
+++ b/backend/src/org/commcare/suite/model/RemoteRequestEntry.java
@@ -37,12 +37,12 @@ public class RemoteRequestEntry extends Entry {
         this.post = post;
     }
 
-    public PostRequest getSyncPost() {
+    public PostRequest getPostRequest() {
         return post;
     }
 
     @Override
-    public boolean isSync() {
+    public boolean isRemoteRequest() {
         return true;
     }
 

--- a/backend/src/org/commcare/xml/EntryParser.java
+++ b/backend/src/org/commcare/xml/EntryParser.java
@@ -30,7 +30,7 @@ import java.util.Vector;
 public class EntryParser extends CommCareElementParser<Entry> {
     private static final String FORM_ENTRY_TAG = "entry";
     private static final String VIEW_ENTRY_TAG = "view";
-    private static final String SYNC_REQUEST_TAG = "sync-request";
+    protected static final String SYNC_REQUEST_TAG = "remote-request";
     private final String parserBlockTag;
 
     private EntryParser(KXmlParser parser, String parserBlockTag) {

--- a/backend/src/org/commcare/xml/EntryParser.java
+++ b/backend/src/org/commcare/xml/EntryParser.java
@@ -6,8 +6,8 @@ import org.commcare.suite.model.FormEntry;
 import org.commcare.suite.model.Entry;
 import org.commcare.suite.model.SessionDatum;
 import org.commcare.suite.model.StackOperation;
-import org.commcare.suite.model.SyncEntry;
-import org.commcare.suite.model.SyncPost;
+import org.commcare.suite.model.RemoteRequestEntry;
+import org.commcare.suite.model.PostRequest;
 import org.commcare.suite.model.ViewEntry;
 import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.core.model.instance.ExternalDataInstance;
@@ -63,7 +63,7 @@ public class EntryParser extends CommCareElementParser<Entry> {
         DisplayUnit display = null;
         Vector<StackOperation> stackOps = new Vector<>();
         AssertionSet assertions = null;
-        SyncPost post = null;
+        PostRequest post = null;
 
         while (nextTagInBlock(parserBlockTag)) {
             String tagName = parser.getName();
@@ -110,7 +110,7 @@ public class EntryParser extends CommCareElementParser<Entry> {
             if (post == null) {
                 throw new RuntimeException(SYNC_REQUEST_TAG + " must contain a <post> element");
             } else {
-                return new SyncEntry(commandId, display, data, instances, stackOps, assertions, post);
+                return new RemoteRequestEntry(commandId, display, data, instances, stackOps, assertions, post);
             }
         }
 
@@ -153,7 +153,7 @@ public class EntryParser extends CommCareElementParser<Entry> {
         instances.put(instanceId, new ExternalDataInstance(location, instanceId));
     }
 
-    private SyncPost parsePost() throws InvalidStructureException, IOException, XmlPullParserException {
+    private PostRequest parsePost() throws InvalidStructureException, IOException, XmlPullParserException {
         String urlString = parser.getAttributeValue(null, "url");
         if (urlString == null) {
             throw new InvalidStructureException("Expected 'url' attribute in a <post> structure.",
@@ -194,6 +194,6 @@ public class EntryParser extends CommCareElementParser<Entry> {
                         parser);
             }
         }
-        return new SyncPost(url, relevantExpr, postData);
+        return new PostRequest(url, relevantExpr, postData);
     }
 }

--- a/backend/src/org/commcare/xml/EntryParser.java
+++ b/backend/src/org/commcare/xml/EntryParser.java
@@ -30,7 +30,7 @@ import java.util.Vector;
 public class EntryParser extends CommCareElementParser<Entry> {
     private static final String FORM_ENTRY_TAG = "entry";
     private static final String VIEW_ENTRY_TAG = "view";
-    protected static final String SYNC_REQUEST_TAG = "remote-request";
+    protected static final String REMOTE_REQUEST_TAG = "remote-request";
     private final String parserBlockTag;
 
     private EntryParser(KXmlParser parser, String parserBlockTag) {
@@ -48,7 +48,7 @@ public class EntryParser extends CommCareElementParser<Entry> {
     }
 
     public static EntryParser buildRemoteSyncParser(KXmlParser parser) {
-        return new EntryParser(parser, SYNC_REQUEST_TAG);
+        return new EntryParser(parser, REMOTE_REQUEST_TAG);
     }
 
     @Override
@@ -106,9 +106,9 @@ public class EntryParser extends CommCareElementParser<Entry> {
             return new ViewEntry(commandId, display, data, instances, stackOps, assertions);
         } else if (FORM_ENTRY_TAG.equals(parserBlockTag)) {
             return new FormEntry(commandId, display, data, xFormNamespace, instances, stackOps, assertions);
-        } else if (SYNC_REQUEST_TAG.equals(parserBlockTag)) {
+        } else if (REMOTE_REQUEST_TAG.equals(parserBlockTag)) {
             if (post == null) {
-                throw new RuntimeException(SYNC_REQUEST_TAG + " must contain a <post> element");
+                throw new RuntimeException(REMOTE_REQUEST_TAG + " must contain a <post> element");
             } else {
                 return new RemoteRequestEntry(commandId, display, data, instances, stackOps, assertions, post);
             }

--- a/backend/src/org/commcare/xml/SuiteParser.java
+++ b/backend/src/org/commcare/xml/SuiteParser.java
@@ -99,7 +99,7 @@ public class SuiteParser extends ElementParser<Suite> {
                     } else if (parser.getName().toLowerCase().equals("view")) {
                         Entry e = EntryParser.buildViewParser(parser).parse();
                         entries.put(e.getCommandId(), e);
-                    } else if (parser.getName().toLowerCase().equals(EntryParser.SYNC_REQUEST_TAG)) {
+                    } else if (parser.getName().toLowerCase().equals(EntryParser.REMOTE_REQUEST_TAG)) {
                         Entry syncEntry = EntryParser.buildRemoteSyncParser(parser).parse();
                         entries.put(syncEntry.getCommandId(), syncEntry);
                     } else if (parser.getName().toLowerCase().equals("locale")) {

--- a/backend/src/org/commcare/xml/SuiteParser.java
+++ b/backend/src/org/commcare/xml/SuiteParser.java
@@ -99,7 +99,7 @@ public class SuiteParser extends ElementParser<Suite> {
                     } else if (parser.getName().toLowerCase().equals("view")) {
                         Entry e = EntryParser.buildViewParser(parser).parse();
                         entries.put(e.getCommandId(), e);
-                    } else if (parser.getName().toLowerCase().equals("sync-request")) {
+                    } else if (parser.getName().toLowerCase().equals(EntryParser.SYNC_REQUEST_TAG)) {
                         Entry syncEntry = EntryParser.buildRemoteSyncParser(parser).parse();
                         entries.put(syncEntry.getCommandId(), syncEntry);
                     } else if (parser.getName().toLowerCase().equals("locale")) {

--- a/backend/src/org/commcare/xml/SuiteParser.java
+++ b/backend/src/org/commcare/xml/SuiteParser.java
@@ -100,8 +100,8 @@ public class SuiteParser extends ElementParser<Suite> {
                         Entry e = EntryParser.buildViewParser(parser).parse();
                         entries.put(e.getCommandId(), e);
                     } else if (parser.getName().toLowerCase().equals(EntryParser.REMOTE_REQUEST_TAG)) {
-                        Entry syncEntry = EntryParser.buildRemoteSyncParser(parser).parse();
-                        entries.put(syncEntry.getCommandId(), syncEntry);
+                        Entry remoteRequestEntry = EntryParser.buildRemoteSyncParser(parser).parse();
+                        entries.put(remoteRequestEntry.getCommandId(), remoteRequestEntry);
                     } else if (parser.getName().toLowerCase().equals("locale")) {
                         String localeKey = parser.getAttributeValue(null, "language");
                         //resource def

--- a/tests/resources/app_structure/suite.xml
+++ b/tests/resources/app_structure/suite.xml
@@ -82,7 +82,7 @@
     </session>
   </entry>
 
-  <sync-request>
+  <remote-request>
     <post url="http://fake.com/claim_patient/">
       <data key="selected_name" ref="instance('patients')/case/name"/>
       <data key="selected_case_id" ref="instance('patients')/case/@case_id"/>
@@ -116,7 +116,7 @@
         <datum id="calculated_data" value="'claimed'"/>
       </push>
     </stack>
-  </sync-request>
+  </remote-request>
 
   <menu id="m0">
     <text>Menu</text>

--- a/tests/resources/session-tests-template/suite.xml
+++ b/tests/resources/session-tests-template/suite.xml
@@ -103,7 +103,7 @@
     </session>
   </entry>
 
-  <sync-request>
+  <remote-request>
     <post url="http://fake.com/claim_patient/"
           relevant="count(instance('casedb')/casedb/case[@case_id=instance('session')/session/data/case_id]) = 0">
       <data key="selected_case_id" ref="instance('session')/session/data/case_id"/>
@@ -138,37 +138,37 @@
         <datum id="case_id" value="instance('patients')/patients/patient/bolivar"/>
       </create>
     </stack>
-  </sync-request>
+  </remote-request>
 
-  <sync-request>
+  <remote-request>
     <post url="http://fake.com/claim_patient/"/>
-    <command id="empty-sync-request">
+    <command id="empty-remote-request">
       <display>
         <text>Global search for person</text>
       </display>
     </command>
     <session/>
-  </sync-request>
+  </remote-request>
 
-  <sync-request>
+  <remote-request>
     <post url="http://fake.com/claim_patient/" relevant="false()"/>
-    <command id="irrelevant-sync-request">
+    <command id="irrelevant-remote-request">
       <display>
         <text>Global search for person</text>
       </display>
     </command>
     <session/>
-  </sync-request>
+  </remote-request>
 
-  <sync-request>
+  <remote-request>
     <post url="http://fake.com/claim_patient/" relevant="true()"/>
-    <command id="relevant-sync-request">
+    <command id="relevant-remote-request">
       <display>
         <text>Global search for person</text>
       </display>
     </command>
     <session/>
-  </sync-request>
+  </remote-request>
 
   <menu id="m0">
     <text>

--- a/tests/test/org/commcare/backend/session/test/BasicSessionNavigationTests.java
+++ b/tests/test/org/commcare/backend/session/test/BasicSessionNavigationTests.java
@@ -168,16 +168,16 @@ public class BasicSessionNavigationTests {
     public void testInvokeEmptySyncRequest() {
         SessionWrapper session = mApp.getSession();
 
-        session.setCommand("empty-sync-request");
+        session.setCommand("empty-remote-request");
         Assert.assertEquals(session.getNeededData(), SessionFrame.STATE_SYNC_REQUEST);
     }
 
     @Test
     public void testStepToSyncRequestRelevancy() {
-        session.setCommand("irrelevant-sync-request");
+        session.setCommand("irrelevant-remote-request");
         Assert.assertEquals(session.getNeededData(), null);
 
-        session.setCommand("relevant-sync-request");
+        session.setCommand("relevant-remote-request");
         Assert.assertEquals(session.getNeededData(), SessionFrame.STATE_SYNC_REQUEST);
     }
 }


### PR DESCRIPTION
Realized that my naming for the case claim feature was super confusing. Usage of 'sync' is unneeded; changed them to 'remote request'

Requires HQ changes, but @proteusvacuum agreed to get those in on Monday.

cross-request: https://github.com/dimagi/commcare-android/pull/1451