### PR TITLE
Keep ordering info on case search user query prompts

### DIFF
--- a/backend/src/org/commcare/session/RemoteQuerySessionManager.java
+++ b/backend/src/org/commcare/session/RemoteQuerySessionManager.java
@@ -4,6 +4,7 @@ import org.commcare.suite.model.DisplayUnit;
 import org.commcare.suite.model.RemoteQueryDatum;
 import org.commcare.suite.model.SessionDatum;
 import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.util.OrderedHashtable;
 import org.javarosa.xpath.expr.XPathExpression;
 import org.javarosa.xpath.expr.XPathFuncExpr;
 
@@ -45,7 +46,7 @@ public class RemoteQuerySessionManager {
         }
     }
 
-    public Hashtable<String, DisplayUnit> getNeededUserInputDisplays() {
+    public OrderedHashtable<String, DisplayUnit> getNeededUserInputDisplays() {
         return queryDatum.getUserQueryPrompts();
     }
 

--- a/backend/src/org/commcare/suite/model/RemoteQueryDatum.java
+++ b/backend/src/org/commcare/suite/model/RemoteQueryDatum.java
@@ -64,7 +64,7 @@ public class RemoteQueryDatum extends SessionDatum {
                 (Hashtable<String, XPathExpression>) ExtUtil.read(in, new ExtWrapMapPoly(String.class), pf);
         userQueryPrompts =
                 (OrderedHashtable<String, DisplayUnit>) ExtUtil.read(in,
-                        new ExtWrapMap(String.class, DisplayUnit.class), pf);
+                        new ExtWrapMap(String.class, DisplayUnit.class, ExtWrapMap.TYPE_ORDERED), pf);
     }
 
     @Override

--- a/backend/src/org/commcare/suite/model/RemoteQueryDatum.java
+++ b/backend/src/org/commcare/suite/model/RemoteQueryDatum.java
@@ -1,5 +1,6 @@
 package org.commcare.suite.model;
 
+import org.javarosa.core.util.OrderedHashtable;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.ExtWrapMap;
@@ -22,7 +23,7 @@ import java.util.Hashtable;
  */
 public class RemoteQueryDatum extends SessionDatum {
     private Hashtable<String, XPathExpression> hiddenQueryValues;
-    private Hashtable<String, DisplayUnit> userQueryPrompts;
+    private OrderedHashtable<String, DisplayUnit> userQueryPrompts;
 
     @SuppressWarnings("unused")
     public RemoteQueryDatum() {
@@ -30,13 +31,13 @@ public class RemoteQueryDatum extends SessionDatum {
 
     public RemoteQueryDatum(URL url, String storageInstance,
                             Hashtable<String, XPathExpression> hiddenQueryValues,
-                            Hashtable<String, DisplayUnit> userQueryPrompts) {
+                            OrderedHashtable<String, DisplayUnit> userQueryPrompts) {
         super(storageInstance, url.toString());
         this.hiddenQueryValues = hiddenQueryValues;
         this.userQueryPrompts = userQueryPrompts;
     }
 
-    public Hashtable<String, DisplayUnit> getUserQueryPrompts() {
+    public OrderedHashtable<String, DisplayUnit> getUserQueryPrompts() {
         return userQueryPrompts;
     }
 
@@ -62,7 +63,7 @@ public class RemoteQueryDatum extends SessionDatum {
         hiddenQueryValues =
                 (Hashtable<String, XPathExpression>) ExtUtil.read(in, new ExtWrapMapPoly(String.class), pf);
         userQueryPrompts =
-                (Hashtable<String, DisplayUnit>) ExtUtil.read(in,
+                (OrderedHashtable<String, DisplayUnit>) ExtUtil.read(in,
                         new ExtWrapMap(String.class, DisplayUnit.class), pf);
     }
 

--- a/backend/src/org/commcare/xml/SessionDatumParser.java
+++ b/backend/src/org/commcare/xml/SessionDatumParser.java
@@ -6,6 +6,7 @@ import org.commcare.suite.model.EntityDatum;
 import org.commcare.suite.model.FormIdDatum;
 import org.commcare.suite.model.RemoteQueryDatum;
 import org.commcare.suite.model.SessionDatum;
+import org.javarosa.core.util.OrderedHashtable;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xpath.XPathParseTool;
 import org.javarosa.xpath.expr.XPathExpression;
@@ -73,8 +74,8 @@ public class SessionDatumParser extends CommCareElementParser<SessionDatum> {
             throws InvalidStructureException, IOException, XmlPullParserException {
         Hashtable<String, XPathExpression> hiddenQueryValues =
                 new Hashtable<>();
-        Hashtable<String, DisplayUnit> userQueryPrompts =
-                new Hashtable<>();
+        OrderedHashtable<String, DisplayUnit> userQueryPrompts =
+                new OrderedHashtable<>();
         this.checkNode("query");
 
         String queryUrlString = parser.getAttributeValue(null, "url");


### PR DESCRIPTION
Preserve ordering info for user prompts in the case claim query screen

![image](https://cloud.githubusercontent.com/assets/94817/17839799/69380034-67c1-11e6-9d9b-33154d840260.png)

Fix for http://manage.dimagi.com/default.asp?235310

cross-request: https://github.com/dimagi/commcare-android/pull/1464
