### PR TITLE
Provide more specific app upgrade failure stacktraces

### DIFF
--- a/backend/src/org/commcare/resources/ResourceManager.java
+++ b/backend/src/org/commcare/resources/ResourceManager.java
@@ -183,9 +183,9 @@ public class ResourceManager {
                 Logger.log("Resource", "Upgrade table fetched, beginning upgrade");
 
                 // Try to stage the upgrade table to replace the incoming table
-                if (!masterTable.upgradeTable(upgradeTable)) {
-                    throw new RuntimeException("global table failed to upgrade!");
-                } else if (upgradeTable.getTableReadiness() != ResourceTable.RESOURCE_TABLE_INSTALLED) {
+                masterTable.upgradeTable(upgradeTable);
+
+                if (upgradeTable.getTableReadiness() != ResourceTable.RESOURCE_TABLE_INSTALLED) {
                     throw new RuntimeException("not all incoming resources were installed!!");
                 } else {
                     Logger.log("Resource", "Global table unstaged, upgrade table ready");

--- a/backend/src/org/commcare/resources/model/ResourceTable.java
+++ b/backend/src/org/commcare/resources/model/ResourceTable.java
@@ -289,7 +289,7 @@ public class ResourceTable {
      * installed?
      */
     public boolean isReady() {
-        return getUnreadyResources().size() == 0;
+        return getUnreadyResources().isEmpty();
     }
 
     public void commitCompoundResource(Resource r, int status, int version)
@@ -635,13 +635,10 @@ public class ResourceTable {
      * relevant.
      *
      * @param incoming Table for which resource upgrades are applied
-     * @return True if this table was prepared and the incoming table can be
-     * fully installed. False if something is this table couldn't be unstaged.
-     * @throws UnresolvedResourceException
      */
-    public boolean upgradeTable(ResourceTable incoming) throws UnresolvedResourceException {
+    public void upgradeTable(ResourceTable incoming) throws UnresolvedResourceException {
         if (!incoming.isReady()) {
-            return false;
+            throw new RuntimeException("Incoming table is not ready to be upgraded");
         }
 
         // Everything incoming should be marked either ready or upgrade.
@@ -677,7 +674,7 @@ public class ResourceTable {
                             Logger.log("Resource",
                                     "Failed to upgrade resource: " + r.getDescriptor());
                             // REVERT!
-                            return false;
+                            throw new RuntimeException("Failed to upgrade resource " + r.getDescriptor());
                         }
                     }
                 }
@@ -686,8 +683,6 @@ public class ResourceTable {
                 // resource locations could change
             }
         }
-
-        return true;
     }
 
     /**

--- a/javarosa/src/main/java/org/javarosa/core/reference/ReferenceDataSource.java
+++ b/javarosa/src/main/java/org/javarosa/core/reference/ReferenceDataSource.java
@@ -19,20 +19,17 @@ import java.util.Hashtable;
  */
 public class ReferenceDataSource implements LocaleDataSource {
 
-    String referenceURI;
+    private String referenceURI;
 
-    /**
-     * NOTE: FOR SERIALIZATION ONLY!
-     */
+    @SuppressWarnings("unused")
     public ReferenceDataSource() {
-
+        // for serialization
     }
 
     /**
      * Creates a new Data Source for Locale data with the given resource URI.
      *
      * @param referenceURI URI to the resource file from which data should be loaded
-     * @throws NullPointerException if resourceURI is null
      */
     public ReferenceDataSource(String referenceURI) {
         if (referenceURI == null) {


### PR DESCRIPTION
Been seeing a lot of upgrade failures with the following unhelpful stacktrace. This PR updates where we throw errors to get a little more context on why this failure is occurring.

```
java.lang.RuntimeException: global table failed to upgrade!
at org.commcare.resources.ResourceManager.upgrade(ResourceManager.java:187)
at org.commcare.tasks.InstallStagedUpdateTask.installStagedUpdate(InstallStagedUpdateTask.java:44)
at org.commcare.tasks.InstallStagedUpdateTask.doTaskBackground(InstallStagedUpdateTask.java:27)
at org.commcare.tasks.InstallStagedUpdateTask.doTaskBackground(InstallStagedUpdateTask.java:17)
at org.commcare.tasks.templates.CommCareTask.doInBackground(CommCareTask.java:38)
```

cross-request: https://github.com/dimagi/commcare-android/pull/1575