### PR TITLE
Tests for predicate with != 

### DIFF
--- a/src/test/java/org/commcare/cases/test/CaseXPathQueryTest.java
+++ b/src/test/java/org/commcare/cases/test/CaseXPathQueryTest.java
@@ -75,7 +75,7 @@ public class CaseXPathQueryTest {
                         CaseTestUtils.CASE_INSTANCE);
 
         Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(ec,
-                "count(instance('casedb')/casedb/case[case_name = 'case'])", 2.0));
+                "count(instance('casedb')/casedb/case[@case_id = 'case_one'])", 1.0));
     }
 
     @Test
@@ -87,6 +87,6 @@ public class CaseXPathQueryTest {
                         CaseTestUtils.CASE_INSTANCE);
 
         Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(ec,
-                "count(instance('casedb')/casedb/case[case_name != 'case'])", 1.0));
+                "count(instance('casedb')/casedb/case[@case_id != 'case_one'])", 2.0));
     }
 }

--- a/src/test/java/org/commcare/cases/test/CaseXPathQueryTest.java
+++ b/src/test/java/org/commcare/cases/test/CaseXPathQueryTest.java
@@ -36,7 +36,7 @@ public class CaseXPathQueryTest {
     @Test
     public void elementQueryWithCaseInstance() throws Exception {
         ParseUtils.parseIntoSandbox(
-                this.getClass().getResourceAsStream("/case_create_basic.xml"), sandbox);
+                this.getClass().getResourceAsStream("/case_query_testing.xml"), sandbox);
         EvaluationContext ec = MockDataUtils.buildContextWithInstance(sandbox, "casedb",
                 CaseTestUtils.CASE_INSTANCE);
 
@@ -47,7 +47,7 @@ public class CaseXPathQueryTest {
     @Test
     public void referenceNonExistentCaseId() throws Exception {
         ParseUtils.parseIntoSandbox(
-                this.getClass().getResourceAsStream("/case_create_basic.xml"), sandbox);
+                this.getClass().getResourceAsStream("/case_query_testing.xml"), sandbox);
         EvaluationContext ec = MockDataUtils.buildContextWithInstance(sandbox, "casedb",
                 CaseTestUtils.CASE_INSTANCE);
 
@@ -58,7 +58,7 @@ public class CaseXPathQueryTest {
     @Test
     public void caseQueryWithBadPath() throws Exception {
         ParseUtils.parseIntoSandbox(
-                this.getClass().getResourceAsStream("/case_create_basic.xml"), sandbox);
+                this.getClass().getResourceAsStream("/case_query_testing.xml"), sandbox);
         EvaluationContext ec = MockDataUtils.buildContextWithInstance(sandbox, "casedb",
                 CaseTestUtils.CASE_INSTANCE);
 
@@ -69,7 +69,7 @@ public class CaseXPathQueryTest {
     @Test
     public void caseQueryEqualsTest() throws Exception {
         ParseUtils.parseIntoSandbox(
-                this.getClass().getResourceAsStream("/case_create_basic.xml"), sandbox);
+                this.getClass().getResourceAsStream("/case_query_testing.xml"), sandbox);
         EvaluationContext ec =
                 MockDataUtils.buildContextWithInstance(sandbox, "casedb",
                         CaseTestUtils.CASE_INSTANCE);
@@ -81,7 +81,7 @@ public class CaseXPathQueryTest {
     @Test
     public void caseQueryNotEqualsTest() throws Exception {
         ParseUtils.parseIntoSandbox(
-                this.getClass().getResourceAsStream("/case_create_basic.xml"), sandbox);
+                this.getClass().getResourceAsStream("/case_query_testing.xml"), sandbox);
         EvaluationContext ec =
                 MockDataUtils.buildContextWithInstance(sandbox, "casedb",
                         CaseTestUtils.CASE_INSTANCE);

--- a/src/test/java/org/commcare/cases/test/CaseXPathQueryTest.java
+++ b/src/test/java/org/commcare/cases/test/CaseXPathQueryTest.java
@@ -24,28 +24,69 @@ public class CaseXPathQueryTest {
     }
 
     @Test
-    public void caseQueryWithNoCaseInstance() throws XPathSyntaxException {
+    public void elementQueryWithNoCaseInstance() throws XPathSyntaxException {
         MockUserDataSandbox emptySandbox = MockDataUtils.getStaticStorage();
+        EvaluationContext ec = MockDataUtils.buildContextWithInstance(emptySandbox, "casedb",
+                CaseTestUtils.CASE_INSTANCE);
 
-        EvaluationContext ec =
-                MockDataUtils.buildContextWithInstance(emptySandbox, "casedb", CaseTestUtils.CASE_INSTANCE);
-        Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(ec, "instance('casedb')/casedb/case[@case_id = 'case_one']/case_name", ""));
+        Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(ec,
+                "instance('casedb')/casedb/case[@case_id = 'case_one']/case_name", ""));
+    }
+
+    @Test
+    public void elementQueryWithCaseInstance() throws Exception {
+        ParseUtils.parseIntoSandbox(
+                this.getClass().getResourceAsStream("/case_create_basic.xml"), sandbox);
+        EvaluationContext ec = MockDataUtils.buildContextWithInstance(sandbox, "casedb",
+                CaseTestUtils.CASE_INSTANCE);
+
+        Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(ec,
+                "instance('casedb')/casedb/case[@case_id = 'case_one']/case_name", "case"));
     }
 
     @Test
     public void referenceNonExistentCaseId() throws Exception {
-        ParseUtils.parseIntoSandbox(this.getClass().getResourceAsStream("/case_create_basic.xml"), sandbox);
-        EvaluationContext ec =
-                MockDataUtils.buildContextWithInstance(sandbox, "casedb", CaseTestUtils.CASE_INSTANCE);
+        ParseUtils.parseIntoSandbox(
+                this.getClass().getResourceAsStream("/case_create_basic.xml"), sandbox);
+        EvaluationContext ec = MockDataUtils.buildContextWithInstance(sandbox, "casedb",
+                CaseTestUtils.CASE_INSTANCE);
 
-        Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(ec, "instance('casedb')/casedb/case[@case_id = 'no-case']", ""));
+        Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(ec,
+                "count(instance('casedb')/casedb/case[@case_id = 'no-case'])", 0.0));
     }
 
     @Test
     public void caseQueryWithBadPath() throws Exception {
-        ParseUtils.parseIntoSandbox(this.getClass().getResourceAsStream("/case_create_basic.xml"), sandbox);
+        ParseUtils.parseIntoSandbox(
+                this.getClass().getResourceAsStream("/case_create_basic.xml"), sandbox);
+        EvaluationContext ec = MockDataUtils.buildContextWithInstance(sandbox, "casedb",
+                CaseTestUtils.CASE_INSTANCE);
+
+        Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(ec,
+                "instance('casedb')/casedb/case[@case_id = 'case_one']/doesnt_exist", ""));
+    }
+
+    @Test
+    public void caseQueryEqualsTest() throws Exception {
+        ParseUtils.parseIntoSandbox(
+                this.getClass().getResourceAsStream("/case_create_basic.xml"), sandbox);
         EvaluationContext ec =
-                MockDataUtils.buildContextWithInstance(sandbox, "casedb", CaseTestUtils.CASE_INSTANCE);
-        Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(ec, "instance('casedb')/casedb/case[@case_id = 'case_one']/doesnt_exist", ""));
+                MockDataUtils.buildContextWithInstance(sandbox, "casedb",
+                        CaseTestUtils.CASE_INSTANCE);
+
+        Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(ec,
+                "count(instance('casedb')/casedb/case[case_name = 'case'])", 2.0));
+    }
+
+    @Test
+    public void caseQueryNotEqualsTest() throws Exception {
+        ParseUtils.parseIntoSandbox(
+                this.getClass().getResourceAsStream("/case_create_basic.xml"), sandbox);
+        EvaluationContext ec =
+                MockDataUtils.buildContextWithInstance(sandbox, "casedb",
+                        CaseTestUtils.CASE_INSTANCE);
+
+        Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(ec,
+                "count(instance('casedb')/casedb/case[case_name != 'case'])", 1.0));
     }
 }

--- a/src/test/java/org/javarosa/xpath/expr/test/XPathPathExprTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/test/XPathPathExprTest.java
@@ -52,7 +52,6 @@ public class XPathPathExprTest {
     public void testNestedPreds() {
         FormParseInit fpi = new FormParseInit("/test_nested_preds_with_rel_refs.xml");
         FormDef fd = fpi.getFormDef();
-        FormInstance fi = fd.getInstance();
         FormInstance groupsInstance = (FormInstance)fd.getNonMainInstance("groups");
         EvaluationContext ec = fd.getEvaluationContext();
 
@@ -82,5 +81,18 @@ public class XPathPathExprTest {
 
         ExprEvalUtils.testEval("if(count(instance('groups')/root/groups/group/group_data/data) > 0 and count(instance('groups')/root/groups/group[count(group_data/data[@key = 'all_field_staff' and . ='yes']) > 0]) = 1, instance('groups')/root/groups/group[count(group_data/data[@key = 'all_field_staff' and . ='yes']) > 0]/@id, '')",
                 groupsInstance, ec, "inc");
+    }
+
+    @Test
+    public void testCaseDbQueriesFromForm() {
+        FormParseInit fpi = new FormParseInit("/test_casedb_query_from_form.xml");
+        FormDef fd = fpi.getFormDef();
+        FormInstance casedb = (FormInstance)fd.getNonMainInstance("casedb");
+        EvaluationContext ec = fd.getEvaluationContext();
+
+        ExprEvalUtils.testEval("count(instance('casedb')/casedb/case[case_name = 'case'])",
+                casedb, ec, 2.0);
+        ExprEvalUtils.testEval("count(instance('casedb')/casedb/case[case_name != 'case'])",
+                casedb, ec, 1.0);
     }
 }

--- a/src/test/java/org/javarosa/xpath/expr/test/XPathPathExprTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/test/XPathPathExprTest.java
@@ -90,9 +90,9 @@ public class XPathPathExprTest {
         FormInstance casedb = (FormInstance)fd.getNonMainInstance("casedb");
         EvaluationContext ec = fd.getEvaluationContext();
 
-        ExprEvalUtils.testEval("count(instance('casedb')/casedb/case[case_name = 'case'])",
-                casedb, ec, 2.0);
-        ExprEvalUtils.testEval("count(instance('casedb')/casedb/case[case_name != 'case'])",
+        ExprEvalUtils.testEval("count(instance('casedb')/casedb/case[@case_id = 'case_one'])",
                 casedb, ec, 1.0);
+        ExprEvalUtils.testEval("count(instance('casedb')/casedb/case[@case_id != 'case_one'])",
+                casedb, ec, 2.0);
     }
 }

--- a/src/test/resources/case_create_basic.xml
+++ b/src/test/resources/case_create_basic.xml
@@ -26,5 +26,4 @@
 			<owner_id>test_group</owner_id>
 		</create>
 	</case>
-
 </OpenRosaResponse>

--- a/src/test/resources/case_create_basic.xml
+++ b/src/test/resources/case_create_basic.xml
@@ -27,23 +27,4 @@
 		</create>
 	</case>
 
-	<case case_id="case_two"
-		date_modified="2014-08-04T21:09:07.000000Z" user_id="test_example"
-		xmlns="http://commcarehq.org/case/transaction/v2">
-		<create>
-			<case_type>retain_test</case_type>
-			<case_name>case</case_name>
-			<owner_id>test_group</owner_id>
-		</create>
-	</case>
-
-	<case case_id="case_three"
-		date_modified="2014-08-04T21:09:07.000000Z" user_id="test_example"
-		xmlns="http://commcarehq.org/case/transaction/v2">
-		<create>
-			<case_type>retain_test</case_type>
-			<case_name>case name</case_name>
-			<owner_id>test_group</owner_id>
-		</create>
-	</case>
 </OpenRosaResponse>

--- a/src/test/resources/case_create_basic.xml
+++ b/src/test/resources/case_create_basic.xml
@@ -26,4 +26,24 @@
 			<owner_id>test_group</owner_id>
 		</create>
 	</case>
+
+	<case case_id="case_two"
+		date_modified="2014-08-04T21:09:07.000000Z" user_id="test_example"
+		xmlns="http://commcarehq.org/case/transaction/v2">
+		<create>
+			<case_type>retain_test</case_type>
+			<case_name>case</case_name>
+			<owner_id>test_group</owner_id>
+		</create>
+	</case>
+
+	<case case_id="case_three"
+		date_modified="2014-08-04T21:09:07.000000Z" user_id="test_example"
+		xmlns="http://commcarehq.org/case/transaction/v2">
+		<create>
+			<case_type>retain_test</case_type>
+			<case_name>case name</case_name>
+			<owner_id>test_group</owner_id>
+		</create>
+	</case>
 </OpenRosaResponse>

--- a/src/test/resources/case_query_testing.xml
+++ b/src/test/resources/case_query_testing.xml
@@ -1,0 +1,49 @@
+<OpenRosaResponse>
+    <message nature="ota_restore_success">Successfully restored account test!</message>
+    <Sync xmlns="http://commcarehq.org/sync">
+        <restore_id>sync_token_a</restore_id>
+    </Sync>
+    <Registration xmlns="http://openrosa.org/user/registration">
+        <username>test</username>
+        <password>sha1$60441$53cf77c2ac3608a944db96af177a6dfe1579e4ba</password>
+        <uuid>test_example</uuid>
+        <date>2012-04-30</date>
+    </Registration>
+    <fixture id="user-groups" user_id="test_example">
+        <groups>
+            <group id="test_group">
+                <name>Group Name</name>
+            </group>
+        </groups>
+    </fixture>
+
+    <case case_id="case_one"
+        date_modified="2014-08-04T21:09:07.000000Z" user_id="test_example"
+        xmlns="http://commcarehq.org/case/transaction/v2">
+        <create>
+            <case_type>retain_test</case_type>
+            <case_name>case</case_name>
+            <owner_id>test_group</owner_id>
+        </create>
+    </case>
+
+    <case case_id="case_two"
+        date_modified="2014-08-04T21:09:07.000000Z" user_id="test_example"
+        xmlns="http://commcarehq.org/case/transaction/v2">
+        <create>
+            <case_type>retain_test</case_type>
+            <case_name>case</case_name>
+            <owner_id>test_group</owner_id>
+        </create>
+    </case>
+
+    <case case_id="case_three"
+        date_modified="2014-08-04T21:09:07.000000Z" user_id="test_example"
+        xmlns="http://commcarehq.org/case/transaction/v2">
+        <create>
+            <case_type>retain_test</case_type>
+            <case_name>case name</case_name>
+            <owner_id>test_group</owner_id>
+        </create>
+    </case>
+</OpenRosaResponse>

--- a/src/test/resources/test_casedb_query_from_form.xml
+++ b/src/test/resources/test_casedb_query_from_form.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml"
+        xmlns="http://www.w3.org/2002/xforms"
+    >
+    <h:head>
+        <h:title>Nested predicates with relative references</h:title>
+        <model>
+            <instance>
+                <data xmlns="http://openrosa.org/formdesigner/73BD6623-B13A-4C07-850E-583899531924" uiVersion="1" version="1" name="New Form">
+                    <q1/>
+                    <q2/>
+                    <q3/>
+                </data>
+            </instance>
+
+            <instance id="casedb">
+                <casedb>
+                    <case case_id="case_one">
+                        <case_type>retain_test</case_type>
+                        <case_name>case</case_name>
+                        <owner_id>test_group</owner_id>
+                    </case>
+                    <case case_id="case_two">
+                        <case_type>retain_test</case_type>
+                        <case_name>case</case_name>
+                        <owner_id>test_group</owner_id>
+                    </case>
+                    <case case_id="case_three">
+                        <case_type>retain_test</case_type>
+                        <case_name>case name</case_name>
+                        <owner_id>test_group</owner_id>
+                    </case>
+                </casedb>
+            </instance>
+
+        </model>
+    </h:head>
+    <h:body>
+    </h:body>
+</h:html>


### PR DESCRIPTION
This PR includes tests for the issue addressed by https://github.com/dimagi/commcare-core/pull/491, but ended up expanding to include a bit more than that. The issue in that PR was limited to predicates in a query on a non-main form instance, which I didn't actually fully realize until I wrote the tests in the first commit of this PR and realized that they didn't cover that issue. So basically:

-the 1st commit adds to and cleans up some existing tests for querying a storage-backed casedb
-the 3rd commit adds a test for the bug in #491, by executing a query containing a predicate with '!='  on a non-main form instance 