### PR TITLE
Fix session state... again

### DIFF
--- a/backend/src/org/commcare/session/CommCareSession.java
+++ b/backend/src/org/commcare/session/CommCareSession.java
@@ -425,7 +425,11 @@ public class CommCareSession {
     }
 
     public void setDatum(String keyId, String value) {
-        frame.pushStep(new StackFrameStep(SessionFrame.STATE_DATUM_VAL, keyId, value));
+        setDatum(SessionFrame.STATE_DATUM_VAL, keyId, value);
+    }
+
+    public void setDatum(String action, String keyId, String value) {
+        frame.pushStep(new StackFrameStep(action, keyId, value));
         syncState();
     }
 

--- a/backend/src/org/commcare/session/CommCareSession.java
+++ b/backend/src/org/commcare/session/CommCareSession.java
@@ -481,6 +481,7 @@ public class CommCareSession {
 
         for (StackFrameStep step : frame.getSteps()) {
             if (SessionFrame.STATE_DATUM_VAL.equals(step.getType()) ||
+                    SessionFrame.STATE_DATUM_COMPUTED.equals(step.getType()) ||
                     SessionFrame.STATE_UNKNOWN.equals(step.getType()) &&
                             (guessUnknownType(step).equals(SessionFrame.STATE_DATUM_COMPUTED)
                             || guessUnknownType(step).equals(SessionFrame.STATE_DATUM_VAL))) {

--- a/backend/src/org/commcare/session/SessionDescriptorUtil.java
+++ b/backend/src/org/commcare/session/SessionDescriptorUtil.java
@@ -18,7 +18,7 @@ public class SessionDescriptorUtil {
             } else if (action.equals(SessionFrame.STATE_DATUM_VAL) ||
                     action.equals(SessionFrame.STATE_DATUM_COMPUTED) ||
                     action.equals(SessionFrame.STATE_UNKNOWN)) {
-                session.setDatum(tokenStream[++current], tokenStream[++current]);
+                session.setDatum(action, tokenStream[++current], tokenStream[++current]);
             }
             current++;
         }

--- a/tests/test/org/commcare/backend/session/test/StackRegressionTests.java
+++ b/tests/test/org/commcare/backend/session/test/StackRegressionTests.java
@@ -34,4 +34,17 @@ public class StackRegressionTests {
         blankSession.stepBack();
         assertEquals(SessionFrame.STATE_COMMAND_ID, blankSession.getNeededData());
     }
+
+    @Test
+    public void testKeepComputedDatum() throws Exception {
+        MockApp mockApp = new MockApp("/nav_back/");
+        SessionWrapper session = mockApp.getSession();
+        UserSandbox sandbox = session.getSandbox();
+        SessionWrapper blankSession = new SessionWrapper(session.getPlatform(), sandbox);
+        String descriptor = "COMMAND_ID m0-f0 " +
+                "COMPUTED_DATUM case_id_new_mother_0 test_id " +
+                "COMPUTED_DATUM return_to m1";
+        SessionDescriptorUtil.loadSessionFromDescriptor(descriptor, blankSession);
+        assertEquals(2, blankSession.getData().size());
+    }
 }


### PR DESCRIPTION
This issue just reared its head again, this time in caught by a Formplayer end of form navigation test. I think what's happening is that the "return_to" session datum wasn't being added as a collectedDatum because its not a STATE_DATUM_VAL or STATE_UNKNOWN (its a STATE_DATUM_COMPUTED). I'm surprised this hasn't come up elsewhere, but I feel that way every time I "fix" a "bug" in this part of the code. 