### PR TITLE
Extend case list actions to allow for relevancy condition

### DIFF
--- a/backend/src/org/commcare/resources/ResourceManager.java
+++ b/backend/src/org/commcare/resources/ResourceManager.java
@@ -7,7 +7,6 @@ import org.commcare.resources.model.ResourceLocation;
 import org.commcare.resources.model.ResourceTable;
 import org.commcare.resources.model.TableStateListener;
 import org.commcare.resources.model.UnresolvedResourceException;
-import org.commcare.suite.model.Profile;
 import org.commcare.util.CommCarePlatform;
 import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.storage.StorageFullException;

--- a/backend/src/org/commcare/suite/model/Action.java
+++ b/backend/src/org/commcare/suite/model/Action.java
@@ -1,10 +1,15 @@
 package org.commcare.suite.model;
 
+import org.commcare.session.RemoteQuerySessionManager;
+import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.ExtWrapList;
+import org.javarosa.core.util.externalizable.ExtWrapNullable;
+import org.javarosa.core.util.externalizable.ExtWrapTagged;
 import org.javarosa.core.util.externalizable.Externalizable;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.javarosa.xpath.expr.XPathExpression;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -12,20 +17,22 @@ import java.io.IOException;
 import java.util.Vector;
 
 /**
- * <p>An action defines a user interface element that can be
+ * An action defines a user interface element that can be
  * triggered by the user to fire off one or more stack operations
- * in the current session</p>
+ * in the current session
  *
  * @author ctsims
  */
 public class Action implements Externalizable {
 
-    DisplayUnit display;
-    Vector<StackOperation> stackOps;
+    private DisplayUnit display;
+    private Vector<StackOperation> stackOps;
+    private XPathExpression relevantExpr;
 
     /**
      * Serialization only!!!
      */
+    @SuppressWarnings("unused")
     public Action() {
 
     }
@@ -34,9 +41,10 @@ public class Action implements Externalizable {
      * Creates an Action model with the associated display details and stack
      * operations set.
      */
-    public Action(DisplayUnit display, Vector<StackOperation> stackOps) {
+    public Action(DisplayUnit display, Vector<StackOperation> stackOps, XPathExpression relevantExpr) {
         this.display = display;
         this.stackOps = stackOps;
+        this.relevantExpr = relevantExpr;
     }
 
     /**
@@ -55,19 +63,26 @@ public class Action implements Externalizable {
         return stackOps;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.util.externalizable.Externalizable#readExternal(java.io.DataInputStream, org.javarosa.core.util.externalizable.PrototypeFactory)
-     */
-    public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
-        this.display = (DisplayUnit)ExtUtil.read(in, DisplayUnit.class, pf);
-        this.stackOps = (Vector<StackOperation>)ExtUtil.read(in, new ExtWrapList(StackOperation.class), pf);
+    public boolean isRelevant(EvaluationContext evalContext) {
+        if (relevantExpr == null) {
+            return true;
+        } else {
+            String result = RemoteQuerySessionManager.evalXpathExpression(relevantExpr, evalContext);
+            return "true".equals(result);
+        }
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.util.externalizable.Externalizable#writeExternal(java.io.DataOutputStream)
-     */
+    @Override
+    public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
+        display = (DisplayUnit)ExtUtil.read(in, DisplayUnit.class, pf);
+        stackOps = (Vector<StackOperation>)ExtUtil.read(in, new ExtWrapList(StackOperation.class), pf);
+        relevantExpr = (XPathExpression)ExtUtil.read(in, new ExtWrapNullable(new ExtWrapTagged()), pf);
+    }
+
+    @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.write(out, display);
         ExtUtil.write(out, new ExtWrapList(stackOps));
+        ExtUtil.write(out, new ExtWrapNullable(relevantExpr == null ? null : new ExtWrapTagged(relevantExpr)));
     }
 }

--- a/backend/src/org/commcare/suite/model/Detail.java
+++ b/backend/src/org/commcare/suite/model/Detail.java
@@ -242,8 +242,14 @@ public class Detail implements Externalizable {
      * @return An Action model definition if one is defined for this detail.
      * Null if there is no associated action.
      */
-    public Vector<Action> getCustomActions() {
-        return actions;
+    public Vector<Action> getCustomActions(EvaluationContext evaluationContext) {
+        Vector<Action> relevantActions = new Vector<>();
+        for (Action action : actions) {
+            if (action.isRelevant(evaluationContext)) {
+                relevantActions.addElement(action);
+            }
+        }
+        return relevantActions;
     }
 
     /**

--- a/tests/resources/complex_stack/suite.xml
+++ b/tests/resources/complex_stack/suite.xml
@@ -60,6 +60,17 @@
         <title>
             <text>Case List</text>
         </title>
+        <action>
+            <display>
+                <text>Jump to Menu 2 Form 1</text>
+            </display>
+            <stack>
+                <push>
+                    <command value="'m1-f0'"/>
+                    <datum id="calculated_data" value="'new'"/>
+                </push>
+            </stack>
+        </action>
         <action relevant="true()">
             <display>
                 <text>Jump to Menu 2 Form 1</text>

--- a/tests/resources/complex_stack/suite.xml
+++ b/tests/resources/complex_stack/suite.xml
@@ -56,6 +56,49 @@
             </background>
         </field>
     </detail>
+    <detail id="actions-test-case-list">
+        <title>
+            <text>Case List</text>
+        </title>
+        <action relevant="true()">
+            <display>
+                <text>Jump to Menu 2 Form 1</text>
+            </display>
+            <stack>
+                <push>
+                    <command value="'m1-f0'"/>
+                    <datum id="calculated_data" value="'new'"/>
+                </push>
+            </stack>
+        </action>
+        <action relevant="false()">
+            <display>
+                <text>Jump to Menu 2 Form 1</text>
+            </display>
+            <stack>
+                <push>
+                    <command value="'m1-f0'"/>
+                    <datum id="calculated_data" value="'new'"/>
+                </push>
+            </stack>
+        </action>
+
+        <field>
+            <header>
+                <text>Name</text>
+            </header>
+            <template>
+                <text>
+                    <xpath function="case_name"/>
+                </text>
+            </template>
+            <sort type="string" order="1" direction="ascending">
+                <text>
+                    <xpath function="case_name"/>
+                </text>
+            </sort>
+        </field>
+    </detail>
 
     <entry>
         <form>http://commcarehq.org/test/placeholder_destination</form>
@@ -76,7 +119,6 @@
             <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='test_case'][@status='open']" value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
         </session>
     </entry>
-
 
     <entry>
         <form>http://commcarehq.org/test/placeholder</form>
@@ -130,6 +172,17 @@
         </session>
     </entry>
 
+    <entry>
+        <form>http://commcarehq.org/test/placeholder</form>
+        <command id="test-actions-entry">
+            <text>Form</text>
+        </command>
+        <instance id="casedb" src="jr://instance/casedb"/>
+        <session>
+            <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='test_case'][@status='open']" value="./@case_id" detail-select="actions-test-case-list" detail-confirm="m0_case_long"/>
+        </session>
+    </entry>
+
     <menu id="m0">
         <text>Menu 1</text>
         <command id="m0-f0"/>
@@ -143,6 +196,10 @@
     <menu id="m2">
         <text>Receiver Module</text>
         <command id="m2-f0"/>
+    </menu>
+    <menu id="test-actions">
+        <text>Menu 1</text>
+        <command id="test-actions-entry"/>
     </menu>
     <menu id="root">
         <text>Sender Module</text>

--- a/tests/test/org/commcare/backend/session/test/SessionStackTests.java
+++ b/tests/test/org/commcare/backend/session/test/SessionStackTests.java
@@ -272,7 +272,7 @@ public class SessionStackTests {
 
         EvaluationContext ec = session.getEvaluationContext();
         Vector<Action> actions = session.getDetail(entityDatum.getShortDetail()).getCustomActions(ec);
-        assertEquals(1, actions.size());
+        assertEquals(2, actions.size());
     }
 
     protected static TreeElement buildExampleInstanceRoot(String bolivarsId) {

--- a/tests/test/org/commcare/backend/session/test/SessionStackTests.java
+++ b/tests/test/org/commcare/backend/session/test/SessionStackTests.java
@@ -13,12 +13,16 @@ import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.test_utils.ExprEvalUtils;
 import org.javarosa.xpath.XPathMissingInstanceException;
 import org.javarosa.xpath.parser.XPathSyntaxException;
-import org.junit.Assert;
 
 import org.commcare.session.SessionFrame;
 import org.junit.Test;
 
 import java.util.Vector;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * This is a super basic test just to make sure the test infrastructure is working correctly
@@ -27,39 +31,39 @@ import java.util.Vector;
  * Created by ctsims on 8/14/2015.
  */
 public class SessionStackTests {
-    MockApp mApp;
+    private MockApp mApp;
 
     @Test
     public void testDoubleManagementAndOverlappingStack() throws Exception {
         mApp = new MockApp("/complex_stack/");
         SessionWrapper session = mApp.getSession();
 
-        Assert.assertEquals(SessionFrame.STATE_COMMAND_ID, session.getNeededData());
+        assertEquals(SessionFrame.STATE_COMMAND_ID, session.getNeededData());
 
         session.setCommand("m0");
 
-        Assert.assertEquals(SessionFrame.STATE_DATUM_COMPUTED, session.getNeededData());
+        assertEquals(SessionFrame.STATE_DATUM_COMPUTED, session.getNeededData());
 
         session.setComputedDatum();
 
-        Assert.assertEquals(SessionFrame.STATE_DATUM_VAL, session.getNeededData());
+        assertEquals(SessionFrame.STATE_DATUM_VAL, session.getNeededData());
         EntityDatum entityDatum = (EntityDatum)session.getNeededDatum();
-        Assert.assertEquals("case_id", entityDatum.getDataId());
+        assertEquals("case_id", entityDatum.getDataId());
 
-        Vector<Action> actions = session.getDetail(entityDatum.getShortDetail()).getCustomActions();
+        Vector<Action> actions = session.getDetail(entityDatum.getShortDetail()).getCustomActions(session.getEvaluationContext());
 
         if(actions == null || actions.isEmpty()) {
-            Assert.fail("Detail screen stack action was missing from app!");
+            fail("Detail screen stack action was missing from app!");
         }
         Action dblManagement = actions.firstElement();
 
         session.executeStackOperations(dblManagement.getStackOperations(), session.getEvaluationContext());
 
         if(session.getNeededData() != null) {
-            Assert.fail("After executing stack frame steps, session should be redirected");
+            fail("After executing stack frame steps, session should be redirected");
         }
 
-        Assert.assertEquals("http://commcarehq.org/test/placeholder_destination", session.getForm());
+        assertEquals("http://commcarehq.org/test/placeholder_destination", session.getForm());
 
         EvaluationContext ec = session.getEvaluationContext();
 
@@ -73,21 +77,21 @@ public class SessionStackTests {
         mApp = new MockApp("/complex_stack/");
         SessionWrapper session = mApp.getSession();
 
-        Assert.assertEquals(SessionFrame.STATE_COMMAND_ID, session.getNeededData());
+        assertEquals(SessionFrame.STATE_COMMAND_ID, session.getNeededData());
 
         session.setCommand("m3-f0");
 
-        Assert.assertEquals(SessionFrame.STATE_DATUM_VAL, session.getNeededData());
+        assertEquals(SessionFrame.STATE_DATUM_VAL, session.getNeededData());
 
-        Assert.assertEquals("case_id_to_send", session.getNeededDatum().getDataId());
+        assertEquals("case_id_to_send", session.getNeededDatum().getDataId());
 
-        Assert.assertFalse("Session incorrectly determined a view command", session.isViewCommand(session.getCommand()));
+        assertFalse("Session incorrectly determined a view command", session.isViewCommand(session.getCommand()));
 
         session.setDatum("case_id_to_send", "case_one");
 
         session.finishExecuteAndPop(session.getEvaluationContext());
 
-        Assert.assertEquals("m2", session.getCommand());
+        assertEquals("m2", session.getCommand());
 
         CaseTestUtils.xpathEvalAndCompare(session.getEvaluationContext(),
                 "instance('session')/session/data/case_id", "case_one");
@@ -95,7 +99,7 @@ public class SessionStackTests {
         CaseTestUtils.xpathEvalAndCompare(session.getEvaluationContext(),
                 "count(instance('session')/session/data/case_id_to_send)", "0");
 
-        Assert.assertEquals(SessionFrame.STATE_COMMAND_ID, session.getNeededData());
+        assertEquals(SessionFrame.STATE_COMMAND_ID, session.getNeededData());
     }
 
     @Test
@@ -103,15 +107,15 @@ public class SessionStackTests {
         mApp = new MockApp("/complex_stack/");
         SessionWrapper session = mApp.getSession();
 
-        Assert.assertEquals(SessionFrame.STATE_COMMAND_ID, session.getNeededData());
+        assertEquals(SessionFrame.STATE_COMMAND_ID, session.getNeededData());
 
         session.setCommand("m4-f0");
 
-        Assert.assertEquals(SessionFrame.STATE_DATUM_VAL, session.getNeededData());
+        assertEquals(SessionFrame.STATE_DATUM_VAL, session.getNeededData());
 
-        Assert.assertEquals("case_id_to_view", session.getNeededDatum().getDataId());
+        assertEquals("case_id_to_view", session.getNeededDatum().getDataId());
 
-        Assert.assertTrue("Session incorrectly tagged a view command", session.isViewCommand(session.getCommand()));
+        assertTrue("Session incorrectly tagged a view command", session.isViewCommand(session.getCommand()));
     }
 
     @Test
@@ -121,10 +125,10 @@ public class SessionStackTests {
 
         // Select a form that has 3 datum requirements to enter (in order from suite.xml: case_id,
         // case_id_new_visit_0, usercase_id)
-        Assert.assertEquals(SessionFrame.STATE_COMMAND_ID, session.getNeededData());
+        assertEquals(SessionFrame.STATE_COMMAND_ID, session.getNeededData());
         session.setCommand("m0");
 
-        Assert.assertEquals(SessionFrame.STATE_COMMAND_ID, session.getNeededData());
+        assertEquals(SessionFrame.STATE_COMMAND_ID, session.getNeededData());
         session.setCommand("m0-f3");
 
         // Set 2 of the 3 needed datums, but not in order (1st and 3rd)
@@ -132,14 +136,14 @@ public class SessionStackTests {
         session.setDatum("usercase_id", "usercase_id_value");
 
         // Session should now need the case_id_new_visit_0, which is a computed datum
-        Assert.assertEquals(SessionFrame.STATE_DATUM_COMPUTED, session.getNeededData());
+        assertEquals(SessionFrame.STATE_DATUM_COMPUTED, session.getNeededData());
 
         // The key of the needed datum should be "case_id_new_visit_0"
-        Assert.assertEquals("case_id_new_visit_0", session.getNeededDatum().getDataId());
+        assertEquals("case_id_new_visit_0", session.getNeededDatum().getDataId());
 
         // Add the needed datum to the stack and confirm that the session is now ready to proceed
         session.setDatum("case_id_new_visit_0", "visit_id_value");
-        Assert.assertEquals(null, session.getNeededData());
+        assertEquals(null, session.getNeededData());
     }
 
     @Test
@@ -149,10 +153,10 @@ public class SessionStackTests {
 
         // Select a form that has 3 datum requirements to enter (in order from suite.xml: case_id,
         // case_id_new_visit_0, usercase_id)
-        Assert.assertEquals(SessionFrame.STATE_COMMAND_ID, session.getNeededData());
+        assertEquals(SessionFrame.STATE_COMMAND_ID, session.getNeededData());
         session.setCommand("m0");
 
-        Assert.assertEquals(SessionFrame.STATE_COMMAND_ID, session.getNeededData());
+        assertEquals(SessionFrame.STATE_COMMAND_ID, session.getNeededData());
         session.setCommand("m0-f3");
 
         // Set 2 of the 3 needed datums, so that the datum that is actually still needed (case_id)
@@ -161,14 +165,14 @@ public class SessionStackTests {
         session.setDatum("usercase_id", "usercase_id_value");
 
         // Session should now see that it needs a normal datum val (NOT a computed val)
-        Assert.assertEquals(SessionFrame.STATE_DATUM_VAL, session.getNeededData());
+        assertEquals(SessionFrame.STATE_DATUM_VAL, session.getNeededData());
 
         // The key of the needed datum should be "case_id"
-        Assert.assertEquals("case_id", session.getNeededDatum().getDataId());
+        assertEquals("case_id", session.getNeededDatum().getDataId());
 
         // Add the needed datum to the stack and confirm that the session is now ready to proceed
         session.setDatum("case_id", "case_id_value");
-        Assert.assertEquals(null, session.getNeededData());
+        assertEquals(null, session.getNeededData());
     }
 
     @Test
@@ -178,10 +182,10 @@ public class SessionStackTests {
 
         // Select a form that has 3 datum requirements to enter (in order from suite.xml: case_id,
         // case_id_new_visit_0, usercase_id)
-        Assert.assertEquals(SessionFrame.STATE_COMMAND_ID, session.getNeededData());
+        assertEquals(SessionFrame.STATE_COMMAND_ID, session.getNeededData());
         session.setCommand("m0");
 
-        Assert.assertEquals(SessionFrame.STATE_COMMAND_ID, session.getNeededData());
+        assertEquals(SessionFrame.STATE_COMMAND_ID, session.getNeededData());
         session.setCommand("m0-f3");
 
         // Put a bunch of random data on the stack such that there are more datums on the stack
@@ -195,19 +199,19 @@ public class SessionStackTests {
         // and still sees itself as needing each of the datums defined for this form, in the correct
         // order
 
-        Assert.assertEquals(SessionFrame.STATE_DATUM_VAL, session.getNeededData());
-        Assert.assertEquals("case_id", session.getNeededDatum().getDataId());
+        assertEquals(SessionFrame.STATE_DATUM_VAL, session.getNeededData());
+        assertEquals("case_id", session.getNeededDatum().getDataId());
 
         session.setDatum("case_id", "case_id_value");
-        Assert.assertEquals(SessionFrame.STATE_DATUM_COMPUTED, session.getNeededData());
-        Assert.assertEquals("case_id_new_visit_0", session.getNeededDatum().getDataId());
+        assertEquals(SessionFrame.STATE_DATUM_COMPUTED, session.getNeededData());
+        assertEquals("case_id_new_visit_0", session.getNeededDatum().getDataId());
 
         session.setDatum("case_id_new_visit_0", "visit_id_value");
-        Assert.assertEquals(SessionFrame.STATE_DATUM_COMPUTED, session.getNeededData());
-        Assert.assertEquals("usercase_id", session.getNeededDatum().getDataId());
+        assertEquals(SessionFrame.STATE_DATUM_COMPUTED, session.getNeededData());
+        assertEquals("usercase_id", session.getNeededDatum().getDataId());
 
         session.setDatum("usercase_id", "usercase_id_value");
-        Assert.assertEquals(null, session.getNeededData());
+        assertEquals(null, session.getNeededData());
     }
 
     /**
@@ -220,7 +224,7 @@ public class SessionStackTests {
         SessionWrapper session = mApp.getSession();
 
         session.setCommand("patient-search");
-        Assert.assertEquals(session.getNeededData(), SessionFrame.STATE_QUERY_REQUEST);
+        assertEquals(session.getNeededData(), SessionFrame.STATE_QUERY_REQUEST);
 
         SessionDatum datum = session.getNeededDatum();
         String bolivarsId = "123";
@@ -231,8 +235,8 @@ public class SessionStackTests {
                 session.getEvaluationContext(),
                 bolivarsId);
 
-        Assert.assertEquals(SessionFrame.STATE_DATUM_VAL, session.getNeededData());
-        Assert.assertEquals("case_id", session.getNeededDatum().getDataId());
+        assertEquals(SessionFrame.STATE_DATUM_VAL, session.getNeededData());
+        assertEquals("case_id", session.getNeededDatum().getDataId());
         session.setDatum("case_id", "case_id_value");
 
         session.stepBack();
@@ -255,6 +259,22 @@ public class SessionStackTests {
                 bolivarsId);
     }
 
+    @Test
+    public void testIrrelevantActions() throws Exception {
+        mApp = new MockApp("/complex_stack/");
+        SessionWrapper session = mApp.getSession();
+
+        session.setCommand("test-actions");
+
+        assertEquals(SessionFrame.STATE_DATUM_VAL, session.getNeededData());
+        EntityDatum entityDatum = (EntityDatum)session.getNeededDatum();
+        assertEquals("case_id", entityDatum.getDataId());
+
+        EvaluationContext ec = session.getEvaluationContext();
+        Vector<Action> actions = session.getDetail(entityDatum.getShortDetail()).getCustomActions(ec);
+        assertEquals(1, actions.size());
+    }
+
     protected static TreeElement buildExampleInstanceRoot(String bolivarsId) {
         TreeElement root = new TreeElement("patients");
         TreeElement data = new TreeElement("patient");
@@ -270,7 +290,7 @@ public class SessionStackTests {
             throws XPathSyntaxException {
         try {
             ExprEvalUtils.xpathEval(session.getEvaluationContext(), xpath);
-            Assert.fail("instance('patients') should not be available");
+            fail("instance('patients') should not be available");
         } catch (XPathMissingInstanceException e) {
             // expected
         }

--- a/tests/test/org/commcare/backend/suite/model/test/StackFrameStepTests.java
+++ b/tests/test/org/commcare/backend/suite/model/test/StackFrameStepTests.java
@@ -124,7 +124,7 @@ public class StackFrameStepTests {
         session.setCommand("m0");
         session.setComputedDatum();
         EntityDatum entityDatum = (EntityDatum) session.getNeededDatum();
-        Vector<Action> actions = session.getDetail(entityDatum.getShortDetail()).getCustomActions();
+        Vector<Action> actions = session.getDetail(entityDatum.getShortDetail()).getCustomActions(session.getEvaluationContext());
         if (actions == null || actions.isEmpty()) {
             Assert.fail("Detail screen stack action was missing from app!");
         }

--- a/util/src/org/commcare/util/cli/EntityListSubscreen.java
+++ b/util/src/org/commcare/util/cli/EntityListSubscreen.java
@@ -40,7 +40,7 @@ public class EntityListSubscreen extends Subscreen<EntityScreen> {
         this.mChoices = new TreeReference[references.size()];
         references.copyInto(mChoices);
 
-        actions = shortDetail.getCustomActions();
+        actions = shortDetail.getCustomActions(context);
     }
 
     private String createRow(TreeReference entity, Detail shortDetail, EvaluationContext ec) {


### PR DESCRIPTION
Add `relevant=xpath_expr` to case list actions, allowing them to be hidden for certain mobile workers.

```
<action relevant="true()">
    <display>
        ...
    </display>
    <stack>
        ...
    </stack>
</action>
```

cross-request: https://github.com/dimagi/commcare-android/pull/1473