### PR TITLE
Make max and min work on datestrings

### DIFF
--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -32,6 +32,7 @@ import org.javarosa.xpath.parser.XPathSyntaxException;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.text.DateFormat;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.Hashtable;
@@ -660,6 +661,20 @@ public class XPathFuncExpr extends XPathExpression {
         }
     }
 
+    private static Double convertToValidMaxOrMinValue(Object o) {
+        Double d = toNumeric(o);
+        if (Double.isNaN(d.doubleValue())) {
+            o = unpack(o);
+            if (o instanceof String) {
+                Date dateFromString = DateUtils.parseDate((String)o);
+                if (dateFromString != null) {
+                    return new Double(DateUtils.daysSinceEpoch(dateFromString));
+                }
+            }
+        }
+        return d;
+    }
+
     /**
      * convert a value to a number using xpath's type conversion rules (note that xpath itself makes
      * no distinction between integer and floating point numbers)
@@ -948,7 +963,7 @@ public class XPathFuncExpr extends XPathExpression {
     private static Object max(Object[] argVals) {
         double max = Double.MIN_VALUE;
         for (int i = 0; i < argVals.length; i++) {
-            max = Math.max(max, toNumeric(argVals[i]).doubleValue());
+            max = Math.max(max, convertToValidMaxOrMinValue(argVals[i]).doubleValue());
         }
         return new Double(max);
     }
@@ -956,7 +971,7 @@ public class XPathFuncExpr extends XPathExpression {
     private static Object min(Object[] argVals) {
         double min = Double.MAX_VALUE;
         for (int i = 0; i < argVals.length; i++) {
-            min = Math.min(min, toNumeric(argVals[i]).doubleValue());
+            min = Math.min(min, convertToValidMaxOrMinValue(argVals[i]).doubleValue());
         }
         return new Double(min);
     }

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -666,7 +666,7 @@ public class XPathFuncExpr extends XPathExpression {
             if (o instanceof String) {
                 Date dateFromString = DateUtils.parseDate((String)o);
                 if (dateFromString != null) {
-                    return new Double(DateUtils.daysSinceEpoch(dateFromString));
+                    return toNumeric(dateFromString);
                 }
             }
         }

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -9,7 +9,6 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.model.utils.DateUtils;
 import org.javarosa.core.model.utils.GeoPointUtils;
-import org.javarosa.core.services.Logger;
 import org.javarosa.core.util.CacheTable;
 import org.javarosa.core.util.DataUtil;
 import org.javarosa.core.util.MathUtils;
@@ -32,7 +31,6 @@ import org.javarosa.xpath.parser.XPathSyntaxException;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.text.DateFormat;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.Hashtable;
@@ -661,7 +659,7 @@ public class XPathFuncExpr extends XPathExpression {
         }
     }
 
-    private static Double convertToValidMaxOrMinValue(Object o) {
+    private static Double toNumeric_inclusiveOfDatestrings(Object o) {
         Double d = toNumeric(o);
         if (Double.isNaN(d.doubleValue())) {
             o = unpack(o);
@@ -963,7 +961,7 @@ public class XPathFuncExpr extends XPathExpression {
     private static Object max(Object[] argVals) {
         double max = Double.MIN_VALUE;
         for (int i = 0; i < argVals.length; i++) {
-            max = Math.max(max, convertToValidMaxOrMinValue(argVals[i]).doubleValue());
+            max = Math.max(max, toNumeric_inclusiveOfDatestrings(argVals[i]).doubleValue());
         }
         return new Double(max);
     }
@@ -971,7 +969,7 @@ public class XPathFuncExpr extends XPathExpression {
     private static Object min(Object[] argVals) {
         double min = Double.MAX_VALUE;
         for (int i = 0; i < argVals.length; i++) {
-            min = Math.min(min, convertToValidMaxOrMinValue(argVals[i]).doubleValue());
+            min = Math.min(min, toNumeric_inclusiveOfDatestrings(argVals[i]).doubleValue());
         }
         return new Double(min);
     }

--- a/javarosa/src/test/java/org/javarosa/xpath/test/XPathEvalTest.java
+++ b/javarosa/src/test/java/org/javarosa/xpath/test/XPathEvalTest.java
@@ -66,6 +66,8 @@ public class XPathEvalTest {
                 Double t = ((Double)expected).doubleValue();
                 if (Math.abs(o - t) > tolerance) {
                     fail("Doubles outside of tolerance [" + o + "," + t + " ]");
+                } else if (Double.isNaN(o) && !Double.isNaN(t)) {
+                    fail("Result was NaN when not expected");
                 }
             } else if (!expected.equals(result)) {
                 fail("Expected " + expected + ", got " + result);

--- a/javarosa/src/test/java/org/javarosa/xpath/test/XPathEvalTest.java
+++ b/javarosa/src/test/java/org/javarosa/xpath/test/XPathEvalTest.java
@@ -252,6 +252,25 @@ public class XPathEvalTest {
         testEval("min(5.5)", null, null, new Double(5.5));
         testEval("date(min(date('2012-02-05'), date('2012-01-01')))", null, null, DateUtils.parseDate("2012-01-01"));
 
+        testEval("max(5.5, 0.5)", null, null, new Double(5.5));
+        testEval("max(0.5)", null, null, new Double(0.5));
+        testEval("date(max(date('2012-02-05'), date('2012-01-01')))", null, null, DateUtils.parseDate("2012-02-05"));
+
+
+        // Test that taking the min or max of date-strings works, but still fails properly for
+        // numeric strings that are not dates
+        testEval("min('2012-02-05', '2012-01-01', '2012-04-20')", null, null,
+                new Double(DateUtils.daysSinceEpoch(DateUtils.parseDate("2012-01-01"))));
+        testEval("max('2012-02-05', '2012-01-01', '2012-04-20')", null, null,
+                new Double(DateUtils.daysSinceEpoch(DateUtils.parseDate("2012-04-20"))));
+        testEval("max('-1-02-05', '2012-01-01', '2012-04-20')", null, null,
+                new Double(Double.NaN));
+        testEval("max('02-05', '2012-01-01', '2012-04-20')", null, null,
+                new Double(Double.NaN));
+        testEval("max('2012-02-05-', '2012-01-01', '2012-04-20')", null, null,
+                new Double(Double.NaN));
+
+
         testEval("5.5 + 5.5", null, null, new Double(11.0));
         testEval("0 + 0", null, null, new Double(0.0));
         testEval("6.1 - 7.8", null, null, new Double(-1.7));


### PR DESCRIPTION
For the 2.30 PR, I'm only extending max() and min() to accept date-strings, but we should talk about making all uses of `toNumeric()` behave this way (Possible that it's totally straightforward, but I wanted to make the minimum amount of changes necessary for 2.30 here)