### PR TITLE
Use safe double parse function

### DIFF
--- a/javarosa/src/main/java/org/javarosa/core/util/MathUtils.java
+++ b/javarosa/src/main/java/org/javarosa/core/util/MathUtils.java
@@ -28,7 +28,6 @@ public class MathUtils {
     }
 
     // double parsing from http://stackoverflow.com/questions/8564896/fastest-way-to-check-if-a-string-can-be-parsed-to-double-in-java
-
     final static String Digits     = "(\\p{Digit}+)";
     final static String HexDigits  = "(\\p{XDigit}+)";
 
@@ -59,7 +58,7 @@ public class MathUtils {
 
                     // Hexadecimal strings
                     "((" +
-                    // 0[xX] HexDigits ._opt BinaryExponent FloatTypeSuffix_opt
+                    // 0[xX] HlxDigits ._opt BinaryExponent FloatTypeSuffix_opt
                     "(0[xX]" + HexDigits + "(\\.)?)|" +
 
                     // 0[xX] HexDigits_opt . HexDigits BinaryExponent FloatTypeSuffix_opt
@@ -69,6 +68,7 @@ public class MathUtils {
                     "[fFdD]?))" +
                     "[\\x00-\\x20]*");// Optional trailing "whitespace"
 
+    // Safe double parsing - see PR https://github.com/dimagi/commcare-core/pull/405
     public static Double parseDoubleSafe(String string) {
         if (Pattern.matches(fpRegex, string))
             return Double.valueOf(string);

--- a/javarosa/src/main/java/org/javarosa/core/util/MathUtils.java
+++ b/javarosa/src/main/java/org/javarosa/core/util/MathUtils.java
@@ -27,6 +27,8 @@ public class MathUtils {
         return r;
     }
 
+    // double parsing from http://stackoverflow.com/questions/8564896/fastest-way-to-check-if-a-string-can-be-parsed-to-double-in-java
+
     final static String Digits     = "(\\p{Digit}+)";
     final static String HexDigits  = "(\\p{XDigit}+)";
 

--- a/javarosa/src/main/java/org/javarosa/core/util/MathUtils.java
+++ b/javarosa/src/main/java/org/javarosa/core/util/MathUtils.java
@@ -1,7 +1,6 @@
 package org.javarosa.core.util;
 
 import java.util.Random;
-import java.util.regex.Pattern;
 
 /**
  * Static utility functions for mathematical operations
@@ -25,55 +24,5 @@ public class MathUtils {
             r = new Random();
         }
         return r;
-    }
-
-    // double parsing from http://stackoverflow.com/questions/8564896/fastest-way-to-check-if-a-string-can-be-parsed-to-double-in-java
-    final static String Digits     = "(\\p{Digit}+)";
-    final static String HexDigits  = "(\\p{XDigit}+)";
-
-    // an exponent is 'e' or 'E' followed by an optionally
-    // signed decimal integer.
-    final static String Exp        = "[eE][+-]?"+Digits;
-    final static String fpRegex    =
-            ("[\\x00-\\x20]*"+  // Optional leading "whitespace"
-                    "[+-]?(" + // Optional sign character
-                    "NaN|" +           // "NaN" string
-                    "Infinity|" +      // "Infinity" string
-
-                    // A decimal floating-point string representing a finite positive
-                    // number without a leading sign has at most five basic pieces:
-                    // Digits . Digits ExponentPart FloatTypeSuffix
-                    //
-                    // Since this method allows integer-only strings as input
-                    // in addition to strings of floating-point literals, the
-                    // two sub-patterns below are simplifications of the grammar
-                    // productions from the Java Language Specification, 2nd
-                    // edition, section 3.10.2.
-
-                    // Digits ._opt Digits_opt ExponentPart_opt FloatTypeSuffix_opt
-                    "((("+Digits+"(\\.)?("+Digits+"?)("+Exp+")?)|"+
-
-                    // . Digits ExponentPart_opt FloatTypeSuffix_opt
-                    "(\\.("+Digits+")("+Exp+")?)|"+
-
-                    // Hexadecimal strings
-                    "((" +
-                    // 0[xX] HlxDigits ._opt BinaryExponent FloatTypeSuffix_opt
-                    "(0[xX]" + HexDigits + "(\\.)?)|" +
-
-                    // 0[xX] HexDigits_opt . HexDigits BinaryExponent FloatTypeSuffix_opt
-                    "(0[xX]" + HexDigits + "?(\\.)" + HexDigits + ")" +
-
-                    ")[pP][+-]?" + Digits + "))" +
-                    "[fFdD]?))" +
-                    "[\\x00-\\x20]*");// Optional trailing "whitespace"
-
-    // Safe double parsing - see PR https://github.com/dimagi/commcare-core/pull/405
-    public static Double parseDoubleSafe(String string) {
-        if (Pattern.matches(fpRegex, string))
-            return Double.valueOf(string);
-        else {
-            throw new NumberFormatException();
-        }
     }
 }

--- a/javarosa/src/main/java/org/javarosa/core/util/MathUtils.java
+++ b/javarosa/src/main/java/org/javarosa/core/util/MathUtils.java
@@ -1,6 +1,7 @@
 package org.javarosa.core.util;
 
 import java.util.Random;
+import java.util.regex.Pattern;
 
 /**
  * Static utility functions for mathematical operations
@@ -24,5 +25,53 @@ public class MathUtils {
             r = new Random();
         }
         return r;
+    }
+
+    final static String Digits     = "(\\p{Digit}+)";
+    final static String HexDigits  = "(\\p{XDigit}+)";
+
+    // an exponent is 'e' or 'E' followed by an optionally
+    // signed decimal integer.
+    final static String Exp        = "[eE][+-]?"+Digits;
+    final static String fpRegex    =
+            ("[\\x00-\\x20]*"+  // Optional leading "whitespace"
+                    "[+-]?(" + // Optional sign character
+                    "NaN|" +           // "NaN" string
+                    "Infinity|" +      // "Infinity" string
+
+                    // A decimal floating-point string representing a finite positive
+                    // number without a leading sign has at most five basic pieces:
+                    // Digits . Digits ExponentPart FloatTypeSuffix
+                    //
+                    // Since this method allows integer-only strings as input
+                    // in addition to strings of floating-point literals, the
+                    // two sub-patterns below are simplifications of the grammar
+                    // productions from the Java Language Specification, 2nd
+                    // edition, section 3.10.2.
+
+                    // Digits ._opt Digits_opt ExponentPart_opt FloatTypeSuffix_opt
+                    "((("+Digits+"(\\.)?("+Digits+"?)("+Exp+")?)|"+
+
+                    // . Digits ExponentPart_opt FloatTypeSuffix_opt
+                    "(\\.("+Digits+")("+Exp+")?)|"+
+
+                    // Hexadecimal strings
+                    "((" +
+                    // 0[xX] HexDigits ._opt BinaryExponent FloatTypeSuffix_opt
+                    "(0[xX]" + HexDigits + "(\\.)?)|" +
+
+                    // 0[xX] HexDigits_opt . HexDigits BinaryExponent FloatTypeSuffix_opt
+                    "(0[xX]" + HexDigits + "?(\\.)" + HexDigits + ")" +
+
+                    ")[pP][+-]?" + Digits + "))" +
+                    "[fFdD]?))" +
+                    "[\\x00-\\x20]*");// Optional trailing "whitespace"
+
+    public static Double parseDoubleSafe(String string) {
+        if (Pattern.matches(fpRegex, string))
+            return Double.valueOf(string);
+        else {
+            throw new NumberFormatException();
+        }
     }
 }

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -1449,7 +1449,12 @@ public class XPathFuncExpr extends XPathExpression {
         }
 
         try {
-            Double ret = MathUtils.parseDoubleSafe(attrValue);
+            // Don't process strings with scientific notation or +/- Infinity as doubles
+            if (checkForInvalidNumericOrDatestringCharacters(attrValue)) {
+                mDoubleParseCache.register(attrValue, new Double(Double.NaN));
+                return attrValue;
+            }
+            Double ret = Double.parseDouble(attrValue);
             mDoubleParseCache.register(attrValue, ret);
             return ret;
         } catch (NumberFormatException ife) {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -1449,7 +1449,7 @@ public class XPathFuncExpr extends XPathExpression {
         }
 
         try {
-            Double ret = new Double(Double.parseDouble(attrValue));
+            Double ret = MathUtils.parseDoubleSafe(attrValue);
             mDoubleParseCache.register(attrValue, ret);
             return ret;
         } catch (NumberFormatException ife) {

--- a/javarosa/src/test/java/org/javarosa/xpath/test/XPathEvalTest.java
+++ b/javarosa/src/test/java/org/javarosa/xpath/test/XPathEvalTest.java
@@ -17,6 +17,7 @@ import org.javarosa.xpath.XPathParseTool;
 import org.javarosa.xpath.XPathTypeMismatchException;
 import org.javarosa.xpath.XPathUnhandledException;
 import org.javarosa.xpath.XPathUnsupportedException;
+import org.javarosa.xpath.expr.XPathEqExpr;
 import org.javarosa.xpath.expr.XPathExpression;
 import org.javarosa.xpath.expr.XPathFuncExpr;
 import org.javarosa.xpath.expr.XPathNumericLiteral;
@@ -551,6 +552,13 @@ public class XPathEvalTest {
         testEval("count(/data/strtest[@val = 'a'])", instance, null, new Double(1));
         testEval("count(/data/strtest[@val = 2])", instance, null, new Double(0));
         testEval("count(/data/strtest[@val = /data/string])", instance, null, new Double(1));
+    }
+
+    @Test
+    public void testDoNotInferScientificNotationAsDouble() {
+        Object dbl = XPathFuncExpr.InferType("100E5");
+        Assert.assertTrue("We should not evaluate strings with scientific notation as doubles",
+                XPathEqExpr.testEquality(dbl, "100E5"));
     }
 
     protected void addDataRef(FormInstance dm, String ref, IAnswerData data) {


### PR DESCRIPTION
Fixes http://manage.dimagi.com/default.asp?237000

This is without a doubt the most obscure bug I've fixed in my lifetime. 

Basically way deep down in the XForm engine we have this code that attempts to parse as a double every string literal we process and, if successful, stores the value as in a CacheTable with the parsed double as the value and the string as a key. This includes things like fixture ID's that we use for indexing and later lookups. 

Unfortunately, until version 4.4 Android had a bug with the parseDouble function that you can read about here: https://android-review.googlesource.com/#/c/102376/. Because Java doubles use the exponential format MeP the "e" character could be in a valid double in certain circumstances. In the bug above case, the fixture ID was 1d9098a0c23a0c83740547dd946**e3783**

So, the bug would parse the trailing 946e3783 as a valid exponential with mantissa even though the rest of the string was complete garbage. This would evaluate to infinity (or Double.POSITIVE_INFINITY to be precise) and then be stored in the cache table as a valid double mapping.

Then, all later lookups would use this value when trying to match against the filter expression in the XForm, which would of course fail.

This fix simply uses code from SO to parse the double and is the fastest possible (according to SO). Another smaller-touch fix would be to manually check for and reject the infinity value after parsing. 

There's also a great post in Russian about the original discovery of the bug https://habrahabr.ru/post/234193/