### PR TITLE
Allow super big strings to be serialized

### DIFF
--- a/javarosa/src/main/java/org/javarosa/core/model/data/LargeString.java
+++ b/javarosa/src/main/java/org/javarosa/core/model/data/LargeString.java
@@ -1,0 +1,67 @@
+package org.javarosa.core.model.data;
+
+import org.javarosa.core.util.externalizable.DeserializationException;
+import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.ExternalizableWrapper;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+/**
+ * Stores string data that is larger than 65535 bytes long.
+ *
+ * Useful because our traditional string serialization implementation has a
+ * max size limit equivalent to the max value of an unsigned short
+ *
+ * @author Phillip Mates (pmates@dimagi.com)
+ */
+public class LargeString extends ExternalizableWrapper {
+
+    @SuppressWarnings("unused")
+    public LargeString() {
+    }
+
+    public LargeString(String val) {
+        this.val = val;
+    }
+
+    @Override
+    public ExternalizableWrapper clone(Object val) {
+        return new LargeString((String)val);
+    }
+
+    @Override
+    public void metaReadExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
+
+    }
+
+    @Override
+    public void metaWriteExternal(DataOutputStream out) throws IOException {
+
+    }
+
+    @Override
+    public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
+        int size = (int)ExtUtil.readNumeric(in);
+        byte[] bytes = new byte[size];
+        int read = 0;
+        int toread = size;
+        while (read != size) {
+            read = in.read(bytes, 0, toread);
+            toread -= read;
+        }
+
+        val = new String(bytes, "UTF-8");
+    }
+
+    @Override
+    public void writeExternal(DataOutputStream out) throws IOException {
+        byte[] stringAsBytes = ((String)val).getBytes("UTF-8");
+        ExtUtil.writeNumeric(out, stringAsBytes.length);
+        if (stringAsBytes.length > 0) {
+            out.write(stringAsBytes);
+        }
+    }
+}

--- a/javarosa/src/main/java/org/javarosa/core/model/data/LargeString.java
+++ b/javarosa/src/main/java/org/javarosa/core/model/data/LargeString.java
@@ -44,24 +44,12 @@ public class LargeString extends ExternalizableWrapper {
 
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
-        int size = (int)ExtUtil.readNumeric(in);
-        byte[] bytes = new byte[size];
-        int read = 0;
-        int toread = size;
-        while (read != size) {
-            read = in.read(bytes, 0, toread);
-            toread -= read;
-        }
-
-        val = new String(bytes, "UTF-8");
+        val = new String(ExtUtil.readBytes(in), "UTF-8");
     }
 
     @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         byte[] stringAsBytes = ((String)val).getBytes("UTF-8");
-        ExtUtil.writeNumeric(out, stringAsBytes.length);
-        if (stringAsBytes.length > 0) {
-            out.write(stringAsBytes);
-        }
+        ExtUtil.writeBytes(out, stringAsBytes);
     }
 }

--- a/javarosa/src/main/java/org/javarosa/core/util/externalizable/ExtWrapTagged.java
+++ b/javarosa/src/main/java/org/javarosa/core/util/externalizable/ExtWrapTagged.java
@@ -1,5 +1,7 @@
 package org.javarosa.core.util.externalizable;
 
+import org.javarosa.core.model.data.LargeString;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -19,6 +21,7 @@ public class ExtWrapTagged extends ExternalizableWrapper {
         WRAPPER_CODES.put(ExtWrapMapPoly.class, 0x23);
         WRAPPER_CODES.put(ExtWrapIntEncodingUniform.class, 0x40);
         WRAPPER_CODES.put(ExtWrapIntEncodingSmall.class, 0x41);
+        WRAPPER_CODES.put(LargeString.class, 0x42);
     }
 
     /* serialization */


### PR DESCRIPTION
There is a limitation in our serialization framework where strings over `65535` bytes cannot be serialized. The fix I've implemented checks the length of the string as bytes and dispatches to more robust serialization logic if the string is above the limit. This does not require a migration because of some sneaky uses of tagging. This does come with a limitation that if you try to directly read out a large string that was serialized using `readString`, it doesn't work. On the plus side, in the case of case properties, which are stored using `ExtWrapMapPoly`, everything works because `ExtWrapMapPoly` utilizes tags.

Targeting 2.31, but can change it to master if we think the change is too big for 2.31.

Fix for http://manage.dimagi.com/default.asp?237711