### PR TITLE
Add dev function to CLI eval mode to show all available xpath functions

### DIFF
--- a/src/translate/java/org/javarosa/engine/FunctionExtensions.java
+++ b/src/translate/java/org/javarosa/engine/FunctionExtensions.java
@@ -13,7 +13,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import java.util.Vector;
 
 /**
@@ -153,4 +155,34 @@ public class FunctionExtensions {
         }
     }
 
+    static class ListXPathFunc implements IFunctionHandler {
+
+        @Override
+        public String getName() {
+            return "funcs";
+        }
+
+        @Override
+        public Vector getPrototypes() {
+            Vector<Class[]> p = new Vector<>();
+            p.addElement(new Class[0]);
+            return p;
+        }
+
+        @Override
+        public boolean rawArgs() {
+            return true;
+        }
+
+        @Override
+        public Object eval(Object[] args, EvaluationContext ec) {
+            StringBuilder builder = new StringBuilder();
+            List<String> sortedFunctionNames = FunctionUtils.xPathFuncList();
+            Collections.sort(sortedFunctionNames);
+            for (String funcName : sortedFunctionNames) {
+                builder.append(funcName).append("\n");
+            }
+            return builder.toString();
+        }
+    }
 }

--- a/src/translate/java/org/javarosa/engine/XFormEnvironment.java
+++ b/src/translate/java/org/javarosa/engine/XFormEnvironment.java
@@ -106,6 +106,7 @@ public class XFormEnvironment {
         ec.addFunctionHandler(new FunctionExtensions.TodayFunc("now", hardCodedDate));
         ec.addFunctionHandler(new FunctionExtensions.PrintFunc(createIIF()));
         ec.addFunctionHandler(new FunctionExtensions.DocFunc());
+        ec.addFunctionHandler(new FunctionExtensions.ListXPathFunc());
 
         return ec;
     }


### PR DESCRIPTION
Sometimes when you are in the CLI / CloudCare debugger you want to see all the XPath functions available to you. This PR extends the CLI (but not the CloudCare debugger) environment with the `funcs` XPath function which prints out all the available XPath functions.

```
> funcs()
abs
acos
asin
atan
atan2
boolean
boolean-from-string
....
```