### PR TITLE
CommCareConfigurationEngine refactor

### DIFF
--- a/api/org/commcare/api/persistence/JdbcSqlStorageIterator.java
+++ b/api/org/commcare/api/persistence/JdbcSqlStorageIterator.java
@@ -19,7 +19,6 @@ public class JdbcSqlStorageIterator<E extends Persistable> implements IStorageIt
     private int count = -1;
     private final SqliteIndexedStorageUtility<E> storage;
     private Connection connection;
-    private IStorageIterator<E> backingIterator;
 
     public JdbcSqlStorageIterator(PreparedStatement preparedStatement,
                                   ResultSet resultSet,

--- a/api/org/commcare/api/persistence/JdbcSqlStorageIterator.java
+++ b/api/org/commcare/api/persistence/JdbcSqlStorageIterator.java
@@ -19,6 +19,7 @@ public class JdbcSqlStorageIterator<E extends Persistable> implements IStorageIt
     private int count = -1;
     private final SqliteIndexedStorageUtility<E> storage;
     private Connection connection;
+    private IStorageIterator<E> backingIterator;
 
     public JdbcSqlStorageIterator(PreparedStatement preparedStatement,
                                   ResultSet resultSet,

--- a/api/org/commcare/api/persistence/SqliteIndexedStorageUtility.java
+++ b/api/org/commcare/api/persistence/SqliteIndexedStorageUtility.java
@@ -47,6 +47,7 @@ public class SqliteIndexedStorageUtility<T extends Persistable> implements IStor
         try {
             c = getConnection();
             SqlHelper.createTable(c, tableName, prototype.newInstance());
+            c.prepareStatement("PRAGMA journal_mode=WAL;").execute();
             c.close();
         } catch (SQLException e) {
             e.printStackTrace();

--- a/api/org/commcare/api/persistence/SqliteIndexedStorageUtility.java
+++ b/api/org/commcare/api/persistence/SqliteIndexedStorageUtility.java
@@ -47,6 +47,7 @@ public class SqliteIndexedStorageUtility<T extends Persistable> implements IStor
         try {
             c = getConnection();
             SqlHelper.createTable(c, tableName, prototype.newInstance());
+            // This enables concurrent reads and writes, needed for updates
             c.prepareStatement("PRAGMA journal_mode=WAL;").execute();
             c.close();
         } catch (SQLException e) {

--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ sourceSets {
         java {
             srcDir 'api'
             srcDir 'util/src/org/commcare/util/screen'
+            srcDir 'util/src/org/commcare/util/engine'
             compileClasspath += main.output
         }
     }

--- a/javarosa/src/main/java/org/javarosa/core/services/storage/IStorageIndexedFactory.java
+++ b/javarosa/src/main/java/org/javarosa/core/services/storage/IStorageIndexedFactory.java
@@ -1,0 +1,5 @@
+package org.javarosa.core.services.storage;
+
+public interface IStorageIndexedFactory extends IStorageFactory {
+    IStorageUtilityIndexed newStorage(String name, Class type);
+}

--- a/tests/test/org/commcare/backend/suite/model/test/ProfileTests.java
+++ b/tests/test/org/commcare/backend/suite/model/test/ProfileTests.java
@@ -4,7 +4,7 @@ import org.commcare.resources.model.Resource;
 import org.commcare.resources.model.ResourceTable;
 import org.commcare.suite.model.Profile;
 import org.commcare.test.utilities.PersistableSandbox;
-import org.commcare.util.CommCareConfigEngine;
+import org.commcare.util.engine.CommCareConfigEngine;
 import org.commcare.xml.ProfileParser;
 import org.javarosa.core.services.storage.util.DummyIndexedStorageUtility;
 import org.javarosa.core.util.ArrayUtilities;

--- a/tests/test/org/commcare/test/utilities/MockApp.java
+++ b/tests/test/org/commcare/test/utilities/MockApp.java
@@ -38,6 +38,12 @@ public class MockApp {
         }
         APP_BASE = resourcePath;
         final LivePrototypeFactory mPrototypeFactory = setupStaticStorage();
+        CommCareConfigEngine.setStorageFactory(new IStorageIndexedFactory() {
+            @Override
+            public IStorageUtilityIndexed newStorage(String name, Class type) {
+                return new DummyIndexedStorageUtility(type, mPrototypeFactory);
+            }
+        });
         MockUserDataSandbox mSandbox = new MockUserDataSandbox(mPrototypeFactory);
         CommCareConfigEngine mEngine = new CommCareConfigEngine(mPrototypeFactory);
 

--- a/tests/test/org/commcare/test/utilities/MockApp.java
+++ b/tests/test/org/commcare/test/utilities/MockApp.java
@@ -2,7 +2,7 @@ package org.commcare.test.utilities;
 
 import org.commcare.modern.session.SessionWrapper;
 import org.commcare.core.parse.ParseUtils;
-import org.commcare.util.CommCareConfigEngine;
+import org.commcare.util.engine.CommCareConfigEngine;
 import org.commcare.util.mocks.MockUserDataSandbox;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.FormIndex;

--- a/tests/test/org/commcare/test/utilities/MockApp.java
+++ b/tests/test/org/commcare/test/utilities/MockApp.java
@@ -6,6 +6,9 @@ import org.commcare.util.engine.CommCareConfigEngine;
 import org.commcare.util.mocks.MockUserDataSandbox;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.FormIndex;
+import org.javarosa.core.services.storage.IStorageIndexedFactory;
+import org.javarosa.core.services.storage.IStorageUtilityIndexed;
+import org.javarosa.core.services.storage.util.DummyIndexedStorageUtility;
 import org.javarosa.core.test.FormParseInit;
 import org.javarosa.core.util.externalizable.LivePrototypeFactory;
 import org.javarosa.form.api.FormEntryController;
@@ -34,7 +37,7 @@ public class MockApp {
             throw new IllegalArgumentException("Invalid resource path for a mock app " + resourcePath);
         }
         APP_BASE = resourcePath;
-        LivePrototypeFactory mPrototypeFactory = setupStaticStorage();
+        final LivePrototypeFactory mPrototypeFactory = setupStaticStorage();
         MockUserDataSandbox mSandbox = new MockUserDataSandbox(mPrototypeFactory);
         CommCareConfigEngine mEngine = new CommCareConfigEngine(mPrototypeFactory);
 

--- a/util/src/org/commcare/util/cli/ApplicationHost.java
+++ b/util/src/org/commcare/util/cli/ApplicationHost.java
@@ -7,7 +7,7 @@ import org.commcare.data.xml.DataModelPullParser;
 import org.commcare.suite.model.FormIdDatum;
 import org.commcare.suite.model.SessionDatum;
 import org.commcare.suite.model.StackFrameStep;
-import org.commcare.util.CommCareConfigEngine;
+import org.commcare.util.engine.CommCareConfigEngine;
 import org.commcare.util.CommCarePlatform;
 import org.commcare.session.SessionFrame;
 import org.commcare.util.mocks.CLISessionWrapper;

--- a/util/src/org/commcare/util/cli/CliCommand.java
+++ b/util/src/org/commcare/util/cli/CliCommand.java
@@ -7,7 +7,7 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.commcare.util.CommCareConfigEngine;
+import org.commcare.util.engine.CommCareConfigEngine;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 
 public abstract class CliCommand {

--- a/util/src/org/commcare/util/cli/CliPlayCommand.java
+++ b/util/src/org/commcare/util/cli/CliPlayCommand.java
@@ -3,7 +3,7 @@ package org.commcare.util.cli;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.commcare.util.CommCareConfigEngine;
+import org.commcare.util.engine.CommCareConfigEngine;
 import org.javarosa.core.util.externalizable.LivePrototypeFactory;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 

--- a/util/src/org/commcare/util/cli/CliValidateCommand.java
+++ b/util/src/org/commcare/util/cli/CliValidateCommand.java
@@ -1,7 +1,7 @@
 package org.commcare.util.cli;
 
 import org.apache.commons.cli.ParseException;
-import org.commcare.util.CommCareConfigEngine;
+import org.commcare.util.engine.CommCareConfigEngine;
 import org.javarosa.core.util.externalizable.LivePrototypeFactory;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 

--- a/util/src/org/commcare/util/engine/CommCareConfigEngine.java
+++ b/util/src/org/commcare/util/engine/CommCareConfigEngine.java
@@ -1,4 +1,4 @@
-package org.commcare.util;
+package org.commcare.util.engine;
 
 import org.commcare.modern.reference.ArchiveFileRoot;
 import org.commcare.modern.reference.JavaFileRoot;
@@ -20,6 +20,7 @@ import org.commcare.suite.model.Profile;
 import org.commcare.suite.model.PropertySetter;
 import org.commcare.suite.model.SessionDatum;
 import org.commcare.suite.model.Suite;
+import org.commcare.util.CommCarePlatform;
 import org.javarosa.core.io.BufferedInputStream;
 import org.javarosa.core.io.StreamsUtil;
 import org.javarosa.core.model.FormDef;
@@ -54,12 +55,12 @@ import java.util.zip.ZipFile;
  * @author ctsims
  */
 public class CommCareConfigEngine {
-    private final ResourceTable table;
-    private final ResourceTable updateTable;
-    private final ResourceTable recoveryTable;
-    private final PrintStream print;
-    private final CommCarePlatform platform;
+    protected ResourceTable table;
+    protected ResourceTable updateTable;
+    protected ResourceTable recoveryTable;
+    protected CommCarePlatform platform;
     private final PrototypeFactory mLiveFactory;
+    private final PrintStream print;
 
     private ArchiveFileRoot mArchiveRoot;
 
@@ -102,7 +103,7 @@ public class CommCareConfigEngine {
         StorageManager.registerStorage(OfflineUserRestore.STORAGE_KEY, OfflineUserRestore.class);
     }
 
-    private void setRoots() {
+    protected void setRoots() {
         ReferenceManager.instance().addReferenceFactory(new JavaHttpRoot());
 
         this.mArchiveRoot = new ArchiveFileRoot();
@@ -124,7 +125,6 @@ public class CommCareConfigEngine {
         } catch (IOException e) {
             print.println("File at " + archiveURL + ": is not a valid CommCare Package. Downloaded to: " + fileName);
             e.printStackTrace(print);
-            System.exit(-1);
             return;
         }
         String archiveGUID = this.mArchiveRoot.addArchiveFile(zip);

--- a/util/src/org/commcare/util/engine/CommCareConfigEngine.java
+++ b/util/src/org/commcare/util/engine/CommCareConfigEngine.java
@@ -28,6 +28,7 @@ import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.reference.ResourceReferenceFactory;
+import org.javarosa.core.services.PropertyManager;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.services.storage.*;
 import org.javarosa.core.services.storage.util.DummyIndexedStorageUtility;
@@ -92,7 +93,7 @@ public class CommCareConfigEngine {
         //per device.
         StorageManager.forceClear();
         StorageManager.setStorageFactory(storageFactory);
-
+        PropertyManager.initDefaultPropertyManager();
         StorageManager.registerStorage(Profile.STORAGE_KEY, Profile.class);
         StorageManager.registerStorage(Suite.STORAGE_KEY, Suite.class);
         StorageManager.registerStorage(FormDef.STORAGE_KEY, FormDef.class);

--- a/util/src/org/commcare/util/engine/CommCareConfigEngine.java
+++ b/util/src/org/commcare/util/engine/CommCareConfigEngine.java
@@ -53,11 +53,11 @@ import java.util.zip.ZipFile;
  * @author ctsims
  */
 public class CommCareConfigEngine {
-    protected ResourceTable table;
-    protected ResourceTable updateTable;
-    protected ResourceTable recoveryTable;
-    protected CommCarePlatform platform;
-    private final PrototypeFactory mLiveFactory;
+    private final ResourceTable table;
+    private final ResourceTable updateTable;
+    private final ResourceTable recoveryTable;
+    private final CommCarePlatform platform;
+    private final PrototypeFactory liveFactory;
     private final PrintStream print;
 
     private ArchiveFileRoot mArchiveRoot;
@@ -75,7 +75,7 @@ public class CommCareConfigEngine {
     public CommCareConfigEngine(OutputStream output, PrototypeFactory prototypeFactory) {
         this.print = new PrintStream(output);
         this.platform = new CommCarePlatform(2, 32);
-        this.mLiveFactory = prototypeFactory;
+        this.liveFactory = prototypeFactory;
 
         if (storageFactory == null) {
             setupDummyStorageFactory();
@@ -105,7 +105,7 @@ public class CommCareConfigEngine {
         CommCareConfigEngine.setStorageFactory(new IStorageIndexedFactory() {
             @Override
             public IStorageUtilityIndexed newStorage(String name, Class type) {
-                return new DummyIndexedStorageUtility(type, mLiveFactory);
+                return new DummyIndexedStorageUtility(type, liveFactory);
             }
         });
     }


### PR DESCRIPTION
1. Move configuration engine into separate package
2. Implement Factory pattern to allow overriding the storage layer
3. Allow concurrent reads in SQLite DBs