### PR TITLE
Fix nepali date widget change on swipe

### DIFF
--- a/javarosa/src/main/java/org/javarosa/xform/util/CalendarUtils.java
+++ b/javarosa/src/main/java/org/javarosa/xform/util/CalendarUtils.java
@@ -4,17 +4,14 @@ import org.commcare.util.ArrayDataSource;
 import org.commcare.util.LocaleArrayDataSource;
 import org.joda.time.Chronology;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.joda.time.chrono.EthiopicChronology;
 import org.joda.time.chrono.GregorianChronology;
 
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.TimeZone;
 
-/**
- * Created by willpride on 7/15/16.
- */
 public class CalendarUtils {
 
     private static ArrayDataSource arrayDataSource = new LocaleArrayDataSource();
@@ -280,7 +277,7 @@ public class CalendarUtils {
      * @param millisFromJavaEpoch Argument must be normalized to UTC to prevent
      *                            timezone issues when casting to a calendar date
      */
-    public static UniversalDate fromMillis(long millisFromJavaEpoch, TimeZone currentTimeZone) {
+    public static UniversalDate fromMillis(long millisFromJavaEpoch, DateTimeZone currentTimeZone) {
         // Since epoch calculations are relative to UTC, take current timezone
         // into account. This prevents two time values that lie on the same day
         // in the given timezone from falling on different GMT days.
@@ -319,7 +316,7 @@ public class CalendarUtils {
     }
 
     public static UniversalDate fromMillis(long millisFromJavaEpoch) {
-        return fromMillis(millisFromJavaEpoch, TimeZone.getDefault());
+        return fromMillis(millisFromJavaEpoch, DateTimeZone.getDefault());
     }
 
     public static UniversalDate incrementMonth(UniversalDate date) {
@@ -372,10 +369,10 @@ public class CalendarUtils {
     }
 
     public static long toMillisFromJavaEpoch(int year, int month, int day) {
-        return toMillisFromJavaEpoch(year, month, day, TimeZone.getDefault());
+        return toMillisFromJavaEpoch(year, month, day, DateTimeZone.getDefault());
     }
 
-    public static long toMillisFromJavaEpoch(int year, int month, int day, TimeZone currentTimeZone) {
+    public static long toMillisFromJavaEpoch(int year, int month, int day, DateTimeZone currentTimeZone) {
         int daysFromMinDay = countDaysFromMinDay(year, month, day);
         long millisFromMinDay = daysFromMinDay * UniversalDate.MILLIS_IN_DAY;
         int timezoneOffsetFromUTC = currentTimeZone.getOffset(millisFromMinDay);

--- a/javarosa/src/test/java/org/javarosa/xform/util/test/CalendarTests.java
+++ b/javarosa/src/test/java/org/javarosa/xform/util/test/CalendarTests.java
@@ -2,9 +2,11 @@ package org.javarosa.xform.util.test;
 
 import org.javarosa.xform.util.CalendarUtils;
 import org.javarosa.xform.util.UniversalDate;
+import org.joda.time.DateTimeZone;
 import org.junit.Test;
 
 import java.util.Calendar;
+import java.util.Date;
 import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
@@ -15,19 +17,19 @@ import static org.junit.Assert.assertEquals;
 public class CalendarTests {
     @Test
     public void testTimesFallOnSameDate() {
-        TimeZone nepaliTimeZone = TimeZone.getTimeZone("GMT+05:45");
+        DateTimeZone nepaliTimeZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone("GMT+05:45"));
 
-        Calendar nepaliMiddleOfDayDate = Calendar.getInstance(nepaliTimeZone);
+        Calendar nepaliMiddleOfDayDate = Calendar.getInstance(nepaliTimeZone.toTimeZone());
         nepaliMiddleOfDayDate.set(2007, Calendar.JULY, 7, 18, 46);
 
-        Calendar nepaliBeginningOfDayDate = Calendar.getInstance(nepaliTimeZone);
+        Calendar nepaliBeginningOfDayDate = Calendar.getInstance(nepaliTimeZone.toTimeZone());
         nepaliBeginningOfDayDate.set(2007, Calendar.JULY, 7, 0, 0);
 
         UniversalDate middleOfDay = CalendarUtils.fromMillis(nepaliMiddleOfDayDate.getTimeInMillis(), nepaliTimeZone);
         UniversalDate beginningOfDay = CalendarUtils.fromMillis(nepaliBeginningOfDayDate.getTimeInMillis(), nepaliTimeZone);
         assertSameDate(middleOfDay, beginningOfDay);
 
-        Calendar nepaliEndOfDayDate = Calendar.getInstance(nepaliTimeZone);
+        Calendar nepaliEndOfDayDate = Calendar.getInstance(nepaliTimeZone.toTimeZone());
         nepaliEndOfDayDate.set(2007, Calendar.JULY, 7, 23, 59, 59);
         UniversalDate endOfDay = CalendarUtils.fromMillis(nepaliEndOfDayDate.getTimeInMillis(), nepaliTimeZone);
         assertSameDate(endOfDay, beginningOfDay);
@@ -41,11 +43,11 @@ public class CalendarTests {
 
     @Test
     public void testDateCalcsAreSensitiveToCurrentTimezone() {
-        TimeZone nepaliTimeZone = TimeZone.getTimeZone("GMT+05:45");
-        TimeZone mexicanTimeZone = TimeZone.getTimeZone("GMT-06:00");
-        Calendar nepalCal = Calendar.getInstance(nepaliTimeZone);
+        DateTimeZone nepaliTimeZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone("GMT+05:45"));
+        DateTimeZone mexicanTimeZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone("GMT-06:00"));
+        Calendar nepalCal = Calendar.getInstance(nepaliTimeZone.toTimeZone());
         nepalCal.set(2007, Calendar.JULY, 7, 18, 46);
-        Calendar mexicoCal = Calendar.getInstance(mexicanTimeZone);
+        Calendar mexicoCal = Calendar.getInstance(mexicanTimeZone.toTimeZone());
         mexicoCal.set(2007, Calendar.JULY, 7, 18, 46);
 
         UniversalDate mexicanDate = CalendarUtils.fromMillis(mexicoCal.getTimeInMillis(), mexicanTimeZone);
@@ -55,9 +57,9 @@ public class CalendarTests {
 
     @Test
     public void testUnpackingDateInDifferentTimezone() {
-        TimeZone nepaliTimeZone = TimeZone.getTimeZone("GMT+05:45");
-        TimeZone mexicanTimeZone = TimeZone.getTimeZone("GMT-06:00");
-        Calendar mexicoCal = Calendar.getInstance(mexicanTimeZone);
+        DateTimeZone nepaliTimeZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone("GMT+05:45"));
+        DateTimeZone mexicanTimeZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone("GMT-06:00"));
+        Calendar mexicoCal = Calendar.getInstance(mexicanTimeZone.toTimeZone());
         mexicoCal.set(2007, Calendar.JULY, 7, 18, 46);
 
         UniversalDate mexicanDate = CalendarUtils.fromMillis(mexicoCal.getTimeInMillis(), mexicanTimeZone);
@@ -68,9 +70,9 @@ public class CalendarTests {
 
     @Test
     public void testBaseDateSerialization() {
-        TimeZone nycTimeZone = TimeZone.getTimeZone("America/New_York");
+        DateTimeZone nycTimeZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone("America/New_York"));
 
-        Calendar dayInNewYork = Calendar.getInstance(nycTimeZone);
+        Calendar dayInNewYork = Calendar.getInstance(nycTimeZone.toTimeZone());
         dayInNewYork.set(2007, Calendar.JULY, 7);
         UniversalDate nycTime = CalendarUtils.fromMillis(dayInNewYork.getTimeInMillis(), nycTimeZone);
 
@@ -78,9 +80,27 @@ public class CalendarTests {
         UniversalDate unpackedNycTime = CalendarUtils.fromMillis(time, nycTimeZone);
         assertSameDate(nycTime, unpackedNycTime);
 
-        TimeZone nepaliTimeZone = TimeZone.getTimeZone("GMT+05:45");
+        DateTimeZone nepaliTimeZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone("GMT+05:45"));
         time = CalendarUtils.toMillisFromJavaEpoch(nycTime.year, nycTime.month, nycTime.day, nepaliTimeZone);
         UniversalDate unpackedNepaliTime = CalendarUtils.fromMillis(time, nepaliTimeZone);
         assertSameDate(nycTime, unpackedNepaliTime);
+    }
+
+    @Test
+    public void serializeUniversalDateViaMillisTest() {
+        // India
+        DateTimeZone indiaTimeZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone("GMT+05:00"));
+        UniversalDate nepaliDate = new UniversalDate(2073, 5, 2, 0);
+        long normalizedTime = CalendarUtils.toMillisFromJavaEpoch(2073, 5, 2, indiaTimeZone);
+        Date date = new Date(normalizedTime);
+        UniversalDate deserializedNepaliDate = CalendarUtils.fromMillis(date.getTime(), indiaTimeZone);
+        assertSameDate(nepaliDate, deserializedNepaliDate);
+
+        // Boston
+        DateTimeZone bostonTimeZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone("GMT-04:00"));
+        normalizedTime = CalendarUtils.toMillisFromJavaEpoch(2073, 5, 2, bostonTimeZone);
+        date = new Date(normalizedTime);
+        deserializedNepaliDate = CalendarUtils.fromMillis(date.getTime(), bostonTimeZone);
+        assertSameDate(nepaliDate, deserializedNepaliDate);
     }
 }


### PR DESCRIPTION
Looks like there was a bug in `TimeZone` in Android 4.4 where `TimeZone.getOffset` didn't correctly factor in daylight savings time (at least this is what I've deduced by comparing with executions on an Android 6 device). This was causing normalization to UTC to somehow bleed over into the previous day.

Joda Time to the rescue!

💣 🔥 📅 📆 📅 🔥 💣 

Fix for: http://manage.dimagi.com/default.asp?234517