### PR TITLE
Fix commcare-android test failures after code reorg

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -145,11 +145,12 @@ task harnessJar(type: Jar, dependsOn: translateClasses) {
     }
 }
 
-// used to provide the test source files to external projects, such as odk,
+// used to provide the test source files to external projects, such as commcare-android,
 // which might want to import classes
 task testsrcJar(type: Jar, dependsOn: testClasses) {
     classifier = 'tests'
     from files(sourceSets.test.output.classesDir)
+    from files(sourceSets.cli.output.classesDir)
 }
 
 


### PR DESCRIPTION
Seeing a test failure when running commcare-android tests (only from the command line) due to code in the `cli` sourceset not being present in test jar used by commcare-android.

Issue came up after https://github.com/dimagi/commcare-core/pull/478 was merged