### PR TITLE
Fix for nested repeats not showing up (again)

### DIFF
--- a/src/main/java/org/javarosa/core/model/FormIndex.java
+++ b/src/main/java/org/javarosa/core/model/FormIndex.java
@@ -160,14 +160,11 @@ public class FormIndex {
      * @return The multiplicity of the "most specific" repeated instance of a question or group.
      */
     public int getLastRepeatInstanceIndex() {
-        if(this.getNextLevel() == null) {
-            return getInstanceIndex();
-        }
-        int childIndex = this.getNextLevel().getInstanceIndex();
-        if(childIndex == -1) {
+        int lastRepeatIndex = getDeepestLevel().getInstanceIndex();
+        if (lastRepeatIndex == -1) {
             return getInstanceIndex();
         } else {
-            return childIndex;
+            return lastRepeatIndex;
         }
     }
 
@@ -187,6 +184,16 @@ public class FormIndex {
      */
     public FormIndex getNextLevel() {
         return nextLevel;
+    }
+
+    /**
+     * @return An index into the deepest level of specificity referenced by this index.
+     */
+    public FormIndex getDeepestLevel() {
+        if (nextLevel == null) {
+            return this;
+        }
+        return nextLevel.getDeepestLevel();
     }
 
     public TreeReference getLocalReference() {

--- a/src/main/java/org/javarosa/core/model/FormIndex.java
+++ b/src/main/java/org/javarosa/core/model/FormIndex.java
@@ -16,8 +16,9 @@ import java.util.Vector;
  * FormIndex's, IE, no form index's ancestor can be itself.
  *
  * Datatype Productions:
- * FormIndex = BOF | EOF | CompoundIndex(nextIndex:FormIndex,Location)
- * Location = Empty | Simple(localLevel:int) | WithMult(localLevel:int, multiplicity:int)
+ * FormIndex =  Null | BOF | EOF |
+ *              SimpleIndex(nextIndex:FormIndex, localIndex:int) |
+ *              IndexWithMult(nextIndex:FormIndex, localIndex:int, instanceIndex:int)
  *
  * @author Clayton Sims
  */
@@ -153,18 +154,36 @@ public class FormIndex {
     }
 
     /**
-     * Use this method to get the multiplicity of the deepest repeat group being referenced.
+     * Use this method to get the multiplicity of the deepest repeat group in the index.
+     * If no level of the current index has a multiplicity, this method will return -1
      *
-     * IE: If this index is to 1, 1_2, 2, 1_3 this reference will return 3.
-     *
-     * @return The multiplicity of the "most specific" repeated instance of a question or group.
+     * Examples:
+     * - If this index is to 1, 1_2, 2, 1_3 this method will return 3
+     * - If this index is to 1, 1_2, 3 this method will return 2
+     * - If this index is to 1, 0, 2 this method will return -1
      */
     public int getLastRepeatInstanceIndex() {
-        int lastRepeatIndex = getDeepestLevel().getInstanceIndex();
-        if (lastRepeatIndex == -1) {
-            return getInstanceIndex();
+        FormIndex deepestIndexWithMultiplicity = getDeepestLevelWithInstanceIndex();
+        if (deepestIndexWithMultiplicity == null) {
+            return -1;
         } else {
-            return lastRepeatIndex;
+            return deepestIndexWithMultiplicity.getInstanceIndex();
+        }
+    }
+
+    /**
+     * @return An index into the deepest level of specificity referenced by this index that has
+     * an instance index
+     */
+    private FormIndex getDeepestLevelWithInstanceIndex() { return getDeepestLevelWithInstanceIndex(null); }
+    private FormIndex getDeepestLevelWithInstanceIndex(FormIndex deepestSoFar) {
+        if (this.getInstanceIndex() != -1) {
+            deepestSoFar = this;
+        }
+        if (this.isTerminal()) {
+            return deepestSoFar;
+        } else {
+            return nextLevel.getDeepestLevelWithInstanceIndex(deepestSoFar);
         }
     }
 
@@ -184,16 +203,6 @@ public class FormIndex {
      */
     public FormIndex getNextLevel() {
         return nextLevel;
-    }
-
-    /**
-     * @return An index into the deepest level of specificity referenced by this index.
-     */
-    public FormIndex getDeepestLevel() {
-        if (nextLevel == null) {
-            return this;
-        }
-        return nextLevel.getDeepestLevel();
     }
 
     public TreeReference getLocalReference() {

--- a/src/main/java/org/javarosa/form/api/FormEntryModel.java
+++ b/src/main/java/org/javarosa/form/api/FormEntryModel.java
@@ -368,7 +368,11 @@ public class FormEntryModel {
                         TreeReference ref = getForm().getChildInstanceRef(index);
                         TreeElement element = getForm().getMainInstance().resolveReference(ref);
                         if (element == null) {
-                            if (index.getLastRepeatInstanceIndex() < fullcount) {
+                            int instanceIndexOfDeepestRepeat = index.getLastRepeatInstanceIndex();
+                            if (instanceIndexOfDeepestRepeat == -1) {
+                                throw new RuntimeException("Attempting to expand a repeat for a form index where no repeats were present: " + index);
+                            }
+                            if (instanceIndexOfDeepestRepeat < fullcount) {
                                 try {
                                     getForm().createNewRepeat(index);
                                 } catch (InvalidReferenceException ire) {

--- a/src/test/resources/xform_tests/test_looped_model_iteration.xml
+++ b/src/test/resources/xform_tests/test_looped_model_iteration.xml
@@ -84,15 +84,17 @@
         <group>
             <label ref="jr:itext('outer_repeat-label')"/>
             <repeat nodeset="/data/outer_repeat" jr:count="/data/number" jr:noAddRemove="true()">
-                <group>
-                    <label ref="jr:itext('outer_repeat/iterator/item-label')"/>
-                    <repeat nodeset="/data/outer_repeat/iterator/item" jr:count="/data/outer_repeat/iterator/@count"
-                            jr:noAddRemove="true()">
-                        <trigger appearance="minimal"
-                                 ref="/data/outer_repeat/iterator/item/placeholder">
-                            <label ref="jr:itext('outer_repeat/iterator/item/placeholder-label')"/>
-                        </trigger>
-                    </repeat>
+                <group ref="/data/outer_repeat/iterator" appearance="field-list">
+                    <group>
+                        <label ref="jr:itext('outer_repeat/iterator/item-label')"/>
+                        <repeat nodeset="/data/outer_repeat/iterator/item" jr:count="/data/outer_repeat/iterator/@count"
+                                jr:noAddRemove="true()">
+                            <trigger appearance="minimal"
+                                     ref="/data/outer_repeat/iterator/item/placeholder">
+                                <label ref="jr:itext('outer_repeat/iterator/item/placeholder-label')"/>
+                            </trigger>
+                        </repeat>
+                    </group>
                 </group>
             </repeat>
         </group>


### PR DESCRIPTION
Fix for http://manage.dimagi.com/default.asp?241001

Sadly, https://github.com/dimagi/commcare-core/pull/399 did not quite fix the issue of nested repeats not being shown when the outer repeat's count becomes greater than the inner repeat's count. `getLastRepeatInstanceIndex` was only getting the multiplicity of the direct next level to the current FormIndex, so in a form index with more than 2 levels, this didn't have the desired outcome, and was still reverting back to the old behavior of returning the multiplicity of the outer repeat. The solution is to make sure we have the deepest level being referenced by the current index before getting its multiplicity.

@ctsims, a few things:
1. This definitely fixes the issue reported above (from the broad app), but I was a little surprised because your comment on this method specifically included an example that I don't think would have worked ("1, 1_2, 2, 1_3"), since it has more than 2 levels. The format of the FormIndex in this app that was breaking was something like "1_8, 0, 4_1". So it was grabbing the 2nd level there, which doesn't have an instance index, and therefore defaulting back to the 8 from the first level. I just want to make sure that I'm not missing something more complicated here as to what went wrong in this specific case. 
2. I'm also not 100% how to go about writing a test for this new case, would you mind pointing me in the right direction?
3. I think we should probably do a point release for this, I don't think we can tell the broad team to wait for 2.33 to have this working properly. Does that sound right?

