### PR TITLE
Fix QueryRequestActivityTest test failure

### DIFF
--- a/backend/src/org/commcare/session/CommCareSession.java
+++ b/backend/src/org/commcare/session/CommCareSession.java
@@ -303,8 +303,11 @@ public class CommCareSession {
      * an entry on the stack
      */
     public SessionDatum getNeededDatum() {
-        Entry entry = getEntriesForCommand(getCommand()).elementAt(0);
-        return getNeededDatum(entry);
+        Vector<Entry> entries = getEntriesForCommand(getCommand());
+        if (entries.isEmpty()) {
+            throw new IllegalStateException("The current session has no valid entry");
+        }
+        return getNeededDatum(entries.firstElement());
     }
 
     /**
@@ -813,7 +816,7 @@ public class CommCareSession {
         if (e.size() > 1) {
             throw new IllegalStateException("The current session does not contain a single valid entry");
         }
-        if (e.size() == 0) {
+        if (e.isEmpty()) {
             throw new IllegalStateException("The current session has no valid entry");
         }
         return e.elementAt(0);

--- a/backend/src/org/commcare/session/RemoteQuerySessionManager.java
+++ b/backend/src/org/commcare/session/RemoteQuerySessionManager.java
@@ -46,7 +46,7 @@ public class RemoteQuerySessionManager {
         SessionDatum datum;
         try {
             datum = session.getNeededDatum();
-        } catch (NullPointerException e) {
+        } catch (IllegalStateException e) {
             // tried loading session info when it wasn't there
             return null;
         }


### PR DESCRIPTION
The changes in https://github.com/dimagi/commcare-core/pull/455 caused a sloppy `NullPointerException` catch to fail here https://github.com/dimagi/commcare-core/blob/master/backend/src/org/commcare/session/RemoteQuerySessionManager.java#L49-L51 which caused an `commcare-android` test to fail