### PR TITLE
Always pass in prototype factory when deserializing

### DIFF
--- a/backend/src/org/commcare/session/CommCareSession.java
+++ b/backend/src/org/commcare/session/CommCareSession.java
@@ -904,7 +904,7 @@ public class CommCareSession {
 
         CommCareSession restoredSession = new CommCareSession(ccPlatform);
         restoredSession.frame = restoredFrame;
-        Vector<SessionFrame> frames = (Vector<SessionFrame>) ExtUtil.read(inputStream, new ExtWrapList(SessionFrame.class));
+        Vector<SessionFrame> frames = (Vector<SessionFrame>) ExtUtil.read(inputStream, new ExtWrapList(SessionFrame.class), null);
         Stack<SessionFrame> stackFrames = new Stack<>();
         while(!frames.isEmpty()){
             SessionFrame lastElement = frames.lastElement();

--- a/backend/src/org/commcare/suite/model/AssertionSet.java
+++ b/backend/src/org/commcare/suite/model/AssertionSet.java
@@ -67,8 +67,8 @@ public class AssertionSet implements Externalizable {
 
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
-        this.xpathExpressions = (Vector<String>)ExtUtil.read(in, new ExtWrapList(String.class));
-        this.messages = (Vector<Text>)ExtUtil.read(in, new ExtWrapList(Text.class));
+        this.xpathExpressions = (Vector<String>)ExtUtil.read(in, new ExtWrapList(String.class), pf);
+        this.messages = (Vector<Text>)ExtUtil.read(in, new ExtWrapList(Text.class), pf);
     }
 
     @Override

--- a/backend/src/org/commcare/suite/model/Callout.java
+++ b/backend/src/org/commcare/suite/model/Callout.java
@@ -92,12 +92,12 @@ public class Callout implements Externalizable, DetailTemplate {
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         displayName = ExtUtil.readString(in);
-        actionName = (String)ExtUtil.read(in, new ExtWrapNullable(String.class));
-        image = (String)ExtUtil.read(in, new ExtWrapNullable(String.class));
-        extras = (Hashtable<String, String>)ExtUtil.read(in, new ExtWrapMap(String.class, String.class));
+        actionName = (String)ExtUtil.read(in, new ExtWrapNullable(String.class), pf);
+        image = (String)ExtUtil.read(in, new ExtWrapNullable(String.class), pf);
+        extras = (Hashtable<String, String>)ExtUtil.read(in, new ExtWrapMap(String.class, String.class), pf);
         responses = (Vector<String>)ExtUtil.read(in, new ExtWrapList(String.class), pf);
         responseDetail = (DetailField)ExtUtil.read(in, new ExtWrapNullable(DetailField.class), pf);
-        type = (String)ExtUtil.read(in, new ExtWrapNullable(String.class));
+        type = (String)ExtUtil.read(in, new ExtWrapNullable(String.class), pf);
         isAutoLaunching = ExtUtil.readBool(in);
     }
 

--- a/backend/src/org/commcare/suite/model/Detail.java
+++ b/backend/src/org/commcare/suite/model/Detail.java
@@ -202,9 +202,9 @@ public class Detail implements Externalizable {
 
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
-        id = (String)ExtUtil.read(in, new ExtWrapNullable(String.class));
+        id = (String)ExtUtil.read(in, new ExtWrapNullable(String.class), pf);
         title = (DisplayUnit)ExtUtil.read(in, DisplayUnit.class, pf);
-        titleForm = (String)ExtUtil.read(in, new ExtWrapNullable(String.class));
+        titleForm = (String)ExtUtil.read(in, new ExtWrapNullable(String.class), pf);
         nodeset = (TreeReference)ExtUtil.read(in, new ExtWrapNullable(TreeReference.class), pf);
         Vector<Detail> theDetails = (Vector<Detail>)ExtUtil.read(in, new ExtWrapList(Detail.class), pf);
         details = new Detail[theDetails.size()];

--- a/backend/src/org/commcare/suite/model/DisplayUnit.java
+++ b/backend/src/org/commcare/suite/model/DisplayUnit.java
@@ -70,8 +70,8 @@ public class DisplayUnit implements Externalizable, DetailTemplate {
     public void readExternal(DataInputStream in, PrototypeFactory pf)
             throws IOException, DeserializationException {
         name = (Text)ExtUtil.read(in, Text.class, pf);
-        imageReference = (Text)ExtUtil.read(in, new ExtWrapNullable(Text.class));
-        audioReference = (Text)ExtUtil.read(in, new ExtWrapNullable(Text.class));
+        imageReference = (Text)ExtUtil.read(in, new ExtWrapNullable(Text.class), pf);
+        audioReference = (Text)ExtUtil.read(in, new ExtWrapNullable(Text.class), pf);
     }
 
     @Override

--- a/backend/src/org/commcare/suite/model/Entry.java
+++ b/backend/src/org/commcare/suite/model/Entry.java
@@ -147,7 +147,7 @@ public abstract class Entry implements Externalizable, MenuDisplayable {
         data = (Vector<SessionDatum>)ExtUtil.read(in, new ExtWrapListPoly(), pf);
         instances = (Hashtable<String, DataInstance>)ExtUtil.read(in, new ExtWrapMap(String.class, new ExtWrapTagged()), pf);
         stackOperations = (Vector<StackOperation>)ExtUtil.read(in, new ExtWrapList(StackOperation.class), pf);
-        assertions = (AssertionSet)ExtUtil.read(in, new ExtWrapNullable(AssertionSet.class));
+        assertions = (AssertionSet)ExtUtil.read(in, new ExtWrapNullable(AssertionSet.class), pf);
     }
 
     @Override

--- a/backend/src/org/commcare/suite/model/Menu.java
+++ b/backend/src/org/commcare/suite/model/Menu.java
@@ -133,7 +133,7 @@ public class Menu implements Externalizable, MenuDisplayable {
         id = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
         root = ExtUtil.readString(in);
         rawRelevance = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
-        display = (DisplayUnit)ExtUtil.read(in, DisplayUnit.class);
+        display = (DisplayUnit)ExtUtil.read(in, DisplayUnit.class, pf);
         commandIds = (Vector<String>)ExtUtil.read(in, new ExtWrapList(String.class), pf);
         commandExprs = new String[ExtUtil.readInt(in)];
         for (int i = 0; i < commandExprs.length; ++i) {

--- a/backend/src/org/commcare/suite/model/StackOperation.java
+++ b/backend/src/org/commcare/suite/model/StackOperation.java
@@ -99,7 +99,7 @@ public class StackOperation implements Externalizable {
             throws IOException, DeserializationException {
         opType = ExtUtil.readInt(in);
         ifCondition = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
-        elements = (Vector<StackFrameStep>)ExtUtil.read(in, new ExtWrapList(StackFrameStep.class));
+        elements = (Vector<StackFrameStep>)ExtUtil.read(in, new ExtWrapList(StackFrameStep.class), pf);
     }
 
     @Override

--- a/cases/src/org/commcare/cases/ledger/Ledger.java
+++ b/cases/src/org/commcare/cases/ledger/Ledger.java
@@ -101,7 +101,7 @@ public class Ledger implements Persistable, IMetaData {
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         recordId = ExtUtil.readInt(in);
         entityId = ExtUtil.readString(in);
-        sections = (Hashtable<String, Hashtable<String, Integer>>)ExtUtil.read(in, new ExtWrapMap(String.class, new ExtWrapMap(String.class, Integer.class)));
+        sections = (Hashtable<String, Hashtable<String, Integer>>)ExtUtil.read(in, new ExtWrapMap(String.class, new ExtWrapMap(String.class, Integer.class)), pf);
     }
 
     @Override

--- a/cases/src/org/commcare/cases/model/Case.java
+++ b/cases/src/org/commcare/cases/model/Case.java
@@ -130,7 +130,7 @@ public class Case implements Persistable, IMetaData, Secure {
         closed = ExtUtil.readBool(in);
         dateOpened = (Date)ExtUtil.read(in, new ExtWrapNullable(Date.class), pf);
         recordId = ExtUtil.readInt(in);
-        indices = (Vector<CaseIndex>)ExtUtil.read(in, new ExtWrapList(CaseIndex.class));
+        indices = (Vector<CaseIndex>)ExtUtil.read(in, new ExtWrapList(CaseIndex.class), pf);
         data = (Hashtable)ExtUtil.read(in, new ExtWrapMapPoly(String.class, true), pf);
     }
 

--- a/javarosa/src/main/java/org/javarosa/core/model/DataBinding.java
+++ b/javarosa/src/main/java/org/javarosa/core/model/DataBinding.java
@@ -129,7 +129,7 @@ public class DataBinding implements Externalizable {
         setDataType(ExtUtil.readInt(in));
         setPreload((String)ExtUtil.read(in, new ExtWrapNullable(String.class), pf));
         setPreloadParams((String)ExtUtil.read(in, new ExtWrapNullable(String.class), pf));
-        ref = (XPathReference)ExtUtil.read(in, new ExtWrapTagged());
+        ref = (XPathReference)ExtUtil.read(in, new ExtWrapTagged(), pf);
 
         //don't bother reading relevancy/required/readonly/constraint/calculate right now; they're only used during parse anyway
     }

--- a/javarosa/src/main/java/org/javarosa/core/model/QuestionString.java
+++ b/javarosa/src/main/java/org/javarosa/core/model/QuestionString.java
@@ -71,10 +71,10 @@ public class QuestionString implements Externalizable {
 
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
-        name = (String)ExtUtil.read(in, new ExtWrapNullable(String.class));
-        textId = (String)ExtUtil.read(in, new ExtWrapNullable(String.class));
-        textInner = (String)ExtUtil.read(in, new ExtWrapNullable(String.class));
-        textFallback = (String)ExtUtil.read(in, new ExtWrapNullable(String.class));
+        name = (String)ExtUtil.read(in, new ExtWrapNullable(String.class), pf);
+        textId = (String)ExtUtil.read(in, new ExtWrapNullable(String.class), pf);
+        textInner = (String)ExtUtil.read(in, new ExtWrapNullable(String.class), pf);
+        textFallback = (String)ExtUtil.read(in, new ExtWrapNullable(String.class), pf);
     }
 
     @Override

--- a/javarosa/src/main/java/org/javarosa/core/model/SubmissionProfile.java
+++ b/javarosa/src/main/java/org/javarosa/core/model/SubmissionProfile.java
@@ -69,11 +69,11 @@ public class SubmissionProfile implements Externalizable {
 
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
-        ref = (XPathReference)ExtUtil.read(in, new ExtWrapTagged(XPathReference.class));
+        ref = (XPathReference)ExtUtil.read(in, new ExtWrapTagged(XPathReference.class), pf);
         method = ExtUtil.readString(in);
         action = ExtUtil.readString(in);
         mediaType = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
-        attributeMap = (Hashtable<String, String>)ExtUtil.read(in, new ExtWrapMap(String.class, String.class));
+        attributeMap = (Hashtable<String, String>)ExtUtil.read(in, new ExtWrapMap(String.class, String.class), pf);
     }
 
     @Override

--- a/javarosa/src/main/java/org/javarosa/core/model/data/PointerAnswerData.java
+++ b/javarosa/src/main/java/org/javarosa/core/model/data/PointerAnswerData.java
@@ -74,7 +74,7 @@ public class PointerAnswerData implements IAnswerData {
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf)
             throws IOException, DeserializationException {
-        data = (IDataPointer)ExtUtil.read(in, new ExtWrapTagged());
+        data = (IDataPointer)ExtUtil.read(in, new ExtWrapTagged(), pf);
     }
 
     @Override

--- a/javarosa/src/main/java/org/javarosa/core/model/instance/FormInstance.java
+++ b/javarosa/src/main/java/org/javarosa/core/model/instance/FormInstance.java
@@ -185,7 +185,7 @@ public class FormInstance extends DataInstance<TreeElement> implements Persistab
         schema = (String)ExtUtil.read(in, new ExtWrapNullable(String.class), pf);
         dateSaved = (Date)ExtUtil.read(in, new ExtWrapNullable(Date.class), pf);
 
-        namespaces = (Hashtable)ExtUtil.read(in, new ExtWrapMap(String.class, String.class));
+        namespaces = (Hashtable)ExtUtil.read(in, new ExtWrapMap(String.class, String.class), pf);
         setRoot((TreeElement)ExtUtil.read(in, TreeElement.class, pf));
     }
 
@@ -310,7 +310,7 @@ public class FormInstance extends DataInstance<TreeElement> implements Persistab
         schema = (String)ExtUtil.read(in, new ExtWrapNullable(String.class), pf);
         dateSaved = (Date)ExtUtil.read(in, new ExtWrapNullable(Date.class), pf);
 
-        namespaces = (Hashtable)ExtUtil.read(in, new ExtWrapMap(String.class, String.class));
+        namespaces = (Hashtable)ExtUtil.read(in, new ExtWrapMap(String.class, String.class), pf);
         TreeElement newRoot;
         try {
             newRoot = TreeElement.class.newInstance();

--- a/javarosa/src/main/java/org/javarosa/core/services/transport/payload/DataPointerPayload.java
+++ b/javarosa/src/main/java/org/javarosa/core/services/transport/payload/DataPointerPayload.java
@@ -71,7 +71,7 @@ public class DataPointerPayload implements IDataPayload {
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf)
             throws IOException, DeserializationException {
-        pointer = (IDataPointer)ExtUtil.read(in, new ExtWrapTagged());
+        pointer = (IDataPointer)ExtUtil.read(in, new ExtWrapTagged(), pf);
     }
 
     @Override

--- a/javarosa/src/main/java/org/javarosa/core/util/SortedIntSet.java
+++ b/javarosa/src/main/java/org/javarosa/core/util/SortedIntSet.java
@@ -82,7 +82,7 @@ public class SortedIntSet implements Externalizable {
 
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
-        v = (Vector)ExtUtil.read(in, new ExtWrapList(Integer.class));
+        v = (Vector)ExtUtil.read(in, new ExtWrapList(Integer.class), pf);
     }
 
     @Override

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -136,7 +136,7 @@ public class XPathFuncExpr extends XPathExpression {
 
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
-        id = (XPathQName)ExtUtil.read(in, XPathQName.class);
+        id = (XPathQName)ExtUtil.read(in, XPathQName.class, pf);
         Vector v = (Vector)ExtUtil.read(in, new ExtWrapListPoly(), pf);
 
         args = new XPathExpression[v.size()];

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathQName.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathQName.java
@@ -71,7 +71,7 @@ public class XPathQName implements Externalizable {
 
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
-        namespace = (String)ExtUtil.read(in, new ExtWrapNullable(String.class));
+        namespace = (String)ExtUtil.read(in, new ExtWrapNullable(String.class), pf);
         name = ExtUtil.readString(in);
         cacheCode();
     }

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathStep.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathStep.java
@@ -270,13 +270,13 @@ public class XPathStep implements Externalizable {
 
         switch (test) {
             case TEST_NAME:
-                name = (XPathQName)ExtUtil.read(in, XPathQName.class);
+                name = (XPathQName)ExtUtil.read(in, XPathQName.class, pf);
                 break;
             case TEST_NAMESPACE_WILDCARD:
                 namespace = ExtUtil.readString(in);
                 break;
             case TEST_TYPE_PROCESSING_INSTRUCTION:
-                literal = (String)ExtUtil.read(in, new ExtWrapNullable(String.class));
+                literal = (String)ExtUtil.read(in, new ExtWrapNullable(String.class), pf);
                 break;
         }
 

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathVariableReference.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathVariableReference.java
@@ -48,7 +48,7 @@ public class XPathVariableReference extends XPathExpression {
 
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
-        id = (XPathQName)ExtUtil.read(in, XPathQName.class);
+        id = (XPathQName)ExtUtil.read(in, XPathQName.class, pf);
     }
 
     @Override

--- a/tests/test/org/commcare/test/utilities/PersistableSandbox.java
+++ b/tests/test/org/commcare/test/utilities/PersistableSandbox.java
@@ -23,7 +23,7 @@ public class PersistableSandbox {
         factory = new PrototypeFactory(new ClassNameHasher());
     }
     
-    public <T extends Externalizable> byte[] serialize(T t) {
+    public static <T extends Externalizable> byte[] serialize(T t) {
         try {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             t.writeExternal(new DataOutputStream(baos));


### PR DESCRIPTION
If you don't pass in the prototype factory when deserializing you can come across annoying deserialization crashes that are sometimes hard to get to the bottom of, so always pass it in

cross-request: https://github.com/dimagi/commcare-android/pull/1559