### PR TITLE
Actually respect not equals op in tryBatchChildFetch

### DIFF
--- a/src/main/java/org/javarosa/core/model/instance/utils/TreeUtilities.java
+++ b/src/main/java/org/javarosa/core/model/instance/utils/TreeUtilities.java
@@ -86,6 +86,7 @@ public class TreeUtilities {
             if (xpe instanceof XPathEqExpr) {
                 XPathExpression left = ((XPathEqExpr)xpe).a;
                 XPathExpression right = ((XPathEqExpr)xpe).b;
+                boolean isEqOp = ((XPathEqExpr)xpe).op == XPathEqExpr.EQ;
 
                 //For now, only cheat when this is a string literal (this basically just means that we're
                 //handling attribute based referencing with very reasonable timing, but it's complex otherwise)
@@ -180,7 +181,7 @@ public class TreeUtilities {
                                 // this value before performing the match
                                 Object value = FunctionUtils.InferType(attrValue);
 
-                                if (XPathEqExpr.testEquality(value, literalMatch)) {
+                                if (isEqOp == XPathEqExpr.testEquality(value, literalMatch)) {
                                     predicateMatches.addElement(kids.elementAt(kidI).getRef());
                                 }
                             }


### PR DESCRIPTION
Fix for http://manage.dimagi.com/default.asp?244045. This was certainly the hardest to track down bug I've had in a while, thanks @proteusvacuum 😈 

`tryBatchChildFetch` is a shortcut that we attempt to use to expand a nodeset reference with predicates. Any predicates that are an `XPathEqExpr` get applied in this method rather than somewhere further down the line that is presumably slower. The problem was that in this method we were just assuming that the `XPathEqExpr` in question was always an '=' expression, and not accounting for the possibility that it was '!='. 

Don't pull yet, need to add tests and probably re-target as a hotfix.