### PR TITLE
2.32.0 Backport: Fixture reference caching bugfix

### DIFF
--- a/core/org/commcare/core/process/CommCareInstanceInitializer.java
+++ b/core/org/commcare/core/process/CommCareInstanceInitializer.java
@@ -115,16 +115,18 @@ public class CommCareInstanceInitializer extends InstanceInitializationFactory {
             userId = u.getUniqueId();
         }
 
-        TreeElement fixtureRoot = loadFixtureRoot(ref, userId);
+        TreeElement fixtureRoot = loadFixtureRoot(instance, ref, userId);
         fixtureRoot.setParent(instance.getBase());
         return fixtureRoot;
     }
 
-    protected TreeElement loadFixtureRoot(String reference, String userId) {
+    protected TreeElement loadFixtureRoot(ExternalDataInstance instance, String reference, String userId) {
         String refId = reference.substring(reference.lastIndexOf('/') + 1, reference.length());
+        String instanceBase = instance.getBase().getInstanceName();
 
         try {
-            String key = refId + userId;
+
+            String key = refId + userId + instanceBase;
 
             TreeElement root = fixtureBases.retrieve(key);
             if (root == null) {

--- a/tests/resources/mixed_instance_initializers/README
+++ b/tests/resources/mixed_instance_initializers/README
@@ -1,0 +1,3 @@
+This set of resources is a fully contained application and user setup which you can copy as a template for easily testing different applicaton structures and functions. 
+
+Don't write tests directly against this app, copy it first into another directory

--- a/tests/resources/mixed_instance_initializers/form_placeholder.xml
+++ b/tests/resources/mixed_instance_initializers/form_placeholder.xml
@@ -1,0 +1,21 @@
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Placeholder Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://commcarehq.org/test/placeholder" uiVersion="1" version="1" name="Placeholder">
+					<item/>
+					<value/>
+				</data>
+			</instance>
+			<instance id="data-list-key-two" src="jr://fixture/data-list"/>
+
+			<setvalue event="xforms-ready" ref="/data/value" value="instance('data-list-key-two')/list/item[@id ='1' and true()]"/>
+		</model>
+	</h:head>
+	<h:body>
+		<input ref="/data/item">
+			<label><output ref="/data/value"/></label>
+		</input>
+	</h:body>
+</h:html>

--- a/tests/resources/mixed_instance_initializers/profile.ccpr
+++ b/tests/resources/mixed_instance_initializers/profile.ccpr
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<profile version="1"
+         requiredMajor="2"
+         requiredMinor="22"
+         uniqueid="id"
+         update=""
+         name="trivial_test_resources"
+         descriptor="Profile">
+
+
+    <suite><resource id="suite" version="1">
+            <location authority="local">./suite.xml</location>
+    </resource></suite>
+</profile>

--- a/tests/resources/mixed_instance_initializers/suite.xml
+++ b/tests/resources/mixed_instance_initializers/suite.xml
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<suite version="1" descriptor="Suite File">
+  <xform>
+    <resource id="546d5695ad31d060faac835fea2bc436810c81f9" version="1" descriptor="Form: Placeholder">
+      <location authority="local">./form_placeholder.xml</location>
+    </resource>
+  </xform>
+
+  <detail id="m0_short">
+    <title>
+      <text>List</text>
+    </title>
+    <field>
+      <header>
+        <text>Name</text>
+      </header>
+      <template>
+        <text>
+          <xpath function="."/>
+        </text>
+      </template>
+    </field>
+  </detail>
+  <entry>
+    <form>http://commcarehq.org/test/placeholder</form>
+    <command id="m0-f0">
+      <text>Form</text>
+    </command>
+    <instance id="data-list-key-one" src="jr://fixture/data-list"/>
+    <session>
+      <datum id="selected_item" function="instance('data-list-key-one')/list/item[@id ='1' and true()]/@id"/>
+    </session>
+  </entry>
+  <menu id="m0">
+    <text>Menu</text>
+    <command id="m0-f0"/>
+  </menu>
+</suite>

--- a/tests/resources/mixed_instance_initializers/user_restore.xml
+++ b/tests/resources/mixed_instance_initializers/user_restore.xml
@@ -1,0 +1,21 @@
+<OpenRosaResponse>
+	<message nature="ota_restore_success">Successfully restored account test!</message>
+	<Sync xmlns="http://commcarehq.org/sync">
+		<restore_id>sync_token</restore_id>
+	</Sync>
+	<Registration xmlns="http://openrosa.org/user/registration">
+		<username>test</username>
+		<password>sha1$60441$53cf77c2ac3608a944db96af177a6dfe1579e4ba</password>
+		<uuid>test_uuid</uuid>
+		<date>2012-04-30</date>
+	</Registration>
+	<fixture id="data-list" user_id="test_uuid">
+		<list>
+			<item id="1">one</item>
+			<item id="2">two</item>
+			<item id="3">three</item>
+			<item id="4">four</item>
+	</list>
+	</fixture>
+
+</OpenRosaResponse>

--- a/tests/test/org/commcare/backend/session/test/InstanceEvaluationTests.java
+++ b/tests/test/org/commcare/backend/session/test/InstanceEvaluationTests.java
@@ -1,9 +1,6 @@
 package org.commcare.backend.session.test;
 
-import org.commcare.core.interfaces.UserSandbox;
 import org.commcare.modern.session.SessionWrapper;
-import org.commcare.session.SessionDescriptorUtil;
-import org.commcare.session.SessionFrame;
 import org.commcare.session.SessionNavigator;
 import org.commcare.test.utilities.MockApp;
 import org.commcare.test.utilities.MockSessionNavigationResponder;
@@ -12,23 +9,20 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-
 /**
  * Created by ctsims on 12/2/2016
  */
-
 public class InstanceEvaluationTests {
 
     private MockApp mApp;
-    private MockSessionNavigationResponder mSessionNavigationResponder;
     private SessionNavigator sessionNavigator;
 
     @Before
     public void setUp() throws Exception {
         mApp = new MockApp("/mixed_instance_initializers/");
-        mSessionNavigationResponder = new MockSessionNavigationResponder(mApp.getSession());
-        sessionNavigator = new SessionNavigator(mSessionNavigationResponder);
+        MockSessionNavigationResponder mockSessionNavigationResponder =
+                new MockSessionNavigationResponder(mApp.getSession());
+        sessionNavigator = new SessionNavigator(mockSessionNavigationResponder);
         mApp.getSession().clearVolitiles();
     }
 
@@ -55,6 +49,6 @@ public class InstanceEvaluationTests {
 
         fec.stepToNextEvent();
 
-        Assert.assertEquals("one",fec.getQuestionPrompts()[0].getQuestionText());
+        Assert.assertEquals("one", fec.getQuestionPrompts()[0].getQuestionText());
     }
 }

--- a/tests/test/org/commcare/backend/session/test/InstanceEvaluationTests.java
+++ b/tests/test/org/commcare/backend/session/test/InstanceEvaluationTests.java
@@ -1,0 +1,60 @@
+package org.commcare.backend.session.test;
+
+import org.commcare.core.interfaces.UserSandbox;
+import org.commcare.modern.session.SessionWrapper;
+import org.commcare.session.SessionDescriptorUtil;
+import org.commcare.session.SessionFrame;
+import org.commcare.session.SessionNavigator;
+import org.commcare.test.utilities.MockApp;
+import org.commcare.test.utilities.MockSessionNavigationResponder;
+import org.javarosa.form.api.FormEntryController;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by ctsims on 12/2/2016
+ */
+
+public class InstanceEvaluationTests {
+
+    private MockApp mApp;
+    private MockSessionNavigationResponder mSessionNavigationResponder;
+    private SessionNavigator sessionNavigator;
+
+    @Before
+    public void setUp() throws Exception {
+        mApp = new MockApp("/mixed_instance_initializers/");
+        mSessionNavigationResponder = new MockSessionNavigationResponder(mApp.getSession());
+        sessionNavigator = new SessionNavigator(mSessionNavigationResponder);
+        mApp.getSession().clearVolitiles();
+    }
+
+    /**
+     * Testing cases where instances are used with different ID's in multiple contexts
+     */
+    @Test
+    public void testMixedInstanceIdCaching() throws Exception {
+        SessionWrapper session = mApp.getSession();
+
+        sessionNavigator.startNextSessionStep();
+
+        session.setCommand("m0");
+
+        sessionNavigator.startNextSessionStep();
+
+        session.setCommand("m0-f0");
+
+        sessionNavigator.startNextSessionStep();
+
+        FormEntryController fec = mApp.loadAndInitForm("form_placeholder.xml");
+
+        Assert.assertTrue(fec.getModel().getEvent() == FormEntryController.EVENT_BEGINNING_OF_FORM);
+
+        fec.stepToNextEvent();
+
+        Assert.assertEquals("one",fec.getQuestionPrompts()[0].getQuestionText());
+    }
+}

--- a/tests/test/org/commcare/test/utilities/MockApp.java
+++ b/tests/test/org/commcare/test/utilities/MockApp.java
@@ -61,7 +61,7 @@ public class MockApp {
      * Loads the provided form and properly initializes external data instances,
      * such as the casedb and commcare session.
      */
-    public FormParseInit loadAndInitForm(String formFileInApp) {
+    public FormEntryController loadAndInitForm(String formFileInApp) {
         FormParseInit fpi = new FormParseInit(APP_BASE + formFileInApp);
         FormEntryController fec = fpi.getFormEntryController();
         fec.jumpToIndex(FormIndex.createBeginningOfFormIndex());
@@ -70,7 +70,7 @@ public class MockApp {
         // run initialization to ensure xforms-ready event and binds are
         // triggered.
         fd.initialize(true, mSessionWrapper.getIIF());
-        return fpi;
+        return fec;
     }
 
 


### PR DESCRIPTION
Fix for odd caching bug when different ids are used in fixture evaluation