### PR TITLE
Datetime fix

### DIFF
--- a/src/api/java/org/commcare/api/json/PromptToJson.java
+++ b/src/api/java/org/commcare/api/json/PromptToJson.java
@@ -144,10 +144,8 @@ public class PromptToJson {
                 obj.put("answer", answerValue.getDisplayText());
                 return;
             case Constants.DATATYPE_DATE_TIME:
-                Date answer = (Date) answerValue.getValue();
-                Calendar calendar = Calendar.getInstance();
-                calendar.setTime(answer);
-                obj.put("answer", new DateTime(calendar.getTime(), DateTimeZone.forTimeZone(calendar.getTimeZone())).toString("yyyy-MM-dd'T'HH:mm:ssZZ"));
+                DateTime answer = new DateTime(answerValue.getValue());
+                obj.put("answer", answer.toString("yyyy-MM-dd'T'HH:mm:ssZZ"));
                 return;
             case Constants.DATATYPE_CHOICE:
                 Selection singleSelection = ((Selection) answerValue.getValue());


### PR DESCRIPTION
@wpride not sure why i didn't do this before... the issue here was that `calendar.getTimeZone()` would return UTC and convert the datetime to UTC and then not match the date time if it was submitted in a different timezone