### PR TITLE
Add test demonstrating session instance reference limitation in session 'create' block

### DIFF
--- a/backend/src/org/commcare/session/CommCareSession.java
+++ b/backend/src/org/commcare/session/CommCareSession.java
@@ -465,7 +465,6 @@ public class CommCareSession {
 
         for (StackFrameStep step : frame.getSteps()) {
             if (SessionFrame.STATE_DATUM_VAL.equals(step.getType()) ||
-                    SessionFrame.STATE_DATUM_COMPUTED.equals(step.getType()) ||
                     SessionFrame.STATE_UNKNOWN.equals(step.getType()) &&
                     guessUnknownType(step).equals(SessionFrame.STATE_DATUM_COMPUTED)) {
                 String key = step.getId();

--- a/backend/src/org/commcare/session/SessionInstanceBuilder.java
+++ b/backend/src/org/commcare/session/SessionInstanceBuilder.java
@@ -118,5 +118,4 @@ public class SessionInstanceBuilder {
         datum.setValue(new UncastData(data));
         root.addChild(datum);
     }
-
 }

--- a/core/org/commcare/core/process/CommCareInstanceInitializer.java
+++ b/core/org/commcare/core/process/CommCareInstanceInitializer.java
@@ -54,6 +54,11 @@ public class CommCareInstanceInitializer extends InstanceInitializationFactory {
         this.mPlatform = platform;
     }
 
+    public CommCareInstanceInitializer copyWithNewSession(CommCareSession session) {
+        return new CommCareInstanceInitializer(session, mSandbox, mPlatform);
+    }
+
+    @Override
     public ExternalDataInstance getSpecializedExternalDataInstance(ExternalDataInstance instance) {
         if (CaseInstanceTreeElement.MODEL_NAME.equals(instance.getInstanceId())) {
             return new CaseDataInstance(instance);

--- a/javarosa/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
+++ b/javarosa/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
@@ -3,6 +3,7 @@ package org.javarosa.core.model.condition;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.instance.AbstractTreeElement;
 import org.javarosa.core.model.instance.DataInstance;
+import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.model.trace.EvaluationTrace;
@@ -15,6 +16,7 @@ import org.javarosa.xpath.expr.XPathFuncExpr;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.Hashtable;
+import java.util.Map;
 import java.util.Vector;
 
 /**
@@ -137,8 +139,12 @@ public class EvaluationContext {
         }
     }
 
+    public EvaluationContext copy() {
+        return new EvaluationContext(this, this.contextNode);
+    }
+
     public DataInstance getInstance(String id) {
-        return formInstances.containsKey(id) ? formInstances.get(id) : null;
+        return formInstances.get(id);
     }
 
     public TreeReference getContextRef() {
@@ -549,5 +555,13 @@ public class EvaluationContext {
      */
     public EvaluationTrace getEvaluationTrace() {
         return mTraceRoot;
+    }
+
+    public void copyOverInstances(EvaluationContext evalContext) {
+        for (Map.Entry<String, DataInstance> idAndInstance : evalContext.formInstances.entrySet()) {
+            if (!formInstances.containsKey(idAndInstance.getKey())) {
+                formInstances.put(idAndInstance.getKey(), idAndInstance.getValue());
+            }
+        }
     }
 }

--- a/javarosa/src/test/java/org/javarosa/core/model/instance/test/DummyInstanceInitializationFactory.java
+++ b/javarosa/src/test/java/org/javarosa/core/model/instance/test/DummyInstanceInitializationFactory.java
@@ -11,12 +11,14 @@ import org.javarosa.core.model.instance.InstanceInitializationFactory;
  *
  * @author Phillip Mates (pmates@dimagi.com)
  */
-
 public class DummyInstanceInitializationFactory extends InstanceInitializationFactory {
 
+    @Override
     public ExternalDataInstance getSpecializedExternalDataInstance(ExternalDataInstance instance) {
         return instance;
     }
+
+    @Override
     public AbstractTreeElement generateRoot(ExternalDataInstance instance) {
         throw new RuntimeException("Loading external instances isn't supported " +
                 "using this instance initialization factory.");

--- a/tests/resources/complex_stack/suite.xml
+++ b/tests/resources/complex_stack/suite.xml
@@ -179,6 +179,31 @@
         <instance id="casedb" src="jr://instance/casedb"/>
         <instance id="session" src="jr://instance/session"/>
         <session>
+            <datum id="case_id_one" function="'first id'"/>
+            <datum id="case_id_two" function="'second id'"/>
+        </session>
+        <stack>
+            <create>
+                <command value="'m6-f0'"/>
+                <datum id="datum_one" value="instance('session')/session/data/case_id_one"/>
+                <datum id="datum_two"
+                       value="instance('session')/session/data/datum_one"/>
+            </create>
+            <create>
+                <command value="'m6-f0'"/>
+                <datum id="datum_one" value="instance('session')/session/data/case_id_two"/>
+                <datum id="datum_two"
+                       value="instance('session')/session/data/datum_one"/>
+            </create>
+        </stack>
+    </entry>
+
+    <entry>
+        <command id="m6-f0">
+            <text>Terminal Detail</text>
+        </command>
+        <instance id="casedb" src="jr://instance/casedb"/>
+        <session>
             <datum detail-confirm="m0_case_long"
                    detail-select="m0_case_short"
                    id="datum_one" nodeset="instance('casedb')/casedb/case[@case_type='test_case'][@status='open']" value="./@case_id"/>
@@ -186,14 +211,6 @@
                    detail-select="m0_case_short"
                    id="datum_two" nodeset="instance('casedb')/casedb/case[@case_type='test_case'][@status='open']" value="./@case_id"/>
         </session>
-        <stack>
-            <create>
-                <command value="'m5-f0'"/>
-                <datum id="datum_one" value="'foo'"/>
-                <datum id="datum_two"
-                       value="instance('session')/session/data/datum_one"/>
-            </create>
-        </stack>
     </entry>
 
     <entry>

--- a/tests/resources/complex_stack/suite.xml
+++ b/tests/resources/complex_stack/suite.xml
@@ -179,6 +179,7 @@
         <instance id="casedb" src="jr://instance/casedb"/>
         <instance id="session" src="jr://instance/session"/>
         <session>
+            <datum id="datum_one" function="'base value'"/>
             <datum id="case_id_one" function="'first id'"/>
             <datum id="case_id_two" function="'second id'"/>
         </session>

--- a/tests/resources/complex_stack/suite.xml
+++ b/tests/resources/complex_stack/suite.xml
@@ -179,8 +179,21 @@
         <instance id="casedb" src="jr://instance/casedb"/>
         <instance id="session" src="jr://instance/session"/>
         <session>
-            <datum id="case_id_to_view" nodeset="instance('casedb')/casedb/case[@case_type='test_case'][@status='open']" value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
+            <datum detail-confirm="m0_case_long"
+                   detail-select="m0_case_short"
+                   id="datum_one" nodeset="instance('casedb')/casedb/case[@case_type='test_case'][@status='open']" value="./@case_id"/>
+            <datum detail-confirm="m0_case_long"
+                   detail-select="m0_case_short"
+                   id="datum_two" nodeset="instance('casedb')/casedb/case[@case_type='test_case'][@status='open']" value="./@case_id"/>
         </session>
+        <stack>
+            <create>
+                <command value="'m5-f0'"/>
+                <datum id="datum_one" value="'foo'"/>
+                <datum id="datum_two"
+                       value="instance('session')/session/data/datum_one"/>
+            </create>
+        </stack>
     </entry>
 
     <entry>

--- a/tests/test/org/commcare/backend/session/test/MarkRewindSessionTests.java
+++ b/tests/test/org/commcare/backend/session/test/MarkRewindSessionTests.java
@@ -35,7 +35,7 @@ public class MarkRewindSessionTests {
         Detail shortDetail = session.getPlatform().getDetail("case-list");
         Action action = shortDetail.getCustomActions(session.getEvaluationContext()).firstElement();
         // queue up action
-        session.executeStackOperations(action.getStackOperations(), session.getEvaluationContext());
+        session.executeStackOperations(action.getStackOperations(), session.getIIF());
 
         // test backing out of action
         session.stepBack();
@@ -43,17 +43,17 @@ public class MarkRewindSessionTests {
         assertEquals(SessionFrame.STATE_DATUM_VAL, session.getFrame().getSteps().lastElement().getType());
 
         // queue up action again
-        session.executeStackOperations(action.getStackOperations(), session.getEvaluationContext());
+        session.executeStackOperations(action.getStackOperations(), session.getIIF());
 
         // finish action
-        session.finishExecuteAndPop(session.getEvaluationContext());
+        session.finishExecuteAndPop(session.getIIF());
 
         // ensure we don't need any more data to perform the visit
         assertEquals(SessionFrame.STATE_COMMAND_ID, session.getNeededData());
 
         CaseTestUtils.xpathEvalAndCompare(session.getEvaluationContext(),
                 "instance('session')/session/data/child_case_1", "billy");
-        session.finishExecuteAndPop(session.getEvaluationContext());
+        session.finishExecuteAndPop(session.getIIF());
         assertTrue(session.getFrame().isDead());
     }
 
@@ -65,7 +65,7 @@ public class MarkRewindSessionTests {
         session.setCommand("create-rewind-behavior");
         assertNull(session.getNeededData());
 
-        session.finishExecuteAndPop(session.getEvaluationContext());
+        session.finishExecuteAndPop(session.getIIF());
 
         assertEquals(SessionFrame.STATE_DATUM_VAL, session.getNeededData());
         assertEquals("child_case_1", session.getNeededDatum().getDataId());
@@ -82,7 +82,7 @@ public class MarkRewindSessionTests {
         session.setCommand("create-rewind-without-mark");
         assertNull(session.getNeededData());
 
-        session.finishExecuteAndPop(session.getEvaluationContext());
+        session.finishExecuteAndPop(session.getIIF());
 
         assertEquals(SessionFrame.STATE_COMMAND_ID, session.getNeededData());
 
@@ -111,7 +111,7 @@ public class MarkRewindSessionTests {
 
         // execute the stack ops for the m0-f0 entry
         session.setCommand("m0-f0");
-        session.finishExecuteAndPop(session.getEvaluationContext());
+        session.finishExecuteAndPop(session.getIIF());
 
         assertEquals(SessionFrame.STATE_DATUM_VAL, session.getNeededData());
         assertEquals("child_case_1", session.getNeededDatum().getDataId());
@@ -126,11 +126,11 @@ public class MarkRewindSessionTests {
         SessionWrapper session = mockApp.getSession();
 
         session.setCommand("nested-mark-and-rewinds-part-i");
-        session.finishExecuteAndPop(session.getEvaluationContext());
+        session.finishExecuteAndPop(session.getIIF());
         assertEquals(SessionFrame.STATE_COMMAND_ID, session.getNeededData());
 
         session.setCommand("nested-mark-and-rewinds-part-ii");
-        session.finishExecuteAndPop(session.getEvaluationContext());
+        session.finishExecuteAndPop(session.getIIF());
 
         assertEquals(SessionFrame.STATE_DATUM_VAL, session.getNeededData());
         assertEquals("child_case_1", session.getNeededDatum().getDataId());
@@ -146,11 +146,11 @@ public class MarkRewindSessionTests {
         SessionWrapper session = mockApp.getSession();
 
         session.setCommand("push-rewind-to-current-id-frame-part-i");
-        session.finishExecuteAndPop(session.getEvaluationContext());
+        session.finishExecuteAndPop(session.getIIF());
         assertEquals(SessionFrame.STATE_DATUM_VAL, session.getNeededData());
 
         session.setCommand("push-rewind-to-current-id-frame-part-ii");
-        session.finishExecuteAndPop(session.getEvaluationContext());
+        session.finishExecuteAndPop(session.getIIF());
 
         assertEquals(SessionFrame.STATE_DATUM_VAL, session.getNeededData());
         assertEquals("child_case_1", session.getNeededDatum().getDataId());
@@ -165,11 +165,11 @@ public class MarkRewindSessionTests {
         SessionWrapper session = mockApp.getSession();
 
         session.setCommand("push-rewind-to-current-id-frame-part-i");
-        session.finishExecuteAndPop(session.getEvaluationContext());
+        session.finishExecuteAndPop(session.getIIF());
         assertEquals(SessionFrame.STATE_DATUM_VAL, session.getNeededData());
 
         session.setCommand("rewind-without-value");
-        session.finishExecuteAndPop(session.getEvaluationContext());
+        session.finishExecuteAndPop(session.getIIF());
 
         assertEquals(SessionFrame.STATE_DATUM_VAL, session.getNeededData());
         assertEquals("mother_case_1", session.getNeededDatum().getDataId());

--- a/tests/test/org/commcare/backend/session/test/SessionStackTests.java
+++ b/tests/test/org/commcare/backend/session/test/SessionStackTests.java
@@ -12,6 +12,7 @@ import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.test_utils.ExprEvalUtils;
 import org.javarosa.xpath.XPathMissingInstanceException;
+import org.javarosa.xpath.XPathTypeMismatchException;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 import org.commcare.session.SessionFrame;
@@ -115,6 +116,28 @@ public class SessionStackTests {
         assertEquals("case_id_to_view", session.getNeededDatum().getDataId());
 
         assertTrue("Session incorrectly tagged a view command", session.isViewCommand(session.getCommand()));
+    }
+
+    @Test(expected=XPathTypeMismatchException.class)
+    public void testSessionInstanceNotRefreshedInStackCreate() throws Exception {
+        MockApp mockApp = new MockApp("/complex_stack/");
+        SessionWrapper session = mockApp.getSession();
+
+        assertEquals(SessionFrame.STATE_COMMAND_ID, session.getNeededData());
+
+        session.setCommand("m5-f0");
+
+        // The stack action has 2 datums, 'datum_one' and 'datum_two'. The
+        // value of 'datum_two' references
+        // instance(session)/session/data/datum_one, defined directly above.
+        // Since we don't refresh the evaluation context / session instance at
+        // each step, this reference should not valid, resulting in a
+        // XPathTypeMismatchException.
+        // If at any point we decide we want to support this behavior, this
+        // test should be adapted to reflect that. The test is left here to
+        // demonstrate the current limitation and allow TDD if the behavior is
+        // modified.
+        session.finishExecuteAndPop(session.getEvaluationContext());
     }
 
     @Test

--- a/tests/test/org/commcare/backend/session/test/SessionStackTests.java
+++ b/tests/test/org/commcare/backend/session/test/SessionStackTests.java
@@ -129,6 +129,7 @@ public class SessionStackTests {
         assertEquals(SessionFrame.STATE_DATUM_COMPUTED, session.getNeededData());
         session.setComputedDatum();
         session.setComputedDatum();
+        session.setComputedDatum();
         assertNull(session.getNeededData());
 
         session.finishExecuteAndPop(session.getIIF());
@@ -136,6 +137,15 @@ public class SessionStackTests {
         Vector<StackFrameStep> steps = session.getFrame().getSteps();
         assertEquals("datum_one", steps.get(steps.size() - 2).getId());
         assertEquals("second id", steps.get(steps.size() - 2).getValue());
+
+        int datumOneCount = 0;
+        for (StackFrameStep step : steps) {
+            if ("datum_one".equals(step.getId())) {
+                datumOneCount++;
+                assertEquals("second id", step.getValue());
+            }
+        }
+        assertEquals(1, datumOneCount);
     }
 
     @Test

--- a/tests/test/org/commcare/backend/suite/model/test/StackFrameStepTests.java
+++ b/tests/test/org/commcare/backend/suite/model/test/StackFrameStepTests.java
@@ -131,7 +131,7 @@ public class StackFrameStepTests {
         //We're using the second action for this screen which requires us to still need another datum
         Action dblManagement = actions.elementAt(1);
         assertEquals(1, session.getFrame().getSteps().size());
-        session.executeStackOperations(dblManagement.getStackOperations(), session.getEvaluationContext());
+        session.executeStackOperations(dblManagement.getStackOperations(), session.getIIF());
         assertEquals(5, session.getFrame().getSteps().size());
         session.stepBack();
         assertEquals(1, session.getFrame().getSteps().size());

--- a/tests/test/org/commcare/test/utilities/TestInstanceInitializer.java
+++ b/tests/test/org/commcare/test/utilities/TestInstanceInitializer.java
@@ -20,6 +20,7 @@ public class TestInstanceInitializer extends InstanceInitializationFactory {
         this.sandbox = sandbox;
     }
 
+    @Override
     public ExternalDataInstance getSpecializedExternalDataInstance(ExternalDataInstance instance) {
         if (CaseInstanceTreeElement.MODEL_NAME.equals(instance.getInstanceId())) {
             return new CaseDataInstance(instance);
@@ -28,6 +29,7 @@ public class TestInstanceInitializer extends InstanceInitializationFactory {
         }
     }
 
+    @Override
     public AbstractTreeElement generateRoot(ExternalDataInstance instance) {
         String ref = instance.getReference();
         if (ref.contains(CaseInstanceTreeElement.MODEL_NAME)) {

--- a/util/src/org/commcare/util/cli/ApplicationHost.java
+++ b/util/src/org/commcare/util/cli/ApplicationHost.java
@@ -272,7 +272,7 @@ public class ApplicationHost {
 
     private void finishSession() {
         mSession.clearVolitiles();
-        if (mSession.finishExecuteAndPop(mSession.getEvaluationContext())) {
+        if (mSession.finishExecuteAndPop(mSession.getIIF())) {
             mSessionHasNextFrameReady = true;
         }
     }

--- a/util/src/org/commcare/util/cli/EntityScreen.java
+++ b/util/src/org/commcare/util/cli/EntityScreen.java
@@ -113,7 +113,7 @@ public class EntityScreen extends CompoundScreenHost {
     @Override
     protected void updateSession(CommCareSession session) {
         if(mPendingAction != null) {
-            session.executeStackOperations(mPendingAction.getStackOperations(), mSession.getEvaluationContext());
+            session.executeStackOperations(mPendingAction.getStackOperations(), mSession.getIIF());
             return;
         }
 


### PR DESCRIPTION
Spent some time getting to the bottom of http://manage.dimagi.com/default.asp?236750

Turns out we have a limitation in our session stack processing where we can't reference datums stored immediately afterwards via `instance('session')/session/data/...`

The change turned out to be more comprehensive than I initially thought:
We want the session information from the current frame to be available along with the session information for the frame being pushed. This is complicated in the fact that one of those frames might not have access to the `instance('commcaresession')` data instance, so we have to take care in making them available. 

My approach builds a new evaluation context using the frame currently being created. But adds in instances defined in the current frame but not the new frame. In the case of the session data instance, datums from the current frame are copied over to the new frame when building the evaluation context, so they are available as well.  