### PR TITLE
Don't confuse union with intersection... again

### DIFF
--- a/cases/src/org/commcare/cases/util/StorageBackedTreeRoot.java
+++ b/cases/src/org/commcare/cases/util/StorageBackedTreeRoot.java
@@ -30,10 +30,6 @@ public abstract class StorageBackedTreeRoot<T extends AbstractTreeElement> imple
 
     protected abstract IStorageUtilityIndexed<?> getStorage();
 
-    protected Vector<Integer> union(Vector<Integer> selectedCases, Vector<Integer> cases) {
-        return DataUtil.intersection(selectedCases, cases);
-    }
-
     protected abstract void initStorageCache();
 
     protected String translateFilterExpr(XPathPathExpr expressionTemplate, XPathPathExpr matchingExpr, Hashtable<XPathPathExpr, String> indices) {
@@ -154,7 +150,7 @@ public abstract class StorageBackedTreeRoot<T extends AbstractTreeElement> imple
                 if (selectedElements == null) {
                     selectedElements = cases;
                 } else {
-                    selectedElements = union(selectedElements, cases);
+                    selectedElements = DataUtil.intersection(selectedElements, cases);
                 }
             }
 


### PR DESCRIPTION
Follow-up to https://github.com/dimagi/commcare-core/pull/321

Turns out I left the code such that a method named `union` called a method named `intersection`, not confusing at all...

cross-request: https://github.com/dimagi/commcare-android/pull/1584