### PR TITLE
Add a 'Sync' command to the CLI to facilitate testing and debugging

### DIFF
--- a/src/cli/java/org/commcare/util/cli/ApplicationHost.java
+++ b/src/cli/java/org/commcare/util/cli/ApplicationHost.java
@@ -459,7 +459,7 @@ public class ApplicationHost {
                 System.out.println("Server Response 412 - The user sandbox is not consistent with " +
                         "the server's data. \n\nThis is expected if you have changed cases locally, " +
                         "since data is not sent to the server for updates. \n\nServer response cannot be restored," +
-                        " you will need to restart the user's session.");
+                        " you will need to restart the user's session to get new data.");
             } else if (conn.getResponseCode() == HttpURLConnection.HTTP_UNAUTHORIZED) {
                 System.out.println("\nInvalid username or password!");
             } else if (conn.getResponseCode() >= 200 && conn.getResponseCode() < 300) {

--- a/src/cli/java/org/commcare/util/cli/ApplicationHost.java
+++ b/src/cli/java/org/commcare/util/cli/ApplicationHost.java
@@ -458,7 +458,8 @@ public class ApplicationHost {
             if (conn.getResponseCode() == 412) {
                 System.out.println("Server Response 412 - The user sandbox is not consistent with " +
                         "the server's data. \n\nThis is expected if you have changed cases locally, " +
-                        "since data is not sent to the server for updates");
+                        "since data is not sent to the server for updates. \n\nServer response cannot be restored," +
+                        " you will need to restart the user's session.");
             } else if (conn.getResponseCode() == HttpURLConnection.HTTP_UNAUTHORIZED) {
                 System.out.println("\nInvalid username or password!");
             } else if (conn.getResponseCode() >= 200 && conn.getResponseCode() < 300) {

--- a/src/cli/java/org/commcare/util/cli/ApplicationHost.java
+++ b/src/cli/java/org/commcare/util/cli/ApplicationHost.java
@@ -426,11 +426,9 @@ public class ApplicationHost {
             urlStateParams = String.format("&since=%s&state=ccsh:%s", syncToken, caseStateHash);
             incremental = true;
 
-            if (incremental) {
-                System.out.println(String.format(
-                        "\nIncremental sync requested. \nSync Token: %s\nState Hash: %s",
-                        syncToken, caseStateHash));
-            }
+            System.out.println(String.format(
+                    "\nIncremental sync requested. \nSync Token: %s\nState Hash: %s",
+                    syncToken, caseStateHash));
         }
 
         //fetch the restore data and set credentials
@@ -473,9 +471,8 @@ public class ApplicationHost {
             } else {
                 System.out.println("Unclear/Unexpected server response code: " + conn.getResponseCode());
             }
-        } catch (InvalidStructureException | IOException e) {
-            e.printStackTrace();
-        } catch (XmlPullParserException | UnfullfilledRequirementsException e) {
+        } catch (InvalidStructureException | IOException
+                | XmlPullParserException | UnfullfilledRequirementsException e) {
             e.printStackTrace();
         }
 

--- a/src/cli/java/org/commcare/util/cli/ApplicationHost.java
+++ b/src/cli/java/org/commcare/util/cli/ApplicationHost.java
@@ -411,7 +411,7 @@ public class ApplicationHost {
         System.out.println("Setting logged in user to: " + u.getUsername());
     }
 
-    public static void restoreUserToSandbox(UserSandbox sandbox, String username,
+    public void restoreUserToSandbox(UserSandbox sandbox, String username,
                                             final String password) {
         String urlStateParams = "";
 
@@ -491,6 +491,11 @@ public class ApplicationHost {
                     sandbox.setLoggedInUser(u);
                 }
             }
+        }
+
+        if(mSession != null) {
+            //old session data is now no longer valid
+            mSession.clearVolitiles();
         }
     }
 

--- a/src/cli/java/org/commcare/util/cli/ApplicationHost.java
+++ b/src/cli/java/org/commcare/util/cli/ApplicationHost.java
@@ -377,7 +377,7 @@ public class ApplicationHost {
 
         mSandbox = sandbox;
         if (mLocalUserCredentials != null) {
-            restoreUserToSandbox(mSandbox, mLocalUserCredentials[0], mLocalUserCredentials[1]);
+            restoreUserToSandbox(mSandbox, mSession, mLocalUserCredentials[0], mLocalUserCredentials[1]);
         } else if (mRestoreFile != null) {
             restoreFileToSandbox(mSandbox, mRestoreFile);
         } else {
@@ -411,8 +411,8 @@ public class ApplicationHost {
         System.out.println("Setting logged in user to: " + u.getUsername());
     }
 
-    public void restoreUserToSandbox(UserSandbox sandbox, String username,
-                                            final String password) {
+    public static void restoreUserToSandbox(UserSandbox sandbox, CLISessionWrapper session,
+                                            String username, final String password) {
         String urlStateParams = "";
 
         boolean failed = true;
@@ -493,9 +493,9 @@ public class ApplicationHost {
             }
         }
 
-        if(mSession != null) {
-            //old session data is now no longer valid
-            mSession.clearVolitiles();
+        if (session != null) {
+            // old session data is now no longer valid
+            session.clearVolitiles();
         }
     }
 
@@ -531,23 +531,23 @@ public class ApplicationHost {
     }
 
     private void syncAndReport() {
-        performCasePurge();
+        performCasePurge(mSandbox);
 
         if (mLocalUserCredentials != null) {
             System.out.println("Requesting sync...");
 
-            restoreUserToSandbox(mSandbox, mLocalUserCredentials[0], mLocalUserCredentials[1]);
+            restoreUserToSandbox(mSandbox, mSession, mLocalUserCredentials[0], mLocalUserCredentials[1]);
         } else {
             System.out.println("Syncing is only available when using raw user credentials");
         }
     }
 
-    private void performCasePurge() {
+    public static void performCasePurge(UserSandbox sandbox) {
         System.out.println("Performing Case Purge");
-        CasePurgeFilter purger = new CasePurgeFilter(mSandbox.getCaseStorage(),
-                SandboxUtils.extractEntityOwners(mSandbox));
+        CasePurgeFilter purger = new CasePurgeFilter(sandbox.getCaseStorage(),
+                SandboxUtils.extractEntityOwners(sandbox));
 
-        int removedCases = mSandbox.getCaseStorage().removeAll(purger).size();
+        int removedCases = sandbox.getCaseStorage().removeAll(purger).size();
 
         System.out.println("");
         System.out.println("Purge Report");


### PR DESCRIPTION
Added new info to the restore process that should make certain debugging easier

New command for the CLI that will do a purge and a data pull/sync from the server, and will reveal info that is currently difficult to get access to.

Example:

```
> :sync
Performing Case Purge

Purge Report
=========================
Cases Removed from device[2]: FAKE_GUID FAKE_OTHER_GUID
[Error/Warning] Cases Missing from Device: MISSING_GUID 
[Error/Warning] During Purge Invalid Edges were Detected
Requesting sync...
GET: https://www.commcarehq.org/a/test-domain/phone/restore/e6c88dc7cf8c742cbf397eff07d9a245/?version=2.0&since=3df6df801bbecb70277657334299684a&state=ccsh:de821e620d3cc1400e4b3f1bdb571827
Server Response 412 - The user sandbox is not consistent with the server's data. 
```
