### PR TITLE
Method for getting list of base XPath functions

### DIFF
--- a/cases/src/org/commcare/cases/entity/EntitySorter.java
+++ b/cases/src/org/commcare/cases/entity/EntitySorter.java
@@ -5,6 +5,7 @@ import org.javarosa.core.model.Constants;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.services.Logger;
 import org.javarosa.xpath.XPathTypeMismatchException;
+import org.javarosa.xpath.expr.FunctionUtils;
 import org.javarosa.xpath.expr.XPathFuncExpr;
 
 import java.util.Comparator;
@@ -81,7 +82,7 @@ public class EntitySorter implements Comparator<Entity<TreeReference>> {
                 //Double int compares just fine here and also
                 //deals with NaN's appropriately
 
-                double ret = XPathFuncExpr.toInt(value);
+                double ret = FunctionUtils.toInt(value);
                 if (Double.isNaN(ret)) {
                     String[] stringArgs = new String[3];
                     stringArgs[2] = value;
@@ -92,7 +93,7 @@ public class EntitySorter implements Comparator<Entity<TreeReference>> {
                 }
                 return ret;
             } else if (sortType == Constants.DATATYPE_DECIMAL) {
-                double ret = XPathFuncExpr.toDouble(value);
+                double ret = FunctionUtils.toDouble(value);
                 if (Double.isNaN(ret)) {
 
                     String[] stringArgs = new String[3];

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/FunctionUtils.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/FunctionUtils.java
@@ -7,76 +7,77 @@ import org.javarosa.xpath.IExprDataType;
 import org.javarosa.xpath.XPathNodeset;
 import org.javarosa.xpath.XPathTypeMismatchException;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 
 public class FunctionUtils {
-    public static final HashMap<Class, String> funcList = new HashMap<>();
+    private static final HashMap<Class, String> funcList = new HashMap<>();
 
     static {
-        funcList.put(XPathDateFunc.class, "");
-        funcList.put(XpathCoalesceFunc.class, "");
-        funcList.put(XPathTrueFunc.class, "");
-        funcList.put(XPathNowFunc.class, "");
-        funcList.put(XPathNumberFunc.class, "");
-        funcList.put(XPathSelectedFunc.class, "");
-        funcList.put(XPathBooleanFunc.class, "");
-        funcList.put(XPathLogTenFunc.class, "");
-        funcList.put(XPathExpFunc.class, "");
-        funcList.put(XPathChecklistFunc.class, "");
-        funcList.put(XPathAtanTwoFunc.class, "");
-        funcList.put(XPathSubstrFunc.class, "");
-        funcList.put(XPathStringFunc.class, "");
-        funcList.put(XPathEndsWithFunc.class, "");
-        funcList.put(XPathDependFunc.class, "");
-        funcList.put(XPathDoubleFunc.class, "");
-        funcList.put(XPathTanFunc.class, "");
-        funcList.put(XPathReplaceFunc.class, "");
-        funcList.put(XPathJoinFunc.class, "");
-        funcList.put(XPathFloorFunc.class, "");
-        funcList.put(XPathPiFunc.class, "");
-        funcList.put(XPathFormatDateFunc.class, "");
-        funcList.put(XPathFormatDateForCalendarFunc.class, "");
-        funcList.put(XPathMinFunc.class, "");
-        funcList.put(XPathSinFunc.class, "");
-        funcList.put(XPathBooleanFromStringFunc.class, "");
-        funcList.put(XPathCondFunc.class, "");
-        funcList.put(XPathSubstringBeforeFunc.class, "");
-        funcList.put(XPathCeilingFunc.class, "");
-        funcList.put(XPathPositionFunc.class, "");
-        funcList.put(XPathStringLengthFunc.class, "");
-        funcList.put(XPathRandomFunc.class, "");
-        funcList.put(XPathMaxFunc.class, "");
-        funcList.put(XPathCustomRuntimeFunc.class, "");
-        funcList.put(XPathAcosFunc.class, "");
-        funcList.put(XPathAsinFunc.class, "");
-        funcList.put(XPathIfFunc.class, "");
-        funcList.put(XPathLowerCaseFunc.class, "");
-        funcList.put(XPathIntFunc.class, "");
-        funcList.put(XPathDistanceFunc.class, "");
-        funcList.put(XPathWeightedChecklistFunc.class, "");
-        funcList.put(XPathUpperCaseFunc.class, "");
-        funcList.put(XPathCosFunc.class, "");
-        funcList.put(XPathFalseFunc.class, "");
-        funcList.put(XPathLogFunc.class, "");
-        funcList.put(XPathRoundFunc.class, "");
-        funcList.put(XPathSubstringAfterFunc.class, "");
-        funcList.put(XPathAbsFunc.class, "");
-        funcList.put(XPathTranslateFunc.class, "");
-        funcList.put(XPathCountSelectedFunc.class, "");
-        funcList.put(XPathSelectedAtFunc.class, "");
-        funcList.put(XPathCountFunc.class, "");
-        funcList.put(XPathPowFunc.class, "");
-        funcList.put(XPathContainsFunc.class, "");
-        funcList.put(XPathNotFunc.class, "");
-        funcList.put(XPathSumFunc.class, "");
-        funcList.put(XPathRegexFunc.class, "");
-        funcList.put(XPathAtanFunc.class, "");
-        funcList.put(XPathStartsWithFunc.class, "");
-        funcList.put(XPathTodayFunc.class, "");
-        funcList.put(XPathConcatFunc.class, "");
-        funcList.put(XPathSqrtFunc.class, "");
-        funcList.put(XPathUuidFunc.class, "");
+        funcList.put(XPathDateFunc.class, XPathDateFunc.NAME);
+        funcList.put(XpathCoalesceFunc.class, XpathCoalesceFunc.NAME);
+        funcList.put(XPathTrueFunc.class, XPathTrueFunc.NAME);
+        funcList.put(XPathNowFunc.class, XPathNowFunc.NAME);
+        funcList.put(XPathNumberFunc.class, XPathNumberFunc.NAME);
+        funcList.put(XPathSelectedFunc.class, XPathSelectedFunc.NAME);
+        funcList.put(XPathBooleanFunc.class, XPathBooleanFunc.NAME);
+        funcList.put(XPathLogTenFunc.class, XPathLogTenFunc.NAME);
+        funcList.put(XPathExpFunc.class, XPathExpFunc.NAME);
+        funcList.put(XPathChecklistFunc.class, XPathChecklistFunc.NAME);
+        funcList.put(XPathAtanTwoFunc.class, XPathAtanTwoFunc.NAME);
+        funcList.put(XPathSubstrFunc.class, XPathSubstrFunc.NAME);
+        funcList.put(XPathStringFunc.class, XPathStringFunc.NAME);
+        funcList.put(XPathEndsWithFunc.class, XPathEndsWithFunc.NAME);
+        funcList.put(XPathDependFunc.class, XPathDependFunc.NAME);
+        funcList.put(XPathDoubleFunc.class, XPathDoubleFunc.NAME);
+        funcList.put(XPathTanFunc.class, XPathTanFunc.NAME);
+        funcList.put(XPathReplaceFunc.class, XPathReplaceFunc.NAME);
+        funcList.put(XPathJoinFunc.class, XPathJoinFunc.NAME);
+        funcList.put(XPathFloorFunc.class, XPathFloorFunc.NAME);
+        funcList.put(XPathPiFunc.class, XPathPiFunc.NAME);
+        funcList.put(XPathFormatDateFunc.class, XPathFormatDateFunc.NAME);
+        funcList.put(XPathFormatDateForCalendarFunc.class, XPathFormatDateForCalendarFunc.NAME);
+        funcList.put(XPathMinFunc.class, XPathMinFunc.NAME);
+        funcList.put(XPathSinFunc.class, XPathSinFunc.NAME);
+        funcList.put(XPathBooleanFromStringFunc.class, XPathBooleanFromStringFunc.NAME);
+        funcList.put(XPathCondFunc.class, XPathCondFunc.NAME);
+        funcList.put(XPathSubstringBeforeFunc.class, XPathSubstringBeforeFunc.NAME);
+        funcList.put(XPathCeilingFunc.class, XPathCeilingFunc.NAME);
+        funcList.put(XPathPositionFunc.class, XPathPositionFunc.NAME);
+        funcList.put(XPathStringLengthFunc.class, XPathStringLengthFunc.NAME);
+        funcList.put(XPathRandomFunc.class, XPathRandomFunc.NAME);
+        funcList.put(XPathMaxFunc.class, XPathMaxFunc.NAME);
+        funcList.put(XPathAcosFunc.class, XPathAcosFunc.NAME);
+        funcList.put(XPathAsinFunc.class, XPathAsinFunc.NAME);
+        funcList.put(XPathIfFunc.class, XPathIfFunc.NAME);
+        funcList.put(XPathLowerCaseFunc.class, XPathLowerCaseFunc.NAME);
+        funcList.put(XPathIntFunc.class, XPathIntFunc.NAME);
+        funcList.put(XPathDistanceFunc.class, XPathDistanceFunc.NAME);
+        funcList.put(XPathWeightedChecklistFunc.class, XPathWeightedChecklistFunc.NAME);
+        funcList.put(XPathUpperCaseFunc.class, XPathUpperCaseFunc.NAME);
+        funcList.put(XPathCosFunc.class, XPathCosFunc.NAME);
+        funcList.put(XPathFalseFunc.class, XPathFalseFunc.NAME);
+        funcList.put(XPathLogFunc.class, XPathLogFunc.NAME);
+        funcList.put(XPathRoundFunc.class, XPathRoundFunc.NAME);
+        funcList.put(XPathSubstringAfterFunc.class, XPathSubstringAfterFunc.NAME);
+        funcList.put(XPathAbsFunc.class, XPathAbsFunc.NAME);
+        funcList.put(XPathTranslateFunc.class, XPathTranslateFunc.NAME);
+        funcList.put(XPathCountSelectedFunc.class, XPathCountSelectedFunc.NAME);
+        funcList.put(XPathSelectedAtFunc.class, XPathSelectedAtFunc.NAME);
+        funcList.put(XPathCountFunc.class, XPathCountFunc.NAME);
+        funcList.put(XPathPowFunc.class, XPathPowFunc.NAME);
+        funcList.put(XPathContainsFunc.class, XPathContainsFunc.NAME);
+        funcList.put(XPathNotFunc.class, XPathNotFunc.NAME);
+        funcList.put(XPathSumFunc.class, XPathSumFunc.NAME);
+        funcList.put(XPathRegexFunc.class, XPathRegexFunc.NAME);
+        funcList.put(XPathAtanFunc.class, XPathAtanFunc.NAME);
+        funcList.put(XPathStartsWithFunc.class, XPathStartsWithFunc.NAME);
+        funcList.put(XPathTodayFunc.class, XPathTodayFunc.NAME);
+        funcList.put(XPathConcatFunc.class, XPathConcatFunc.NAME);
+        funcList.put(XPathSqrtFunc.class, XPathSqrtFunc.NAME);
+        funcList.put(XPathUuidFunc.class, XPathUuidFunc.NAME);
     }
 
     private static final CacheTable<String, Double> mDoubleParseCache = new CacheTable<>();
@@ -428,5 +429,19 @@ public class FunctionUtils {
             return s.toUpperCase();
         }
         return s.toLowerCase();
+    }
+
+    /**
+     * Get list of base xpath functions
+     *
+     * (Used in formplayer for function auto-completion)
+     */
+    @SuppressWarnings("unused")
+    public static List<String> xPathFuncList() {
+        return new ArrayList<>(funcList.values());
+    }
+
+    public static HashMap<Class, String> getXPathFuncListMap() {
+        return funcList;
     }
 }

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/FunctionUtils.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/FunctionUtils.java
@@ -13,71 +13,71 @@ import java.util.HashMap;
 import java.util.List;
 
 public class FunctionUtils {
-    private static final HashMap<Class, String> funcList = new HashMap<>();
+    private static final HashMap<String, Class> funcList = new HashMap<>();
 
     static {
-        funcList.put(XPathDateFunc.class, XPathDateFunc.NAME);
-        funcList.put(XpathCoalesceFunc.class, XpathCoalesceFunc.NAME);
-        funcList.put(XPathTrueFunc.class, XPathTrueFunc.NAME);
-        funcList.put(XPathNowFunc.class, XPathNowFunc.NAME);
-        funcList.put(XPathNumberFunc.class, XPathNumberFunc.NAME);
-        funcList.put(XPathSelectedFunc.class, XPathSelectedFunc.NAME);
-        funcList.put(XPathBooleanFunc.class, XPathBooleanFunc.NAME);
-        funcList.put(XPathLogTenFunc.class, XPathLogTenFunc.NAME);
-        funcList.put(XPathExpFunc.class, XPathExpFunc.NAME);
-        funcList.put(XPathChecklistFunc.class, XPathChecklistFunc.NAME);
-        funcList.put(XPathAtanTwoFunc.class, XPathAtanTwoFunc.NAME);
-        funcList.put(XPathSubstrFunc.class, XPathSubstrFunc.NAME);
-        funcList.put(XPathStringFunc.class, XPathStringFunc.NAME);
-        funcList.put(XPathEndsWithFunc.class, XPathEndsWithFunc.NAME);
-        funcList.put(XPathDependFunc.class, XPathDependFunc.NAME);
-        funcList.put(XPathDoubleFunc.class, XPathDoubleFunc.NAME);
-        funcList.put(XPathTanFunc.class, XPathTanFunc.NAME);
-        funcList.put(XPathReplaceFunc.class, XPathReplaceFunc.NAME);
-        funcList.put(XPathJoinFunc.class, XPathJoinFunc.NAME);
-        funcList.put(XPathFloorFunc.class, XPathFloorFunc.NAME);
-        funcList.put(XPathPiFunc.class, XPathPiFunc.NAME);
-        funcList.put(XPathFormatDateFunc.class, XPathFormatDateFunc.NAME);
-        funcList.put(XPathFormatDateForCalendarFunc.class, XPathFormatDateForCalendarFunc.NAME);
-        funcList.put(XPathMinFunc.class, XPathMinFunc.NAME);
-        funcList.put(XPathSinFunc.class, XPathSinFunc.NAME);
-        funcList.put(XPathBooleanFromStringFunc.class, XPathBooleanFromStringFunc.NAME);
-        funcList.put(XPathCondFunc.class, XPathCondFunc.NAME);
-        funcList.put(XPathSubstringBeforeFunc.class, XPathSubstringBeforeFunc.NAME);
-        funcList.put(XPathCeilingFunc.class, XPathCeilingFunc.NAME);
-        funcList.put(XPathPositionFunc.class, XPathPositionFunc.NAME);
-        funcList.put(XPathStringLengthFunc.class, XPathStringLengthFunc.NAME);
-        funcList.put(XPathRandomFunc.class, XPathRandomFunc.NAME);
-        funcList.put(XPathMaxFunc.class, XPathMaxFunc.NAME);
-        funcList.put(XPathAcosFunc.class, XPathAcosFunc.NAME);
-        funcList.put(XPathAsinFunc.class, XPathAsinFunc.NAME);
-        funcList.put(XPathIfFunc.class, XPathIfFunc.NAME);
-        funcList.put(XPathLowerCaseFunc.class, XPathLowerCaseFunc.NAME);
-        funcList.put(XPathIntFunc.class, XPathIntFunc.NAME);
-        funcList.put(XPathDistanceFunc.class, XPathDistanceFunc.NAME);
-        funcList.put(XPathWeightedChecklistFunc.class, XPathWeightedChecklistFunc.NAME);
-        funcList.put(XPathUpperCaseFunc.class, XPathUpperCaseFunc.NAME);
-        funcList.put(XPathCosFunc.class, XPathCosFunc.NAME);
-        funcList.put(XPathFalseFunc.class, XPathFalseFunc.NAME);
-        funcList.put(XPathLogFunc.class, XPathLogFunc.NAME);
-        funcList.put(XPathRoundFunc.class, XPathRoundFunc.NAME);
-        funcList.put(XPathSubstringAfterFunc.class, XPathSubstringAfterFunc.NAME);
-        funcList.put(XPathAbsFunc.class, XPathAbsFunc.NAME);
-        funcList.put(XPathTranslateFunc.class, XPathTranslateFunc.NAME);
-        funcList.put(XPathCountSelectedFunc.class, XPathCountSelectedFunc.NAME);
-        funcList.put(XPathSelectedAtFunc.class, XPathSelectedAtFunc.NAME);
-        funcList.put(XPathCountFunc.class, XPathCountFunc.NAME);
-        funcList.put(XPathPowFunc.class, XPathPowFunc.NAME);
-        funcList.put(XPathContainsFunc.class, XPathContainsFunc.NAME);
-        funcList.put(XPathNotFunc.class, XPathNotFunc.NAME);
-        funcList.put(XPathSumFunc.class, XPathSumFunc.NAME);
-        funcList.put(XPathRegexFunc.class, XPathRegexFunc.NAME);
-        funcList.put(XPathAtanFunc.class, XPathAtanFunc.NAME);
-        funcList.put(XPathStartsWithFunc.class, XPathStartsWithFunc.NAME);
-        funcList.put(XPathTodayFunc.class, XPathTodayFunc.NAME);
-        funcList.put(XPathConcatFunc.class, XPathConcatFunc.NAME);
-        funcList.put(XPathSqrtFunc.class, XPathSqrtFunc.NAME);
-        funcList.put(XPathUuidFunc.class, XPathUuidFunc.NAME);
+        funcList.put(XPathDateFunc.NAME, XPathDateFunc.class);
+        funcList.put(XpathCoalesceFunc.NAME, XpathCoalesceFunc.class);
+        funcList.put(XPathTrueFunc.NAME, XPathTrueFunc.class);
+        funcList.put(XPathNowFunc.NAME, XPathNowFunc.class);
+        funcList.put(XPathNumberFunc.NAME, XPathNumberFunc.class);
+        funcList.put(XPathSelectedFunc.NAME, XPathSelectedFunc.class);
+        funcList.put(XPathBooleanFunc.NAME, XPathBooleanFunc.class);
+        funcList.put(XPathLogTenFunc.NAME, XPathLogTenFunc.class);
+        funcList.put(XPathExpFunc.NAME, XPathExpFunc.class);
+        funcList.put(XPathChecklistFunc.NAME, XPathChecklistFunc.class);
+        funcList.put(XPathAtanTwoFunc.NAME, XPathAtanTwoFunc.class);
+        funcList.put(XPathSubstrFunc.NAME, XPathSubstrFunc.class);
+        funcList.put(XPathStringFunc.NAME, XPathStringFunc.class);
+        funcList.put(XPathEndsWithFunc.NAME, XPathEndsWithFunc.class);
+        funcList.put(XPathDependFunc.NAME, XPathDependFunc.class);
+        funcList.put(XPathDoubleFunc.NAME, XPathDoubleFunc.class);
+        funcList.put(XPathTanFunc.NAME, XPathTanFunc.class);
+        funcList.put(XPathReplaceFunc.NAME, XPathReplaceFunc.class);
+        funcList.put(XPathJoinFunc.NAME, XPathJoinFunc.class);
+        funcList.put(XPathFloorFunc.NAME, XPathFloorFunc.class);
+        funcList.put(XPathPiFunc.NAME, XPathPiFunc.class);
+        funcList.put(XPathFormatDateFunc.NAME, XPathFormatDateFunc.class);
+        funcList.put(XPathFormatDateForCalendarFunc.NAME, XPathFormatDateForCalendarFunc.class);
+        funcList.put(XPathMinFunc.NAME, XPathMinFunc.class);
+        funcList.put(XPathSinFunc.NAME, XPathSinFunc.class);
+        funcList.put(XPathBooleanFromStringFunc.NAME, XPathBooleanFromStringFunc.class);
+        funcList.put(XPathCondFunc.NAME, XPathCondFunc.class);
+        funcList.put(XPathSubstringBeforeFunc.NAME, XPathSubstringBeforeFunc.class);
+        funcList.put(XPathCeilingFunc.NAME, XPathCeilingFunc.class);
+        funcList.put(XPathPositionFunc.NAME, XPathPositionFunc.class);
+        funcList.put(XPathStringLengthFunc.NAME, XPathStringLengthFunc.class);
+        funcList.put(XPathRandomFunc.NAME, XPathRandomFunc.class);
+        funcList.put(XPathMaxFunc.NAME, XPathMaxFunc.class);
+        funcList.put(XPathAcosFunc.NAME, XPathAcosFunc.class);
+        funcList.put(XPathAsinFunc.NAME, XPathAsinFunc.class);
+        funcList.put(XPathIfFunc.NAME, XPathIfFunc.class);
+        funcList.put(XPathLowerCaseFunc.NAME, XPathLowerCaseFunc.class);
+        funcList.put(XPathIntFunc.NAME, XPathIntFunc.class);
+        funcList.put(XPathDistanceFunc.NAME, XPathDistanceFunc.class);
+        funcList.put(XPathWeightedChecklistFunc.NAME, XPathWeightedChecklistFunc.class);
+        funcList.put(XPathUpperCaseFunc.NAME, XPathUpperCaseFunc.class);
+        funcList.put(XPathCosFunc.NAME, XPathCosFunc.class);
+        funcList.put(XPathFalseFunc.NAME, XPathFalseFunc.class);
+        funcList.put(XPathLogFunc.NAME, XPathLogFunc.class);
+        funcList.put(XPathRoundFunc.NAME, XPathRoundFunc.class);
+        funcList.put(XPathSubstringAfterFunc.NAME, XPathSubstringAfterFunc.class);
+        funcList.put(XPathAbsFunc.NAME, XPathAbsFunc.class);
+        funcList.put(XPathTranslateFunc.NAME, XPathTranslateFunc.class);
+        funcList.put(XPathCountSelectedFunc.NAME, XPathCountSelectedFunc.class);
+        funcList.put(XPathSelectedAtFunc.NAME, XPathSelectedAtFunc.class);
+        funcList.put(XPathCountFunc.NAME, XPathCountFunc.class);
+        funcList.put(XPathPowFunc.NAME, XPathPowFunc.class);
+        funcList.put(XPathContainsFunc.NAME, XPathContainsFunc.class);
+        funcList.put(XPathNotFunc.NAME, XPathNotFunc.class);
+        funcList.put(XPathSumFunc.NAME, XPathSumFunc.class);
+        funcList.put(XPathRegexFunc.NAME, XPathRegexFunc.class);
+        funcList.put(XPathAtanFunc.NAME, XPathAtanFunc.class);
+        funcList.put(XPathStartsWithFunc.NAME, XPathStartsWithFunc.class);
+        funcList.put(XPathTodayFunc.NAME, XPathTodayFunc.class);
+        funcList.put(XPathConcatFunc.NAME, XPathConcatFunc.class);
+        funcList.put(XPathSqrtFunc.NAME, XPathSqrtFunc.class);
+        funcList.put(XPathUuidFunc.NAME, XPathUuidFunc.class);
     }
 
     private static final CacheTable<String, Double> mDoubleParseCache = new CacheTable<>();
@@ -438,10 +438,10 @@ public class FunctionUtils {
      */
     @SuppressWarnings("unused")
     public static List<String> xPathFuncList() {
-        return new ArrayList<>(funcList.values());
+        return new ArrayList<>(funcList.keySet());
     }
 
-    public static HashMap<Class, String> getXPathFuncListMap() {
+    public static HashMap<String, Class> getXPathFuncListMap() {
         return funcList;
     }
 }

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/FunctionUtils.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/FunctionUtils.java
@@ -8,8 +8,76 @@ import org.javarosa.xpath.XPathNodeset;
 import org.javarosa.xpath.XPathTypeMismatchException;
 
 import java.util.Date;
+import java.util.HashMap;
 
 public class FunctionUtils {
+    public static final HashMap<Class, String> funcList = new HashMap<>();
+
+    static {
+        funcList.put(XPathDateFunc.class, "");
+        funcList.put(XpathCoalesceFunc.class, "");
+        funcList.put(XPathTrueFunc.class, "");
+        funcList.put(XPathNowFunc.class, "");
+        funcList.put(XPathNumberFunc.class, "");
+        funcList.put(XPathSelectedFunc.class, "");
+        funcList.put(XPathBooleanFunc.class, "");
+        funcList.put(XPathLogTenFunc.class, "");
+        funcList.put(XPathExpFunc.class, "");
+        funcList.put(XPathChecklistFunc.class, "");
+        funcList.put(XPathAtanTwoFunc.class, "");
+        funcList.put(XPathSubstrFunc.class, "");
+        funcList.put(XPathStringFunc.class, "");
+        funcList.put(XPathEndsWithFunc.class, "");
+        funcList.put(XPathDependFunc.class, "");
+        funcList.put(XPathDoubleFunc.class, "");
+        funcList.put(XPathTanFunc.class, "");
+        funcList.put(XPathReplaceFunc.class, "");
+        funcList.put(XPathJoinFunc.class, "");
+        funcList.put(XPathFloorFunc.class, "");
+        funcList.put(XPathPiFunc.class, "");
+        funcList.put(XPathFormatDateFunc.class, "");
+        funcList.put(XPathFormatDateForCalendarFunc.class, "");
+        funcList.put(XPathMinFunc.class, "");
+        funcList.put(XPathSinFunc.class, "");
+        funcList.put(XPathBooleanFromStringFunc.class, "");
+        funcList.put(XPathCondFunc.class, "");
+        funcList.put(XPathSubstringBeforeFunc.class, "");
+        funcList.put(XPathCeilingFunc.class, "");
+        funcList.put(XPathPositionFunc.class, "");
+        funcList.put(XPathStringLengthFunc.class, "");
+        funcList.put(XPathRandomFunc.class, "");
+        funcList.put(XPathMaxFunc.class, "");
+        funcList.put(XPathCustomRuntimeFunc.class, "");
+        funcList.put(XPathAcosFunc.class, "");
+        funcList.put(XPathAsinFunc.class, "");
+        funcList.put(XPathIfFunc.class, "");
+        funcList.put(XPathLowerCaseFunc.class, "");
+        funcList.put(XPathIntFunc.class, "");
+        funcList.put(XPathDistanceFunc.class, "");
+        funcList.put(XPathWeightedChecklistFunc.class, "");
+        funcList.put(XPathUpperCaseFunc.class, "");
+        funcList.put(XPathCosFunc.class, "");
+        funcList.put(XPathFalseFunc.class, "");
+        funcList.put(XPathLogFunc.class, "");
+        funcList.put(XPathRoundFunc.class, "");
+        funcList.put(XPathSubstringAfterFunc.class, "");
+        funcList.put(XPathAbsFunc.class, "");
+        funcList.put(XPathTranslateFunc.class, "");
+        funcList.put(XPathCountSelectedFunc.class, "");
+        funcList.put(XPathSelectedAtFunc.class, "");
+        funcList.put(XPathCountFunc.class, "");
+        funcList.put(XPathPowFunc.class, "");
+        funcList.put(XPathContainsFunc.class, "");
+        funcList.put(XPathNotFunc.class, "");
+        funcList.put(XPathSumFunc.class, "");
+        funcList.put(XPathRegexFunc.class, "");
+        funcList.put(XPathAtanFunc.class, "");
+        funcList.put(XPathStartsWithFunc.class, "");
+        funcList.put(XPathTodayFunc.class, "");
+        funcList.put(XPathConcatFunc.class, "");
+        funcList.put(XPathSqrtFunc.class, "");
+        funcList.put(XPathUuidFunc.class, "");
+    }
 
     private static final CacheTable<String, Double> mDoubleParseCache = new CacheTable<>();
     /**

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathAbsFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathAbsFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathAbsFunc extends XPathFuncExpr {
-    private static final String NAME = "abs";
+    public static final String NAME = "abs";
     private static final int EXPECTED_ARG_COUNT = 1;
 
     public XPathAbsFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathAcosFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathAcosFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathAcosFunc extends XPathFuncExpr {
-    private static final String NAME = "acos";
+    public static final String NAME = "acos";
     private static final int EXPECTED_ARG_COUNT = 1;
 
     public XPathAcosFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathAsinFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathAsinFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathAsinFunc extends XPathFuncExpr {
-    private static final String NAME = "asin";
+    public static final String NAME = "asin";
     private static final int EXPECTED_ARG_COUNT = 1;
 
     public XPathAsinFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathAtanFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathAtanFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathAtanFunc extends XPathFuncExpr {
-    private static final String NAME = "atan";
+    public static final String NAME = "atan";
     private static final int EXPECTED_ARG_COUNT = 1;
 
     public XPathAtanFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathAtanTwoFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathAtanTwoFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathAtanTwoFunc extends XPathFuncExpr {
-    private static final String NAME = "atan2";
+    public static final String NAME = "atan2";
     private static final int EXPECTED_ARG_COUNT = 2;
 
     public XPathAtanTwoFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathBooleanFromStringFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathBooleanFromStringFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathBooleanFromStringFunc extends XPathFuncExpr {
-    private static final String NAME = "boolean-from-string";
+    public static final String NAME = "boolean-from-string";
     private static final int EXPECTED_ARG_COUNT = 1;
 
     public XPathBooleanFromStringFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathBooleanFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathBooleanFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathBooleanFunc extends XPathFuncExpr {
-    private static final String NAME = "boolean";
+    public static final String NAME = "boolean";
     private static final int EXPECTED_ARG_COUNT = 1;
 
     public XPathBooleanFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathCeilingFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathCeilingFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathCeilingFunc extends XPathFuncExpr {
-    private static final String NAME = "ceiling";
+    public static final String NAME = "ceiling";
     private static final int EXPECTED_ARG_COUNT = 1;
 
     public XPathCeilingFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathChecklistFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathChecklistFunc.java
@@ -7,7 +7,7 @@ import org.javarosa.xpath.XPathNodeset;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathChecklistFunc extends XPathFuncExpr {
-    private static final String NAME = "checklist";
+    public static final String NAME = "checklist";
     // two or more arguments
     private static final int EXPECTED_ARG_COUNT = -1;
 

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathConcatFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathConcatFunc.java
@@ -6,7 +6,7 @@ import org.javarosa.xpath.XPathNodeset;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathConcatFunc extends XPathFuncExpr {
-    private static final String NAME = "concat";
+    public static final String NAME = "concat";
     // zero or more arguments
     private static final int EXPECTED_ARG_COUNT = -1;
 

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathCondFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathCondFunc.java
@@ -8,7 +8,7 @@ import org.javarosa.xpath.parser.XPathSyntaxException;
  * @author Phillip Mates (pmates@dimagi.com)
  */
 public class XPathCondFunc extends XPathFuncExpr {
-    private static final String NAME = "cond";
+    public static final String NAME = "cond";
     // expects at least 3 arguments
     private static final int EXPECTED_ARG_COUNT = -1;
 

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathContainsFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathContainsFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathContainsFunc extends XPathFuncExpr {
-    private static final String NAME = "contains";
+    public static final String NAME = "contains";
     private static final int EXPECTED_ARG_COUNT = 2;
 
     public XPathContainsFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathCosFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathCosFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathCosFunc extends XPathFuncExpr {
-    private static final String NAME = "cos";
+    public static final String NAME = "cos";
     private static final int EXPECTED_ARG_COUNT = 1;
 
     public XPathCosFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathCountFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathCountFunc.java
@@ -7,7 +7,7 @@ import org.javarosa.xpath.XPathTypeMismatchException;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathCountFunc extends XPathFuncExpr {
-    private static final String NAME = "count";
+    public static final String NAME = "count";
     private static final int EXPECTED_ARG_COUNT = 1;
 
     public XPathCountFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathCountSelectedFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathCountSelectedFunc.java
@@ -12,7 +12,7 @@ import org.javarosa.xpath.parser.XPathSyntaxException;
  * (i.e, space-delimited choice values)
  */
 public class XPathCountSelectedFunc extends XPathFuncExpr {
-    private static final String NAME = "count-selected";
+    public static final String NAME = "count-selected";
     private static final int EXPECTED_ARG_COUNT = 1;
 
     public XPathCountSelectedFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathDateFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathDateFunc.java
@@ -6,7 +6,7 @@ import org.javarosa.xpath.parser.XPathSyntaxException;
 
 // non-standard
 public class XPathDateFunc extends XPathFuncExpr {
-    private static final String NAME = "date";
+    public static final String NAME = "date";
     private static final int EXPECTED_ARG_COUNT = 1;
 
     public XPathDateFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathDependFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathDependFunc.java
@@ -7,7 +7,7 @@ import org.javarosa.xpath.parser.XPathSyntaxException;
 
 // non-standard
 public class XPathDependFunc extends XPathFuncExpr {
-    private static final String NAME = "depend";
+    public static final String NAME = "depend";
     // at least one argument
     private static final int EXPECTED_ARG_COUNT = -1;
 

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathDistanceFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathDistanceFunc.java
@@ -8,7 +8,7 @@ import org.javarosa.core.model.utils.GeoPointUtils;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathDistanceFunc extends XPathFuncExpr {
-    private static final String NAME = "distance";
+    public static final String NAME = "distance";
     private static final int EXPECTED_ARG_COUNT = 2;
 
     public XPathDistanceFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathDoubleFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathDoubleFunc.java
@@ -6,7 +6,7 @@ import org.javarosa.xpath.parser.XPathSyntaxException;
 
 // non-standard
 public class XPathDoubleFunc extends XPathFuncExpr {
-    private static final String NAME = "double";
+    public static final String NAME = "double";
     private static final int EXPECTED_ARG_COUNT = 1;
 
     public XPathDoubleFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathEndsWithFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathEndsWithFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathEndsWithFunc extends XPathFuncExpr {
-    private static final String NAME = "ends-with";
+    public static final String NAME = "ends-with";
     private static final int EXPECTED_ARG_COUNT = 2;
 
     public XPathEndsWithFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathExpFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathExpFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathExpFunc extends XPathFuncExpr {
-    private static final String NAME = "exp";
+    public static final String NAME = "exp";
     private static final int EXPECTED_ARG_COUNT = 1;
 
     public XPathExpFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathFalseFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathFalseFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathFalseFunc extends XPathFuncExpr {
-    private static final String NAME = "false";
+    public static final String NAME = "false";
     private static final int EXPECTED_ARG_COUNT = 0;
 
     public XPathFalseFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathFloorFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathFloorFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathFloorFunc extends XPathFuncExpr {
-    private static final String NAME = "floor";
+    public static final String NAME = "floor";
     private static final int EXPECTED_ARG_COUNT = 1;
 
     public XPathFloorFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathFormatDateForCalendarFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathFormatDateForCalendarFunc.java
@@ -9,7 +9,7 @@ import org.javarosa.xpath.parser.XPathSyntaxException;
 import java.util.Date;
 
 public class XPathFormatDateForCalendarFunc extends XPathFuncExpr {
-    private static final String NAME = "format-date-for-calendar";
+    public static final String NAME = "format-date-for-calendar";
     private static final int EXPECTED_ARG_COUNT = 2;
 
     public XPathFormatDateForCalendarFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathFormatDateFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathFormatDateFunc.java
@@ -8,7 +8,7 @@ import org.javarosa.xpath.parser.XPathSyntaxException;
 import java.util.Date;
 
 public class XPathFormatDateFunc extends XPathFuncExpr {
-    private static final String NAME = "format-date";
+    public static final String NAME = "format-date";
     private static final int EXPECTED_ARG_COUNT = 2;
 
     public XPathFormatDateFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -68,6 +68,8 @@ public abstract class XPathFuncExpr extends XPathExpression {
 
     protected abstract Object evalBody(DataInstance model, EvaluationContext evalContext);
 
+    //protected abstract String docs();
+
     @Override
     public String toString() {
         StringBuffer sb = new StringBuffer();

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathIfFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathIfFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathIfFunc extends XPathFuncExpr {
-    private static final String NAME = "if";
+    public static final String NAME = "if";
     private static final int EXPECTED_ARG_COUNT = 3;
 
     public XPathIfFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathIntFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathIntFunc.java
@@ -6,7 +6,7 @@ import org.javarosa.xpath.parser.XPathSyntaxException;
 
 //non-standard
 public class XPathIntFunc extends XPathFuncExpr {
-    private static final String NAME = "int";
+    public static final String NAME = "int";
     private static final int EXPECTED_ARG_COUNT = 1;
 
     public XPathIntFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathJoinFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathJoinFunc.java
@@ -7,7 +7,7 @@ import org.javarosa.xpath.XPathNodeset;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathJoinFunc extends XPathFuncExpr {
-    private static final String NAME = "join";
+    public static final String NAME = "join";
     // one or more arguments
     private static final int EXPECTED_ARG_COUNT = -1;
 

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathLogFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathLogFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathLogFunc extends XPathFuncExpr {
-    private static final String NAME = "log";
+    public static final String NAME = "log";
     private static final int EXPECTED_ARG_COUNT = 1;
 
     public XPathLogFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathLogTenFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathLogTenFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathLogTenFunc extends XPathFuncExpr {
-    private static final String NAME = "log10";
+    public static final String NAME = "log10";
     private static final int EXPECTED_ARG_COUNT = 1;
 
     public XPathLogTenFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathLowerCaseFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathLowerCaseFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathLowerCaseFunc extends XPathFuncExpr {
-    private static final String NAME = "lower-case";
+    public static final String NAME = "lower-case";
     private static final int EXPECTED_ARG_COUNT = 1;
 
     public XPathLowerCaseFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathMaxFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathMaxFunc.java
@@ -7,7 +7,7 @@ import org.javarosa.xpath.XPathNodeset;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathMaxFunc extends XPathFuncExpr {
-    private static final String NAME = "max";
+    public static final String NAME = "max";
     // one or more arguments
     private static final int EXPECTED_ARG_COUNT = -1;
 

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathMinFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathMinFunc.java
@@ -7,7 +7,7 @@ import org.javarosa.xpath.XPathNodeset;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathMinFunc extends XPathFuncExpr {
-    private static final String NAME = "min";
+    public static final String NAME = "min";
     // one or more arguments
     private static final int EXPECTED_ARG_COUNT = -1;
 

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathNotFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathNotFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathNotFunc extends XPathFuncExpr {
-    private static final String NAME = "not";
+    public static final String NAME = "not";
     private static final int EXPECTED_ARG_COUNT = 1;
 
     public XPathNotFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathNowFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathNowFunc.java
@@ -7,7 +7,7 @@ import org.javarosa.xpath.parser.XPathSyntaxException;
 import java.util.Date;
 
 public class XPathNowFunc extends XPathFuncExpr {
-    private static final String NAME = "now";
+    public static final String NAME = "now";
     private static final int EXPECTED_ARG_COUNT = 0;
 
     public XPathNowFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathNumberFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathNumberFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathNumberFunc extends XPathFuncExpr {
-    private static final String NAME = "number";
+    public static final String NAME = "number";
     private static final int EXPECTED_ARG_COUNT = 1;
 
     public XPathNumberFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathPiFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathPiFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathPiFunc extends XPathFuncExpr {
-    private static final String NAME = "pi";
+    public static final String NAME = "pi";
     private static final int EXPECTED_ARG_COUNT = 0;
 
     public XPathPiFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathPositionFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathPositionFunc.java
@@ -10,7 +10,7 @@ import org.javarosa.xpath.XPathTypeMismatchException;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathPositionFunc extends XPathFuncExpr {
-    private static final String NAME = "position";
+    public static final String NAME = "position";
     // 0 or 1 arguments
     private static final int EXPECTED_ARG_COUNT = -1;
 

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathPowFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathPowFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathPowFunc extends XPathFuncExpr {
-    private static final String NAME = "pow";
+    public static final String NAME = "pow";
     private static final int EXPECTED_ARG_COUNT = 2;
 
     public XPathPowFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathRandomFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathRandomFunc.java
@@ -7,7 +7,7 @@ import org.javarosa.xpath.parser.XPathSyntaxException;
 
 // non-standard
 public class XPathRandomFunc extends XPathFuncExpr {
-    private static final String NAME = "random";
+    public static final String NAME = "random";
     private static final int EXPECTED_ARG_COUNT = 0;
 
     public XPathRandomFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathRegexFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathRegexFunc.java
@@ -9,7 +9,7 @@ import me.regexp.RE;
 import me.regexp.RESyntaxException;
 
 public class XPathRegexFunc extends XPathFuncExpr {
-    private static final String NAME = "regex";
+    public static final String NAME = "regex";
     private static final int EXPECTED_ARG_COUNT = 2;
 
     public XPathRegexFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathReplaceFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathReplaceFunc.java
@@ -9,7 +9,7 @@ import me.regexp.RE;
 import me.regexp.RESyntaxException;
 
 public class XPathReplaceFunc extends XPathFuncExpr {
-    private static final String NAME = "replace";
+    public static final String NAME = "replace";
     private static final int EXPECTED_ARG_COUNT = 3;
 
     public XPathReplaceFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathRoundFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathRoundFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathRoundFunc extends XPathFuncExpr {
-    private static final String NAME = "round";
+    public static final String NAME = "round";
     private static final int EXPECTED_ARG_COUNT = 1;
 
     public XPathRoundFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathSelectedAtFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathSelectedAtFunc.java
@@ -7,7 +7,7 @@ import org.javarosa.xpath.XPathException;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathSelectedAtFunc extends XPathFuncExpr {
-    private static final String NAME = "selected-at";
+    public static final String NAME = "selected-at";
     private static final int EXPECTED_ARG_COUNT = 2;
 
     public XPathSelectedAtFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathSelectedFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathSelectedFunc.java
@@ -9,7 +9,7 @@ import org.javarosa.xpath.parser.XPathSyntaxException;
 public class XPathSelectedFunc extends XPathFuncExpr {
     // default to 'selected' but could be 'is-selected'
     // we could also serialize this if we wanted to really preserve it.
-    private static final String NAME = "selected";
+    public static final String NAME = "selected";
     private static final int EXPECTED_ARG_COUNT = 2;
 
     public XPathSelectedFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathSinFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathSinFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathSinFunc extends XPathFuncExpr {
-    private static final String NAME = "sin";
+    public static final String NAME = "sin";
     private static final int EXPECTED_ARG_COUNT = 1;
 
     public XPathSinFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathSqrtFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathSqrtFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathSqrtFunc extends XPathFuncExpr {
-    private static final String NAME = "sqrt";
+    public static final String NAME = "sqrt";
     private static final int EXPECTED_ARG_COUNT = 1;
 
     public XPathSqrtFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathStartsWithFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathStartsWithFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathStartsWithFunc extends XPathFuncExpr {
-    private static final String NAME = "starts-with";
+    public static final String NAME = "starts-with";
     private static final int EXPECTED_ARG_COUNT = 2;
 
     public XPathStartsWithFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathStringFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathStringFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathStringFunc extends XPathFuncExpr {
-    private static final String NAME = "string";
+    public static final String NAME = "string";
     private static final int EXPECTED_ARG_COUNT = 1;
 
     public XPathStringFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathStringLengthFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathStringLengthFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathStringLengthFunc extends XPathFuncExpr {
-    private static final String NAME = "string-length";
+    public static final String NAME = "string-length";
     private static final int EXPECTED_ARG_COUNT = 1;
 
     public XPathStringLengthFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathSubstrFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathSubstrFunc.java
@@ -6,7 +6,7 @@ import org.javarosa.xpath.XPathArityException;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathSubstrFunc extends XPathFuncExpr {
-    private static final String NAME = "substr";
+    public static final String NAME = "substr";
     // 2 or 3 arguments
     private static final int EXPECTED_ARG_COUNT = -1;
 

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathSubstringAfterFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathSubstringAfterFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathSubstringAfterFunc extends XPathFuncExpr {
-    private static final String NAME = "substring-after";
+    public static final String NAME = "substring-after";
     private static final int EXPECTED_ARG_COUNT = 2;
 
     public XPathSubstringAfterFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathSubstringBeforeFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathSubstringBeforeFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathSubstringBeforeFunc extends XPathFuncExpr {
-    private static final String NAME = "substring-before";
+    public static final String NAME = "substring-before";
     private static final int EXPECTED_ARG_COUNT = 2;
 
     public XPathSubstringBeforeFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathSumFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathSumFunc.java
@@ -7,7 +7,7 @@ import org.javarosa.xpath.XPathTypeMismatchException;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathSumFunc extends XPathFuncExpr {
-    private static final String NAME = "sum";
+    public static final String NAME = "sum";
     private static final int EXPECTED_ARG_COUNT = 1;
 
     public XPathSumFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathTanFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathTanFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathTanFunc extends XPathFuncExpr {
-    private static final String NAME = "tan";
+    public static final String NAME = "tan";
     private static final int EXPECTED_ARG_COUNT = 1;
 
     public XPathTanFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathTodayFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathTodayFunc.java
@@ -8,7 +8,7 @@ import org.javarosa.xpath.parser.XPathSyntaxException;
 import java.util.Date;
 
 public class XPathTodayFunc extends XPathFuncExpr {
-    private static final String NAME = "today";
+    public static final String NAME = "today";
     private static final int EXPECTED_ARG_COUNT = 0;
 
     public XPathTodayFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathTranslateFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathTranslateFunc.java
@@ -7,7 +7,7 @@ import org.javarosa.xpath.parser.XPathSyntaxException;
 import java.util.Hashtable;
 
 public class XPathTranslateFunc extends XPathFuncExpr {
-    private static final String NAME = "translate";
+    public static final String NAME = "translate";
     private static final int EXPECTED_ARG_COUNT = 3;
 
     public XPathTranslateFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathTrueFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathTrueFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathTrueFunc extends XPathFuncExpr {
-    private static final String NAME = "true";
+    public static final String NAME = "true";
     private static final int EXPECTED_ARG_COUNT = 0;
 
     public XPathTrueFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathUpperCaseFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathUpperCaseFunc.java
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathUpperCaseFunc extends XPathFuncExpr {
-    private static final String NAME = "upper-case";
+    public static final String NAME = "upper-case";
     private static final int EXPECTED_ARG_COUNT = 1;
 
     public XPathUpperCaseFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathUuidFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathUuidFunc.java
@@ -7,7 +7,7 @@ import org.javarosa.xpath.XPathArityException;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathUuidFunc extends XPathFuncExpr {
-    private static final String NAME = "uuid";
+    public static final String NAME = "uuid";
     // 0 or 1 arguments
     private static final int EXPECTED_ARG_COUNT = -1;
 

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathWeightedChecklistFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathWeightedChecklistFunc.java
@@ -8,7 +8,7 @@ import org.javarosa.xpath.XPathTypeMismatchException;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathWeightedChecklistFunc extends XPathFuncExpr {
-    private static final String NAME = "weighted-checklist";
+    public static final String NAME = "weighted-checklist";
     private static final int EXPECTED_ARG_COUNT = -1;
 
     public XPathWeightedChecklistFunc() {

--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XpathCoalesceFunc.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XpathCoalesceFunc.java
@@ -6,7 +6,7 @@ import org.javarosa.xpath.XPathArityException;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XpathCoalesceFunc extends XPathFuncExpr {
-    private static final String NAME = "coalesce";
+    public static final String NAME = "coalesce";
     // at least 1 argument
     private static final int EXPECTED_ARG_COUNT = -1;
 

--- a/javarosa/src/test/java/org/javarosa/test_utils/ClassLoadUtils.java
+++ b/javarosa/src/test/java/org/javarosa/test_utils/ClassLoadUtils.java
@@ -1,0 +1,89 @@
+package org.javarosa.test_utils;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Modifier;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author Phillip Mates (pmates@dimagi.com)
+ */
+public class ClassLoadUtils {
+
+    /**
+     * Filter classes such that they extend the base class and are not abstract
+     */
+    public static List<Class> classesThatExtend(Set<Class> classes, Class baseClass) {
+        List<Class> filteredClasses = new ArrayList<>();
+        for (Class cls : classes) {
+            if (baseClass.isAssignableFrom(cls)
+                    && !Modifier.isAbstract(cls.getModifiers())) {
+                filteredClasses.add(cls);
+            }
+        }
+        return filteredClasses;
+    }
+
+    /**
+     * Scans all classes accessible from the context class loader which belong
+     * to the given package and subpackages.
+     *
+     * via http://stackoverflow.com/a/862130
+     */
+    public static Set<Class> getClasses(String packageName)
+            throws ClassNotFoundException, IOException, URISyntaxException {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        String path = packageName.replace('.', '/');
+        Enumeration<URL> resources = classLoader.getResources(path);
+        List<File> dirs = new ArrayList<>();
+        while (resources.hasMoreElements()) {
+            URL resource = resources.nextElement();
+            URI uri = new URI(resource.toString());
+            if (uri.getPath() != null) {
+                dirs.add(new File(uri.getPath()));
+            }
+        }
+        Set<Class> classes = new HashSet<>();
+        for (File directory : dirs) {
+            classes.addAll(findClasses(directory, packageName));
+        }
+
+        return classes;
+    }
+
+    /**
+     * Recursive method used to find all classes in a given directory and
+     * subdirs.
+     *
+     * via http://stackoverflow.com/a/862130
+     *
+     * @param directory   The base directory
+     * @param packageName The package name for classes found inside the base directory
+     */
+    private static List<Class> findClasses(File directory, String packageName)
+            throws ClassNotFoundException {
+        List<Class> classes = new ArrayList<>();
+        if (!directory.exists()) {
+            return classes;
+        }
+        File[] files = directory.listFiles();
+        if (files != null) {
+            for (File file : files) {
+                if (file.isDirectory()) {
+                    classes.addAll(findClasses(file, packageName + "." + file.getName()));
+                } else if (file.getName().endsWith(".class")) {
+                    String fileName = file.getName().substring(0, file.getName().length() - 6);
+                    classes.add(Class.forName(packageName + '.' + fileName));
+                }
+            }
+        }
+        return classes;
+    }
+}

--- a/javarosa/src/test/java/org/javarosa/xpath/expr/test/XPathFuncExprTest.java
+++ b/javarosa/src/test/java/org/javarosa/xpath/expr/test/XPathFuncExprTest.java
@@ -151,12 +151,12 @@ public class XPathFuncExprTest {
         // exclude functions defined at runtime
         funcClasses.remove(XPathCustomRuntimeFunc.class);
 
-        HashMap<Class, String> funcList = FunctionUtils.getXPathFuncListMap();
+        HashMap<String, Class> funcList = FunctionUtils.getXPathFuncListMap();
         for (Class c : funcClasses) {
             assertTrue(c + " is not in list of functions, please update it",
-                    funcList.containsKey(c));
+                    funcList.containsValue(c));
         }
-        for (Class c : funcList.keySet()) {
+        for (Class c : funcList.values()) {
             assertTrue(c + " is in the list of functions but no longer exists, please remove it.",
                     funcClasses.contains(c));
         }

--- a/javarosa/src/test/java/org/javarosa/xpath/expr/test/XPathFuncExprTest.java
+++ b/javarosa/src/test/java/org/javarosa/xpath/expr/test/XPathFuncExprTest.java
@@ -16,16 +16,9 @@ import org.javarosa.xpath.parser.XPathSyntaxException;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Modifier;
-import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 

--- a/javarosa/src/test/java/org/javarosa/xpath/expr/test/XPathFuncExprTest.java
+++ b/javarosa/src/test/java/org/javarosa/xpath/expr/test/XPathFuncExprTest.java
@@ -8,6 +8,8 @@ import org.javarosa.test_utils.ExprEvalUtils;
 import org.javarosa.xpath.XPathException;
 import org.javarosa.xpath.XPathParseTool;
 import org.javarosa.xpath.XPathTypeMismatchException;
+import org.javarosa.xpath.expr.FunctionUtils;
+import org.javarosa.xpath.expr.XPathFuncExpr;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 import org.junit.Assert;
 import org.junit.Test;
@@ -119,5 +121,12 @@ public class XPathFuncExprTest {
             didParseFail = true;
         }
         assertTrue(didParseFail);
+    }
+    @Test
+    public void funcListTest() {
+        Class<?>[] classes = XPathFuncExprTest.class.getClasses();
+        for (Class c : classes) {
+            assertTrue(FunctionUtils.funcList.containsKey(c));
+        }
     }
 }


### PR DESCRIPTION
Exposes method that returns a list of all the hard coded XPath functions (i.e. `sin, uuid, date, substring,...`)

For use in Form Player to allow for auto-completing text entry.

The list is hard-coded because I don't like reflection but includes tests that ensure the list is kept up-to-date if functions are added or deleted.

cc @benrudolph 

contains commits from https://github.com/dimagi/commcare-core/pull/443