### PR TITLE
Remove leading zeros from Java date string for comparison

### DIFF
--- a/javarosa/src/test/java/org/javarosa/form/api/test/FormatDateTest.java
+++ b/javarosa/src/test/java/org/javarosa/form/api/test/FormatDateTest.java
@@ -55,13 +55,13 @@ public class FormatDateTest {
 
         prompt = fpi.getFormEntryModel().getQuestionPrompt();
         String unwrappedDateString = prompt.getLongText();
-        String javaDateString = new SimpleDateFormat("dd MMM, yyyy", Locale.US).format(new Date());
+        String javaDateString = new SimpleDateFormat("d MMM, yyyy", Locale.US).format(new Date());
         assertEquals(javaDateString, unwrappedDateString);
 
         fec.stepToNextEvent();
         prompt = fpi.getFormEntryModel().getQuestionPrompt();
         unwrappedDateString = prompt.getLongText();
-        javaDateString = new SimpleDateFormat("dd MMM, yyyy", Locale.US).format(new Date());
+        javaDateString = new SimpleDateFormat("d MMM, yyyy", Locale.US).format(new Date());
         assertEquals(javaDateString, unwrappedDateString);
     }
 


### PR DESCRIPTION
Java SImpleDataString was keeping leading 0's as we used it before, this only failed when we rolled over to September 01 :)