### PR TITLE
New XPath Function Handlers crash out with blank args

### DIFF
--- a/javarosa/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/javarosa/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -56,10 +56,10 @@ public abstract class XPathFuncExpr extends XPathExpression {
     }
 
     private void evaluateArguments(DataInstance model, EvaluationContext evalContext) {
+        if (evaluatedArgs == null) {
+            evaluatedArgs = new Object[args.length];
+        }
         if (evaluateArgsFirst) {
-            if (evaluatedArgs == null) {
-                evaluatedArgs = new Object[args.length];
-            }
             for (int i = 0; i < args.length; i++) {
                 evaluatedArgs[i] = args[i].eval(model, evalContext);
             }

--- a/javarosa/src/test/java/org/javarosa/xpath/test/XPathEvalTest.java
+++ b/javarosa/src/test/java/org/javarosa/xpath/test/XPathEvalTest.java
@@ -603,6 +603,33 @@ public class XPathEvalTest {
                 XPathEqExpr.testEquality(dbl, "100E5"));
     }
 
+    @Test
+    public void testOverrideNow() {
+        EvaluationContext ec = new EvaluationContext(null);
+
+        ec.addFunctionHandler(new IFunctionHandler() {
+            public String getName() {
+              return "now";
+            }
+
+            public Vector getPrototypes() {
+              Vector p = new Vector();
+              p.addElement(new Class[0]);
+              return p;
+            }
+
+            public boolean rawArgs() {
+              return false;
+            }
+
+            public Object eval(Object[] args, EvaluationContext ec) {
+              return "pass";
+            }
+        });
+
+        testEval("now()", null, ec, "pass");
+    }
+
     protected void addDataRef(FormInstance dm, String ref, IAnswerData data) {
         TreeReference treeRef = XPathReference.getPathExpr(ref).getReference();
         treeRef = inlinePositionArgs(treeRef);


### PR DESCRIPTION
Adding custom functions seems to work fine, adding custom functions to override methods with no arguments seems to crash. Added test which illustrates and should pass when fixed. Didn't quite have time to dig in to what was up, so assigning over to @phillipm , since he wrote the substem.

Note: Prevents form entry from working in CLI