### PR TITLE
Session replay tweaks

### DIFF
--- a/backend/src/org/commcare/session/CommCareSession.java
+++ b/backend/src/org/commcare/session/CommCareSession.java
@@ -892,7 +892,7 @@ public class CommCareSession {
     }
 
     /**
-     * Builds a session by restoring serialized SessionFrame and syncing
+     * Builds a session from by restoring serialized SessionFrame and syncing
      * from that. Doesn't support restoring the frame stack
      */
     public static CommCareSession restoreSessionFromStream(CommCarePlatform ccPlatform,

--- a/backend/src/org/commcare/session/CommCareSession.java
+++ b/backend/src/org/commcare/session/CommCareSession.java
@@ -892,7 +892,7 @@ public class CommCareSession {
     }
 
     /**
-     * Builds a session from by restoring serialized SessionFrame and syncing
+     * Builds a session by restoring serialized SessionFrame and syncing
      * from that. Doesn't support restoring the frame stack
      */
     public static CommCareSession restoreSessionFromStream(CommCarePlatform ccPlatform,

--- a/javarosa/src/main/java/org/javarosa/form/api/FormEntrySession.java
+++ b/javarosa/src/main/java/org/javarosa/form/api/FormEntrySession.java
@@ -23,6 +23,7 @@ public class FormEntrySession implements FormEntrySessionRecorder, Externalizabl
 
     private Vector<FormEntryAction> actions = new Vector<>();
     private String sessionStopRef;
+    private boolean stopRefWasReplayed;
 
     /**
      * For Externalization
@@ -81,6 +82,10 @@ public class FormEntrySession implements FormEntrySessionRecorder, Externalizabl
         return actions.elementAt(actions.size() - 1).getQuestionRefString();
     }
 
+    public boolean stopRefWasReplayed() {
+        return stopRefWasReplayed;
+    }
+
     /**
      * Remove and return the FormEntryAction corresponding to the given FormIndex, if there is
      * one in this session
@@ -89,6 +94,9 @@ public class FormEntrySession implements FormEntrySessionRecorder, Externalizabl
         for (int i = 0; i < actions.size(); i++) {
             FormEntryAction action = actions.elementAt(i);
             if (action.getQuestionRefString().equals(questionRef.toString())) {
+                if (sessionStopRef.equals(action.getQuestionRefString())) {
+                    stopRefWasReplayed = true;
+                }
                 actions.removeElementAt(i);
                 return action;
             }

--- a/javarosa/src/main/java/org/javarosa/form/api/FormEntrySessionReplayer.java
+++ b/javarosa/src/main/java/org/javarosa/form/api/FormEntrySessionReplayer.java
@@ -36,24 +36,24 @@ public class FormEntrySessionReplayer {
         return formEntrySession != null && formEntrySession.size() > 0;
     }
 
-    private void replayForm() {
-        formEntryController.jumpToIndex(FormIndex.createBeginningOfFormIndex());
-        int event = formEntryController.stepToNextEvent(FormEntryController.STEP_INTO_GROUP);
-        while (event != FormEntryController.EVENT_END_OF_FORM && hasSessionToReplay()
-                && !reachedEndOfReplay()) {
-            replayEvent(event);
-            event = formEntryController.stepToNextEvent(FormEntryController.STEP_INTO_GROUP);
-        }
-        formEntryController.stepToPreviousEvent();
-    }
-
     /**
      * TODO AMS: If the question corresponding to the stopping ref has been removed, this will
      * never return true and replay will take the user all the way to the end of the form
      */
-    private boolean reachedEndOfReplay() {
-        String nextQuestionRef = formEntryController.getModel().getFormIndex().getReference().toString();
-        return nextQuestionRef.equals(formEntrySession.getStopRef());
+    private boolean reachedEndOfReplay(String lastQuestionRefReplayed) {
+        return lastQuestionRefReplayed.equals(formEntrySession.getStopRef());
+    }
+
+    private void replayForm() {
+        formEntryController.jumpToIndex(FormIndex.createBeginningOfFormIndex());
+        int event = formEntryController.stepToNextEvent(FormEntryController.STEP_INTO_GROUP);
+        String lastQuestionRefReplayed = "";
+        while (event != FormEntryController.EVENT_END_OF_FORM && hasSessionToReplay()
+                && !reachedEndOfReplay(lastQuestionRefReplayed)) {
+            lastQuestionRefReplayed = replayEvent(event);
+            event = formEntryController.stepToNextEvent(FormEntryController.STEP_INTO_GROUP);
+        }
+        formEntryController.stepToPreviousEvent();
     }
 
     private String replayEvent(int event) {

--- a/javarosa/src/main/java/org/javarosa/form/api/FormEntrySessionReplayer.java
+++ b/javarosa/src/main/java/org/javarosa/form/api/FormEntrySessionReplayer.java
@@ -36,23 +36,23 @@ public class FormEntrySessionReplayer {
         return formEntrySession != null && formEntrySession.size() > 0;
     }
 
+    private void replayForm() {
+        formEntryController.jumpToIndex(FormIndex.createBeginningOfFormIndex());
+        int event = formEntryController.stepToNextEvent(FormEntryController.STEP_INTO_GROUP);
+        while (event != FormEntryController.EVENT_END_OF_FORM && hasSessionToReplay()
+                && !reachedEndOfReplay()) {
+            replayEvent(event);
+            event = formEntryController.stepToNextEvent(FormEntryController.STEP_INTO_GROUP);
+        }
+    }
+
     /**
      * TODO AMS: If the question corresponding to the stopping ref has been removed, this will
      * never return true and replay will take the user all the way to the end of the form
      */
-    private boolean reachedEndOfReplay(String lastQuestionRefReplayed) {
-        return lastQuestionRefReplayed.equals(formEntrySession.getStopRef());
-    }
-
-    private void replayForm() {
-        formEntryController.jumpToIndex(FormIndex.createBeginningOfFormIndex());
-        int event = formEntryController.stepToNextEvent(FormEntryController.STEP_INTO_GROUP);
-        String lastQuestionRefReplayed = "";
-        while (event != FormEntryController.EVENT_END_OF_FORM && hasSessionToReplay()
-                && !reachedEndOfReplay(lastQuestionRefReplayed)) {
-            lastQuestionRefReplayed = replayEvent(event);
-            event = formEntryController.stepToNextEvent(FormEntryController.STEP_INTO_GROUP);
-        }
+    private boolean reachedEndOfReplay() {
+        String nextQuestionRef = formEntryController.getModel().getFormIndex().getReference().toString();
+        return nextQuestionRef.equals(formEntrySession.getStopRef());
     }
 
     private String replayEvent(int event) {

--- a/javarosa/src/main/java/org/javarosa/form/api/FormEntrySessionReplayer.java
+++ b/javarosa/src/main/java/org/javarosa/form/api/FormEntrySessionReplayer.java
@@ -44,6 +44,7 @@ public class FormEntrySessionReplayer {
             replayEvent(event);
             event = formEntryController.stepToNextEvent(FormEntryController.STEP_INTO_GROUP);
         }
+        formEntryController.stepToPreviousEvent();
     }
 
     /**


### PR DESCRIPTION
Tweak 2 things about how form session replay works:

1. Previously, session replay would actually land you on the question AFTER the last one the user had been on, because the while loop in `replayForm` calls `stepToNextEvent` after an event is replayed. In order to resolve this, just call `formEntryController.stepToPreviousEvent()` once after we are done with the entire replay loop.

2. Previously, if the question at which the user chose to save their session was deleted from the new app version, form replay after updating would land them all the way at the end of the form. It seems slightly less confusing to land users at the _start_ of the form instead, so I changed it to do that. The only other idea I had for this was to try to figure out the last question that was answered, and plop them there, but I think it's more confusing to have inconsistent behavior.