### PR TITLE
Show case name for saved follow-up forms when there isn't a case detail screen

### DIFF
--- a/backend/src/org/commcare/util/FormDataUtil.java
+++ b/backend/src/org/commcare/util/FormDataUtil.java
@@ -2,7 +2,6 @@ package org.commcare.util;
 
 import org.commcare.cases.model.Case;
 import org.commcare.core.interfaces.UserSandbox;
-import org.commcare.modern.util.Pair;
 import org.commcare.session.CommCareSession;
 import org.commcare.suite.model.ComputedDatum;
 import org.commcare.suite.model.EntityDatum;
@@ -13,6 +12,9 @@ import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.TreeReference;
 
 /**
+ * Use the session state descriptor attached to saved forms to load case
+ * information, such as the case name.
+ *
  * @author Phillip Mates (pmates@dimagi.com)
  */
 public class FormDataUtil {
@@ -20,48 +22,36 @@ public class FormDataUtil {
                                              CommCareSession session,
                                              EvaluationContext evalContext) {
         CommCareSession sessionCopy = new CommCareSession(session);
-
-        Pair<EntityDatum, String> datumEntityAndValue =
-                getDatumAndCaseId(sessionCopy, evalContext);
-        EntityDatum entityDatum = datumEntityAndValue.first;
-        String value = datumEntityAndValue.second;
-
-        if (entityDatum == null) {
-            if (value == null) {
-                return null;
-            } else {
-                return getCaseName(userSandbox, value);
-            }
-        } else {
-            return loadTitleFromEntity(entityDatum, value, evalContext, sessionCopy, userSandbox);
-        }
-    }
-
-    private static Pair<EntityDatum, String> getDatumAndCaseId(CommCareSession session,
-                                                               EvaluationContext evaluationContext) {
         String datumValue = null;
-        while (session.getFrame().getSteps().size() > 0) {
-            SessionDatum datum = session.getNeededDatum();
-            if (isCaseIdComputedDatum(datum, datumValue, session.getPoppedStep())) {
+
+        while (sessionCopy.getFrame().getSteps().size() > 0) {
+            SessionDatum datum = sessionCopy.getNeededDatum();
+            if (isCaseIdComputedDatum(datum, datumValue, sessionCopy.getPoppedStep())) {
                 // Loads case id for forms that create cases, since case id was
                 // a computed datum injected into the form. Assumes that it was
                 // the 1st computed datum... another good heuristic would be
                 // session.getPoppedStep().getId().startsWith("case_id")
-                datumValue = session.getPoppedStep().getValue();
+                datumValue = sessionCopy.getPoppedStep().getValue();
             } else if (datum instanceof EntityDatum) {
-                String tmpDatumValue = session.getPoppedStep().getValue();
+                String tmpDatumValue = sessionCopy.getPoppedStep().getValue();
                 if (tmpDatumValue != null) {
                     datumValue = tmpDatumValue;
                 }
                 if (((EntityDatum)datum).getLongDetail() == null) {
-                    return new Pair<>(null, datumValue);
+                    // In the absence of a case detail, use the plain case name as the title
+                    break;
                 } else {
-                    return new Pair<>((EntityDatum)datum, datumValue);
+                    return loadTitleFromEntity((EntityDatum)datum, datumValue, evalContext, sessionCopy, userSandbox);
                 }
             }
-            session.popStep(evaluationContext);
+            sessionCopy.popStep(evalContext);
         }
-        return new Pair<>(null, datumValue);
+
+        if (datumValue == null) {
+            return null;
+        } else {
+            return getCaseName(userSandbox, datumValue);
+        }
     }
 
     private static boolean isCaseIdComputedDatum(SessionDatum datum,

--- a/backend/src/org/commcare/util/FormDataUtil.java
+++ b/backend/src/org/commcare/util/FormDataUtil.java
@@ -48,12 +48,16 @@ public class FormDataUtil {
                 // the 1st computed datum... another good heuristic would be
                 // session.getPoppedStep().getId().startsWith("case_id")
                 datumValue = session.getPoppedStep().getValue();
-            } else if (datum instanceof EntityDatum && ((EntityDatum)datum).getLongDetail() != null) {
+            } else if (datum instanceof EntityDatum) {
                 String tmpDatumValue = session.getPoppedStep().getValue();
                 if (tmpDatumValue != null) {
                     datumValue = tmpDatumValue;
                 }
-                return new Pair<>((EntityDatum)datum, datumValue);
+                if (((EntityDatum)datum).getLongDetail() == null) {
+                    return new Pair<>(null, datumValue);
+                } else {
+                    return new Pair<>((EntityDatum)datum, datumValue);
+                }
             }
             session.popStep(evaluationContext);
         }

--- a/tests/resources/case_title_form_loading/suite.xml
+++ b/tests/resources/case_title_form_loading/suite.xml
@@ -174,6 +174,19 @@
     </session>
   </entry>
 
+  <entry>
+    <form>http://openrosa.org/formdesigner/e1f870ef46c9ec0781806ef24ff0537ad604c816</form>
+    <command id="m4-f0">
+      <text>
+        <locale id="forms.m4f0"/>
+      </text>
+    </command>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <session>
+      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='adult'][@status='closed']" value="./@case_id" detail-select="m0_case_short"/>
+    </session>
+  </entry>
+
   <menu id="m0">
     <display>
       <text>
@@ -191,6 +204,13 @@
       <locale id="modules.m1"/>
     </text>
     <command id="m1-f0"/>
+  </menu>
+
+  <menu id="m4">
+    <text>
+      <locale id="modules.m1"/>
+    </text>
+    <command id="m4-f0"/>
   </menu>
 
   <menu id="m2">

--- a/tests/test/org/commcare/backend/util/test/FormDataUtilTest.java
+++ b/tests/test/org/commcare/backend/util/test/FormDataUtilTest.java
@@ -57,6 +57,24 @@ public class FormDataUtilTest {
     }
 
     /**
+     * Load form title from session where the case list doesn't have a detail screen
+     */
+    @Test
+    public void loadCaseListFormWithoutCaseDetail() throws Exception {
+        MockApp mockApp = new MockApp("/case_title_form_loading/");
+        SessionWrapper session = mockApp.getSession();
+        UserSandbox sandbox = session.getSandbox();
+        SessionWrapper blankSession = new SessionWrapper(session.getPlatform(), sandbox);
+        String descriptor = "COMMAND_ID m4 "
+                + "CASE_ID case_id case_one "
+                + "COMMAND_ID m4-f0";
+        SessionDescriptorUtil.loadSessionFromDescriptor(descriptor, blankSession);
+        String title = FormDataUtil.getTitleFromSession(sandbox,
+                blankSession, blankSession.getEvaluationContext());
+        assertEquals("Saul", title);
+    }
+
+    /**
      * Load form title from session in standard manner, where the case id
      * selected by user
      */


### PR DESCRIPTION
Looks like the calculation that loads the case name for saved forms that update a case couldn't handle the case where there wasn't a case detail screen for the case list. Don't think there was any good reason for this.

Fix for http://manage.dimagi.com/default.asp?235678