### PR TITLE
rename Style to GridStyle 

### DIFF
--- a/backend/src/org/commcare/xml/DetailFieldParser.java
+++ b/backend/src/org/commcare/xml/DetailFieldParser.java
@@ -47,7 +47,7 @@ public class DetailFieldParser extends CommCareElementParser<DetailField> {
             }
         }
         if (nextTagInBlock("field")) {
-            parseStyle(builder);
+            parseGridStyle(builder);
             checkNode("header");
 
             builder.setHeaderWidthHint(parser.getAttributeValue(null, "width"));
@@ -69,7 +69,7 @@ public class DetailFieldParser extends CommCareElementParser<DetailField> {
             throw new InvalidStructureException("detail <field> with no <template>!", parser);
         }
         if (nextTagInBlock("field")) {
-            //sort details
+
             checkNode(new String[]{"sort", "background"});
 
             String name = parser.getName().toLowerCase();
@@ -84,16 +84,15 @@ public class DetailFieldParser extends CommCareElementParser<DetailField> {
         return builder.build();
     }
 
-    private void parseStyle(DetailField.Builder builder) throws InvalidStructureException, IOException, XmlPullParserException {
-        //style
-        if (parser.getName().toLowerCase().equals("style")) {
-            StyleParser styleParser = new StyleParser(builder, parser);
-            styleParser.parse();
-            //Header
+    private void parseGridStyle(DetailField.Builder builder) throws InvalidStructureException, IOException, XmlPullParserException {
+        if (parser.getName().toLowerCase().equals("style") ||
+                parser.getName().toLowerCase().equals("grid-style")) {
+            GridStyleParser gridStyleParser = new GridStyleParser(builder, parser);
+            gridStyleParser.parse();
+
             GridParser gridParser = new GridParser(builder, parser);
             gridParser.parse();
 
-            //exit style block
             parser.nextTag();
             parser.nextTag();
         }

--- a/backend/src/org/commcare/xml/GridStyleParser.java
+++ b/backend/src/org/commcare/xml/GridStyleParser.java
@@ -15,11 +15,11 @@ import java.io.IOException;
  * @author wspride
  */
 
-public class StyleParser extends ElementParser<Integer> {
+public class GridStyleParser extends ElementParser<Integer> {
 
     final Builder builder;
 
-    public StyleParser(Builder builder, KXmlParser parser) {
+    public GridStyleParser(Builder builder, KXmlParser parser) {
         super(parser);
         this.builder = builder;
     }


### PR DESCRIPTION
Currently, the `style` block of a `field` within a `detail` looks like this:

<img width="473" alt="screen shot 2016-08-26 at 2 15 42 pm" src="https://cloud.githubusercontent.com/assets/3723143/18015884/9b65178e-6b97-11e6-8ba7-ebbec273a0cd.png">

which makes it look like the attributes of a `style` block (alignment, font size, etc.) are generically applicable to all detail fields, when in fact they are only used if there is a `grid` element within the `style` block as well. Ideally, I think it would make sense to invert the elements so that `grid` is the outer element, and `style` is a sub-element of that. However, that isn't practical to do without breaking all case tiles that are already out in the wild, so for now I'm settling for just renaming `style` to `grid-style`. The parser will still accept an element name of `style` OR `grid-style` in order to preserve backwards-compatibility, but I'm going to call it `grid-style` in the documentation here https://github.com/dimagi/commcare-core/wiki/Suite20#detail, and try to make sure we use that going forward. 
