### PR TITLE
Externalize fields that were added to Detail recently

### DIFF
--- a/backend/src/org/commcare/suite/model/Detail.java
+++ b/backend/src/org/commcare/suite/model/Detail.java
@@ -208,6 +208,10 @@ public class Detail implements Externalizable {
         variables = (OrderedHashtable<String, String>)ExtUtil.read(in, new ExtWrapMap(String.class, String.class, ExtWrapMap.TYPE_ORDERED), pf);
         actions = (Vector<Action>)ExtUtil.read(in, new ExtWrapList(Action.class), pf);
         callout = (Callout)ExtUtil.read(in, new ExtWrapNullable(Callout.class), pf);
+        forceLandscapeView = ExtUtil.readBool(in);
+        focusToBottomOfEntityList = ExtUtil.readBool(in);
+        numEntitiesToDisplayPerRow = (int)ExtUtil.readNumeric(in);
+        useUniformUnitsInCaseTile = ExtUtil.readBool(in);
     }
 
     @Override
@@ -221,6 +225,10 @@ public class Detail implements Externalizable {
         ExtUtil.write(out, new ExtWrapMap(variables));
         ExtUtil.write(out, new ExtWrapList(actions));
         ExtUtil.write(out, new ExtWrapNullable(callout));
+        ExtUtil.writeBool(out, forceLandscapeView);
+        ExtUtil.writeBool(out, focusToBottomOfEntityList);
+        ExtUtil.writeNumeric(out, numEntitiesToDisplayPerRow);
+        ExtUtil.writeBool(out, useUniformUnitsInCaseTile);
     }
 
     public OrderedHashtable<String, XPathExpression> getVariableDeclarations() {


### PR DESCRIPTION
@wpride I'm assuming this is necessary if formplayer relies on the externalizability of `Detail`