### PR TITLE
fix NPE in getEntriesforCommand

### DIFF
--- a/backend/src/org/commcare/session/CommCareSession.java
+++ b/backend/src/org/commcare/session/CommCareSession.java
@@ -128,6 +128,9 @@ public class CommCareSession {
     private Vector<Entry> getEntriesForCommand(String commandId,
                                                OrderedHashtable<String, String> currentSessionData) {
         Vector<Entry> entries = new Vector<>();
+        if (commandId == null) {
+            return entries;
+        }
         for (Suite s : platform.getInstalledSuites()) {
             List<Menu> menusWithId = s.getMenusWithId(commandId);
             if (menusWithId != null) {


### PR DESCRIPTION
From ACRA
```
Caused by: java.lang.NullPointerException
at java.util.Collections.secondaryHash(Collections.java:3405)
at java.util.Hashtable.containsKey(Hashtable.java:289)
at org.commcare.session.CommCareSession.getEntriesForCommand(CommCareSession.java:139)
at org.commcare.session.CommCareSession.getEntriesForCommand(CommCareSession.java:119)
at org.commcare.session.CommCareSession.isViewCommand(CommCareSession.java:877)
at org.commcare.activities.EntityDetailActivity.onCreate(EntityDetailActivity.java:85)
at android.app.Activity.performCreate(Activity.java:5447)
```