### PR TITLE
Fix for Nested Repeats with different lengths

### DIFF
--- a/javarosa/src/main/java/org/javarosa/core/model/FormIndex.java
+++ b/javarosa/src/main/java/org/javarosa/core/model/FormIndex.java
@@ -153,6 +153,25 @@ public class FormIndex {
     }
 
     /**
+     * Use this method to get the multiplicity of the deepest repeat group being referenced.
+     *
+     * IE: If this index is to 1, 1_2, 2, 1_3 this reference will return 3.
+     *
+     * @return The multiplicity of the "most specific" repeated instance of a question or group.
+     */
+    public int getLastRepeatInstanceIndex() {
+        if(this.getNextLevel() == null) {
+            return getInstanceIndex();
+        }
+        int childIndex = this.getNextLevel().getInstanceIndex();
+        if(childIndex == -1) {
+            return getInstanceIndex();
+        } else {
+            return childIndex;
+        }
+    }
+
+    /**
      * For the fully qualified element, get the multiplicity of the element's reference
      *
      * @return The terminal element (fully qualified)'s instance index

--- a/javarosa/src/main/java/org/javarosa/form/api/FormEntryModel.java
+++ b/javarosa/src/main/java/org/javarosa/form/api/FormEntryModel.java
@@ -368,7 +368,7 @@ public class FormEntryModel {
                         TreeReference ref = getForm().getChildInstanceRef(index);
                         TreeElement element = getForm().getMainInstance().resolveReference(ref);
                         if (element == null) {
-                            if (index.getInstanceIndex() < fullcount) {
+                            if (index.getLastRepeatInstanceIndex() < fullcount) {
                                 try {
                                     getForm().createNewRepeat(index);
                                 } catch (InvalidReferenceException ire) {

--- a/javarosa/src/test/java/org/javarosa/core/model/test/FormDefTest.java
+++ b/javarosa/src/test/java/org/javarosa/core/model/test/FormDefTest.java
@@ -212,7 +212,7 @@ public class FormDefTest {
         stepThroughEntireForm(fec);
 
         ExprEvalUtils.assertEqualsXpathEval("Nested repeats did not evaluate to the proper outcome",
-                30.0,
+                60.0,
                 "/data/sum",
                 fpi.getFormDef().getEvaluationContext());
     }

--- a/javarosa/src/test/resources/xform_tests/test_looped_model_iteration.xml
+++ b/javarosa/src/test/resources/xform_tests/test_looped_model_iteration.xml
@@ -10,7 +10,7 @@
                       uiVersion="1"
                       version="1" xmlns="http://openrosa.org/formdesigner/06DE7FA6-35F7-46EF-9DB0-AD09AAF40438" xmlns:jrm="http://dev.commcarehq.org/jr/xforms">
                     <begin/>
-                    <number>2</number>
+                    <number>6</number>
                     <outer_repeat jr:template="">
                         <iterator count="" current_index="" ids="" vellum:role="Repeat">
                             <item id="" jr:template="">
@@ -35,7 +35,7 @@
             </instance>
 
             <bind nodeset="/data/begin"/>
-            <bind calculate="3" nodeset="/data/number"/>
+            <bind calculate="6" nodeset="/data/number"/>
             <bind nodeset="/data/outer_repeat"/>
             <bind calculate="count(/data/outer_repeat/iterator/item)"
                   nodeset="/data/outer_repeat/iterator/@current_index"/>


### PR DESCRIPTION
This fixes a bug using nested repeats with counts. 

Previously, an "inner" repeat would trigger the creation of its automated children IFF the count of children of the _outer_ repeat was less than the inner repeat's count.