### PR TITLE
Update coalesce to accept more than 2 arguments

### DIFF
--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -174,7 +174,7 @@ public class XPathFuncExpr extends XPathExpression {
 
         //TODO: Func handlers should be able to declare the desire for short circuiting as well
         if (name.equals("if") && args.length == 3) {
-            return ifThenElse(model, evalContext, args, argVals);
+            return ifThenElse(model, evalContext, args);
         } else if (name.equals("coalesce") && args.length > 0) {
             return coalesceEval(model, evalContext, args);
         } else if (name.equals("cond")) {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -170,8 +170,8 @@ public class XPathFuncExpr extends XPathExpression {
         //TODO: Func handlers should be able to declare the desire for short circuiting as well
         if (name.equals("if") && args.length == 3) {
             return ifThenElse(model, evalContext, args, argVals);
-        } else if (name.equals("coalesce") && args.length == 2) {
-            return coalesceEval(model, evalContext, args, argVals);
+        } else if (name.equals("coalesce") && args.length > 0) {
+            return coalesceEval(model, evalContext, args);
         }
 
         for (int i = 0; i < args.length; i++) {
@@ -873,15 +873,15 @@ public class XPathFuncExpr extends XPathExpression {
     }
 
     private static Object coalesceEval(DataInstance model, EvaluationContext evalContext,
-                                       XPathExpression[] args, Object[] argVals) {
+                                       XPathExpression[] args) {
         //Not sure if unpacking here is quiiite right, but it seems right
-        argVals[0] = XPathFuncExpr.unpack(args[0].eval(model, evalContext));
-        if (!isNull(argVals[0])) {
-            return argVals[0];
-        } else {
-            argVals[1] = args[1].eval(model, evalContext);
-            return argVals[1];
+        for (int i = 0; i < args.length - 1; i++) {
+            Object evaluatedArg = XPathFuncExpr.unpack(args[i].eval(model, evalContext));
+            if (!isNull(evaluatedArg)) {
+                return evaluatedArg;
+            }
         }
+        return args[args.length - 1].eval(model, evalContext);
     }
 
     /**

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -171,14 +171,7 @@ public class XPathFuncExpr extends XPathExpression {
         if (name.equals("if") && args.length == 3) {
             return ifThenElse(model, evalContext, args, argVals);
         } else if (name.equals("coalesce") && args.length == 2) {
-            //Not sure if unpacking here is quiiite right, but it seems right
-            argVals[0] = XPathFuncExpr.unpack(args[0].eval(model, evalContext));
-            if (!isNull(argVals[0])) {
-                return argVals[0];
-            } else {
-                argVals[1] = args[1].eval(model, evalContext);
-                return argVals[1];
-            }
+            return coalesceEval(model, evalContext, args, argVals);
         }
 
         for (int i = 0; i < args.length; i++) {
@@ -877,6 +870,18 @@ public class XPathFuncExpr extends XPathExpression {
         argVals[0] = args[0].eval(model, ec);
         boolean b = toBoolean(argVals[0]).booleanValue();
         return (b ? args[1].eval(model, ec) : args[2].eval(model, ec));
+    }
+
+    private static Object coalesceEval(DataInstance model, EvaluationContext evalContext,
+                                       XPathExpression[] args, Object[] argVals) {
+        //Not sure if unpacking here is quiiite right, but it seems right
+        argVals[0] = XPathFuncExpr.unpack(args[0].eval(model, evalContext));
+        if (!isNull(argVals[0])) {
+            return argVals[0];
+        } else {
+            argVals[1] = args[1].eval(model, evalContext);
+            return argVals[1];
+        }
     }
 
     /**

--- a/javarosa/src/test/java/org/javarosa/xpath/expr/test/XPathFuncExprTest.java
+++ b/javarosa/src/test/java/org/javarosa/xpath/expr/test/XPathFuncExprTest.java
@@ -48,4 +48,19 @@ public class XPathFuncExprTest {
         }
         Assert.fail("form entry should fail on bad `position` usage before getting here");
     }
+
+    @Test
+    public void testCoalesce() {
+        FormInstance instance = ExprEvalUtils.loadInstance("/test_xpathpathexpr.xml");
+
+        // demo of basic coalesce behavior
+        ExprEvalUtils.testEval("/data/places/country[@id = 'one']/name", instance, null, "Singapore");
+        ExprEvalUtils.testEval("/data/places/country[@id = 'three']/name", instance, null, "");
+        ExprEvalUtils.testEval("coalesce(/data/places/country[@id = 'three']/name, /data/places/country[@id = 'one']/name)", instance, null, "Singapore");
+
+        // tests for extending coalesce to work with more than one argument
+        ExprEvalUtils.testEval("coalesce('', '', /data/places/country[@id = 'one']/name)", instance, null, "Singapore");
+        ExprEvalUtils.testEval("coalesce('', /data/places/country[@id = 'three']/name, /data/places/country[@id = 'one']/name)", instance, null, "Singapore");
+        ExprEvalUtils.testEval("coalesce('', /data/places/country[@id = 'one']/name, /data/places/country[@id = 'two']/name)", instance, null, "Singapore");
+    }
 }

--- a/javarosa/src/test/java/org/javarosa/xpath/expr/test/XPathFuncExprTest.java
+++ b/javarosa/src/test/java/org/javarosa/xpath/expr/test/XPathFuncExprTest.java
@@ -62,5 +62,6 @@ public class XPathFuncExprTest {
         ExprEvalUtils.testEval("coalesce('', '', /data/places/country[@id = 'one']/name)", instance, null, "Singapore");
         ExprEvalUtils.testEval("coalesce('', /data/places/country[@id = 'three']/name, /data/places/country[@id = 'one']/name)", instance, null, "Singapore");
         ExprEvalUtils.testEval("coalesce('', /data/places/country[@id = 'one']/name, /data/places/country[@id = 'two']/name)", instance, null, "Singapore");
+        ExprEvalUtils.testEval("coalesce('', '', '', '', '')", instance, null, "");
     }
 }


### PR DESCRIPTION
Sometimes users want to be able to coalesce more than 2 values. This PR extends the [`coalesce` function](https://confluence.dimagi.com/display/commcarepublic/CommCare+Functions#CommCareFunctions-coalesce) to accept more than 2 arguments.

For example:

```
coalesce(#case/child_name, #form/child_name, "unknown")
```

For context, the current documentation for coalesce:

> Useful for choosing which of two values to return.  Will return the non-null/empty value.  If both are not null, will return the first argument. 

__Release Notes__ Allow `coalesce` to accept more than 2 arguments.