### PR TITLE
Fix for Crash Querying Non-Homogenous Fixtures

### DIFF
--- a/javarosa/src/main/java/org/javarosa/core/model/instance/utils/TreeUtilities.java
+++ b/javarosa/src/main/java/org/javarosa/core/model/instance/utils/TreeUtilities.java
@@ -169,6 +169,10 @@ public class TreeUtilities {
                             for (int kidI = 0; kidI < kids.size(); ++kidI) {
                                 String attrValue = kids.elementAt(kidI).getAttributeValue(null, attributeName);
 
+                                if(attrValue == null ) {
+                                    attrValue = "";
+                                }
+
                                 // We don't necessarily having typing
                                 // information for these attributes (and if we
                                 // did it's not available here) so we will try

--- a/tests/resources/fixture_create.xml
+++ b/tests/resources/fixture_create.xml
@@ -1,0 +1,43 @@
+<OpenRosaResponse>
+	<message nature="ota_restore_success">Successfully restored account test!</message>
+	<fixture id="commtrack:products">
+	<products>
+	<product id="f895be4959f9a8a66f57c340aac461b4" heterogenous_attribute="present">
+		<name>Collier</name>
+		<unit/>
+		<code>col</code>
+		<description>Collier du cycle mensuel</description>
+		<category/>
+		<program_id>31ab899368d38c2d0207fe80c00fc3f3</program_id>
+		<cost>152</cost>
+	</product>
+	<product id="a6d16035b98f6f962a6538bd927cefb3">
+		<name>CU</name>
+		<unit/>
+		<code>pd</code>
+		<description>La contraception d'urgence</description>
+		<category/>
+		<program_id>31ab899368d38c2d0207fe80c00fc3f3</program_id>
+		<cost>57</cost>
+	</product>
+	<product id="31ab899368d38c2d0207fe80c00fa96c" heterogenous_attribute="present">
+		<name>Depo-Provera</name>
+		<unit/>
+		<code>dp</code>
+		<description>Injectable</description>
+		<category/>
+		<program_id>31ab899368d38c2d0207fe80c00fc3f3</program_id>
+		<cost>152</cost>
+	</product>
+	<product id="31ab899368d38c2d0207fe80c00fb8c1">
+		<name>DIU</name>
+		<unit/>
+		<code>diu</code>
+		<description>TCU 380A</description>
+		<category/>
+		<program_id>31ab899368d38c2d0207fe80c00fc3f3</program_id>
+		<cost>380</cost>
+	</product>
+	</products>
+	</fixture>
+</OpenRosaResponse>

--- a/tests/test/org/commcare/fixtures/test/FixtureQueryTest.java
+++ b/tests/test/org/commcare/fixtures/test/FixtureQueryTest.java
@@ -1,0 +1,39 @@
+package org.commcare.fixtures.test;
+
+import org.commcare.core.parse.ParseUtils;
+import org.commcare.test.utilities.CaseTestUtils;
+import org.commcare.util.mocks.MockDataUtils;
+import org.commcare.util.mocks.MockUserDataSandbox;
+import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.xml.util.InvalidStructureException;
+import org.javarosa.xml.util.UnfullfilledRequirementsException;
+import org.javarosa.xpath.parser.XPathSyntaxException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.xmlpull.v1.XmlPullParserException;
+
+import java.io.IOException;
+
+/**
+ * Test XPath expressions for fixtures
+ *
+ * @author Clayton Sims (csims@dimagi.com)
+ */
+public class FixtureQueryTest {
+    private MockUserDataSandbox sandbox;
+
+    @Before
+    public void setUp() {
+        sandbox = MockDataUtils.getStaticStorage();
+    }
+
+    @Test
+    public void queryNonHomogenousLookups() throws XPathSyntaxException, UnfullfilledRequirementsException, XmlPullParserException, IOException, InvalidStructureException {
+        ParseUtils.parseIntoSandbox(this.getClass().getResourceAsStream("/fixture_create.xml"), sandbox);
+
+        EvaluationContext ec =
+                MockDataUtils.buildContextWithInstance(sandbox, "commtrack:products", CaseTestUtils.FIXTURE_INSTANCE_PRODUCT);
+        CaseTestUtils.xpathEvalAndAssert(ec, "count(instance('commtrack:products')/products/product[@heterogenous_attribute = 'present'])", 2.0);
+    }
+}

--- a/tests/test/org/commcare/test/utilities/CaseTestUtils.java
+++ b/tests/test/org/commcare/test/utilities/CaseTestUtils.java
@@ -5,10 +5,12 @@ import org.javarosa.xpath.XPathParseTool;
 import org.javarosa.xpath.expr.XPathExpression;
 import org.javarosa.xpath.expr.XPathFuncExpr;
 import org.javarosa.xpath.parser.XPathSyntaxException;
+import org.junit.Assert;
 
 public class CaseTestUtils {
     public static final String CASE_INSTANCE = "jr://instance/casedb";
     public static final String LEDGER_INSTANCE = "jr://instance/ledgerdb";
+    public static final String FIXTURE_INSTANCE_PRODUCT = "jr://fixture/commtrack:products";
 
     public static boolean xpathEvalAndCompare(EvaluationContext evalContext,
                                               String input,
@@ -18,6 +20,16 @@ public class CaseTestUtils {
         expr = XPathParseTool.parseXPath(input);
         Object output = XPathFuncExpr.unpack(expr.eval(evalContext));
         return expectedOutput.equals(output);
+    }
+
+    public static void xpathEvalAndAssert(EvaluationContext evalContext,
+                                              String input,
+                                              Object expectedOutput)
+            throws XPathSyntaxException {
+        XPathExpression expr;
+        expr = XPathParseTool.parseXPath(input);
+        Object output = XPathFuncExpr.unpack(expr.eval(evalContext));
+        Assert.assertEquals("XPath: " + input, expectedOutput,output);
     }
 
     public static void xpathEval(EvaluationContext evalContext,


### PR DESCRIPTION
Bug: http://manage.dimagi.com/default.asp?233467#1196349

Fixes issue where querying a tree with attributes that aren't consistent would crash.