### PR TITLE
Fix for TreeElement Child Fetch Hash Collision Bug

### DIFF
--- a/javarosa/src/main/java/org/javarosa/core/model/instance/TreeElement.java
+++ b/javarosa/src/main/java/org/javarosa/core/model/instance/TreeElement.java
@@ -165,7 +165,7 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
         } else {
             for (TreeElement child : children) {
                 if (child.getMult() == multiplicity &&
-                        (name.hashCode() == child.getName().hashCode() || name.equals(child.getName()))) {
+                        (name.hashCode() == child.getName().hashCode() && name.equals(child.getName()))) {
                     return child;
                 }
             }

--- a/javarosa/src/test/java/org/javarosa/core/model/instance/test/TreeElementTests.java
+++ b/javarosa/src/test/java/org/javarosa/core/model/instance/test/TreeElementTests.java
@@ -1,0 +1,38 @@
+package org.javarosa.core.model.instance.test;
+
+import org.javarosa.core.model.instance.TreeElement;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests the functionality of TreeElements
+ *
+ * @author wpride
+ */
+
+public class TreeElementTests {
+
+    TreeElement element;
+    TreeElement childOne;
+    TreeElement childTwo;
+    @Before
+    public void setup() {
+        element = new TreeElement("root");
+        childOne = new TreeElement("H2a");
+        childTwo = new TreeElement("H3B");
+
+        element.addChild(childOne);
+        element.addChild(childTwo);
+    }
+
+    @Test
+    public void testHashCollision() {
+        // childOne and childTwo should have the same hash, but still resolve correctly
+        TreeElement getOne = element.getChild("H2a", 0);
+        TreeElement getTwo = element.getChild("H3B", 0);
+        assertEquals(childOne, getOne);
+        assertEquals(childTwo, getTwo);
+    }
+}


### PR DESCRIPTION
Fix for  http://manage.dimagi.com/default.asp?243592

Tree Element children whose names have hash collisions could result in incorrect fetches.

Backported Tests from https://github.com/dimagi/commcare-core/pull/485 to include here. That PR can be closed.