### PR TITLE
TreeReference hash collision regression

### DIFF
--- a/src/test/java/org/javarosa/core/model/instance/test/TreeElementTests.java
+++ b/src/test/java/org/javarosa/core/model/instance/test/TreeElementTests.java
@@ -1,0 +1,36 @@
+package org.javarosa.core.model.instance.test;
+
+import org.javarosa.core.model.instance.TreeElement;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests the functionality of TreeElements
+ */
+
+public class TreeElementTests {
+
+    TreeElement element;
+    TreeElement childOne;
+    TreeElement childTwo;
+    @Before
+    public void setup() {
+        element = new TreeElement("root");
+        childOne = new TreeElement("H2a");
+        childTwo = new TreeElement("H3B");
+
+        element.addChild(childOne);
+        element.addChild(childTwo);
+    }
+
+    @Test
+    public void testHashCollision() {
+        // childOne and childTwo should have the same hash, but still resolve correctly
+        TreeElement getOne = element.getChild("H2a", 0);
+        TreeElement getTwo = element.getChild("H3B", 0);
+        assertEquals(childOne, getOne);
+        assertEquals(childTwo, getTwo);
+    }
+}

--- a/src/test/java/org/javarosa/core/model/test/TreeReferenceTest.java
+++ b/src/test/java/org/javarosa/core/model/test/TreeReferenceTest.java
@@ -47,6 +47,8 @@ public class TreeReferenceTest {
     private TreeReference acPredNotRef;
     private Vector<XPathExpression> apreds;
 
+    private TreeReference h2aRef;
+    private TreeReference h3BRef;
 
     @Before
     public void initStuff() {
@@ -58,6 +60,9 @@ public class TreeReferenceTest {
 
         acdRef = acRef.extendRef("d", TreeReference.DEFAULT_MUTLIPLICITY);
         aceRef = acRef.extendRef("e", TreeReference.DEFAULT_MUTLIPLICITY);
+
+        h2aRef = root.extendRef("H2a", TreeReference.DEFAULT_MUTLIPLICITY);
+        h3BRef = root.extendRef("H3B", TreeReference.DEFAULT_MUTLIPLICITY);
 
         abcRef = XPathReference.getPathExpr("/a/b/c").getReference();
         ac2Ref = XPathReference.getPathExpr("/a/c").getReference();
@@ -422,5 +427,10 @@ public class TreeReferenceTest {
                     ", which should, once genericized, should match" +
                     aRef.toString());
         }
+    }
+
+    @Test
+    public void testHashCollision() {
+        assertTrue(h2aRef.hashCode() != h3BRef.hashCode());
     }
 }

--- a/src/test/java/org/javarosa/core/model/test/TreeReferenceTest.java
+++ b/src/test/java/org/javarosa/core/model/test/TreeReferenceTest.java
@@ -428,9 +428,4 @@ public class TreeReferenceTest {
                     aRef.toString());
         }
     }
-
-    @Test
-    public void testHashCollision() {
-        assertTrue(h2aRef.hashCode() != h3BRef.hashCode());
-    }
 }


### PR DESCRIPTION
Will fail until we resolve the bug from http://manage.dimagi.com/default.asp?243592