### PR TITLE
Fix for Stateful XPath Functions

### DIFF
--- a/src/main/java/org/javarosa/xpath/expr/XPathAbsFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathAbsFunc.java
@@ -18,7 +18,7 @@ public class XPathAbsFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return Math.abs(FunctionUtils.toDouble(evaluatedArgs[0]));
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathAcosFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathAcosFunc.java
@@ -18,7 +18,7 @@ public class XPathAcosFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return Math.acos(FunctionUtils.toDouble(evaluatedArgs[0]));
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathAsinFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathAsinFunc.java
@@ -18,7 +18,7 @@ public class XPathAsinFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return Math.asin(FunctionUtils.toDouble(evaluatedArgs[0]));
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathAtanFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathAtanFunc.java
@@ -18,7 +18,7 @@ public class XPathAtanFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return Math.atan(FunctionUtils.toDouble(evaluatedArgs[0]));
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathAtanTwoFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathAtanTwoFunc.java
@@ -18,7 +18,7 @@ public class XPathAtanTwoFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         double value1 = FunctionUtils.toDouble(evaluatedArgs[0]);
         double value2 = FunctionUtils.toDouble(evaluatedArgs[1]);
         return Math.atan2(value1, value2);

--- a/src/main/java/org/javarosa/xpath/expr/XPathBooleanFromStringFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathBooleanFromStringFunc.java
@@ -18,7 +18,7 @@ public class XPathBooleanFromStringFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         String s = FunctionUtils.toString(evaluatedArgs[0]);
         if (s.equalsIgnoreCase("true") || s.equals("1")) {
             return Boolean.TRUE;

--- a/src/main/java/org/javarosa/xpath/expr/XPathBooleanFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathBooleanFunc.java
@@ -18,7 +18,7 @@ public class XPathBooleanFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return FunctionUtils.toBoolean(evaluatedArgs[0]);
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathCeilingFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathCeilingFunc.java
@@ -18,7 +18,7 @@ public class XPathCeilingFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return new Double(Math.ceil(FunctionUtils.toDouble(evaluatedArgs[0])));
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathChecklistFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathChecklistFunc.java
@@ -28,7 +28,7 @@ public class XPathChecklistFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         if (args.length == 3 && evaluatedArgs[2] instanceof XPathNodeset) {
             return checklist(evaluatedArgs[0], evaluatedArgs[1], ((XPathNodeset)evaluatedArgs[2]).toArgList());
         } else {

--- a/src/main/java/org/javarosa/xpath/expr/XPathConcatFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathConcatFunc.java
@@ -24,7 +24,7 @@ public class XPathConcatFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         if (args.length == 1 && evaluatedArgs[0] instanceof XPathNodeset) {
             return XPathJoinFunc.join("", ((XPathNodeset)evaluatedArgs[0]).toArgList());
         } else {

--- a/src/main/java/org/javarosa/xpath/expr/XPathCondFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathCondFunc.java
@@ -33,7 +33,7 @@ public class XPathCondFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         for (int i = 0; i < args.length - 2; i+=2) {
             if (FunctionUtils.toBoolean(args[i].eval(model, evalContext))) {
                 return args[i+1].eval(model, evalContext);

--- a/src/main/java/org/javarosa/xpath/expr/XPathContainsFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathContainsFunc.java
@@ -18,7 +18,7 @@ public class XPathContainsFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return FunctionUtils.toString(evaluatedArgs[0]).contains(FunctionUtils.toString(evaluatedArgs[1]));
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathCosFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathCosFunc.java
@@ -18,7 +18,7 @@ public class XPathCosFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return Math.cos(FunctionUtils.toDouble(evaluatedArgs[0]));
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathCountFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathCountFunc.java
@@ -20,7 +20,7 @@ public class XPathCountFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         if (evaluatedArgs[0] instanceof XPathNodeset) {
             return new Double(((XPathNodeset)evaluatedArgs[0]).size());
         } else {

--- a/src/main/java/org/javarosa/xpath/expr/XPathCountSelectedFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathCountSelectedFunc.java
@@ -26,7 +26,7 @@ public class XPathCountSelectedFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         Object evalResult = FunctionUtils.unpack(evaluatedArgs[0]);
         if (!(evalResult instanceof String)) {
             throw new XPathTypeMismatchException("count-selected argument was not a select list");

--- a/src/main/java/org/javarosa/xpath/expr/XPathCustomRuntimeFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathCustomRuntimeFunc.java
@@ -35,7 +35,7 @@ public class XPathCustomRuntimeFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         throw new XPathUnhandledException("function \'" + name + "\'");
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathDateFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathDateFunc.java
@@ -19,7 +19,7 @@ public class XPathDateFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return FunctionUtils.toDate(evaluatedArgs[0]);
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathDependFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathDependFunc.java
@@ -28,7 +28,7 @@ public class XPathDependFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return evaluatedArgs[0];
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathDistanceFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathDistanceFunc.java
@@ -21,7 +21,7 @@ public class XPathDistanceFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return distance(evaluatedArgs[0], evaluatedArgs[1]);
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathDoubleFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathDoubleFunc.java
@@ -19,7 +19,7 @@ public class XPathDoubleFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return FunctionUtils.toDouble(evaluatedArgs[0]);
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathEndsWithFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathEndsWithFunc.java
@@ -18,7 +18,7 @@ public class XPathEndsWithFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return FunctionUtils.toString(evaluatedArgs[0]).endsWith(FunctionUtils.toString(evaluatedArgs[1]));
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathExpFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathExpFunc.java
@@ -18,7 +18,7 @@ public class XPathExpFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return Math.exp(FunctionUtils.toDouble(evaluatedArgs[0]));
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathFalseFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathFalseFunc.java
@@ -18,7 +18,7 @@ public class XPathFalseFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return Boolean.FALSE;
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathFloorFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathFloorFunc.java
@@ -18,7 +18,7 @@ public class XPathFloorFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return new Double(Math.floor(FunctionUtils.toDouble(evaluatedArgs[0])));
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathFormatDateForCalendarFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathFormatDateForCalendarFunc.java
@@ -22,7 +22,7 @@ public class XPathFormatDateForCalendarFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return formatDateForCalendar(evaluatedArgs[0], evaluatedArgs[1]);
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathFormatDateFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathFormatDateFunc.java
@@ -21,7 +21,7 @@ public class XPathFormatDateFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return dateStr(evaluatedArgs[0], evaluatedArgs[1]);
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -23,7 +23,6 @@ import java.util.Vector;
 public abstract class XPathFuncExpr extends XPathExpression {
     protected String name;
     public XPathExpression[] args;
-    protected Object[] evaluatedArgs;
     protected int expectedArgCount;
     private boolean evaluateArgsFirst;
 
@@ -45,28 +44,27 @@ public abstract class XPathFuncExpr extends XPathExpression {
 
     @Override
     public final Object evalRaw(DataInstance model, EvaluationContext evalContext) {
-        evaluateArguments(model, evalContext);
+        Object[] evaluatedArgs = evaluateArguments(model, evalContext);
 
         IFunctionHandler handler = evalContext.getFunctionHandlers().get(name);
         if (handler != null) {
             return XPathCustomRuntimeFunc.evalCustomFunction(handler, evaluatedArgs, evalContext);
         } else {
-            return evalBody(model, evalContext);
+            return evalBody(model, evalContext, evaluatedArgs);
         }
     }
 
-    private void evaluateArguments(DataInstance model, EvaluationContext evalContext) {
-        if (evaluatedArgs == null) {
-            evaluatedArgs = new Object[args.length];
-        }
+    private Object[] evaluateArguments(DataInstance model, EvaluationContext evalContext) {
+        Object[] evaluatedArgs = new Object[args.length];
         if (evaluateArgsFirst) {
             for (int i = 0; i < args.length; i++) {
                 evaluatedArgs[i] = args[i].eval(model, evalContext);
             }
         }
+        return evaluatedArgs;
     }
 
-    protected abstract Object evalBody(DataInstance model, EvaluationContext evalContext);
+    protected abstract Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs);
 
     //protected abstract String docs();
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathIfFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathIfFunc.java
@@ -28,7 +28,7 @@ public class XPathIfFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         if (FunctionUtils.toBoolean(args[0].eval(model, evalContext))) {
             return args[1].eval(model, evalContext);
         } else {

--- a/src/main/java/org/javarosa/xpath/expr/XPathIntFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathIntFunc.java
@@ -19,7 +19,7 @@ public class XPathIntFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return FunctionUtils.toInt(evaluatedArgs[0]);
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathJoinFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathJoinFunc.java
@@ -28,7 +28,7 @@ public class XPathJoinFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         if (args.length == 2 && evaluatedArgs[1] instanceof XPathNodeset) {
             return join(evaluatedArgs[0], ((XPathNodeset)evaluatedArgs[1]).toArgList());
         } else {

--- a/src/main/java/org/javarosa/xpath/expr/XPathLogFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathLogFunc.java
@@ -18,7 +18,7 @@ public class XPathLogFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return Math.log(FunctionUtils.toDouble(evaluatedArgs[0]));
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathLogTenFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathLogTenFunc.java
@@ -18,7 +18,7 @@ public class XPathLogTenFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return Math.log10(FunctionUtils.toDouble(evaluatedArgs[0]));
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathLowerCaseFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathLowerCaseFunc.java
@@ -18,7 +18,7 @@ public class XPathLowerCaseFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return FunctionUtils.normalizeCase(evaluatedArgs[0], false);
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathMaxFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathMaxFunc.java
@@ -28,7 +28,7 @@ public class XPathMaxFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         if (evaluatedArgs.length == 1 && evaluatedArgs[0] instanceof XPathNodeset) {
             return max(((XPathNodeset)evaluatedArgs[0]).toArgList());
         } else {

--- a/src/main/java/org/javarosa/xpath/expr/XPathMinFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathMinFunc.java
@@ -28,7 +28,7 @@ public class XPathMinFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         if (evaluatedArgs.length == 1 && evaluatedArgs[0] instanceof XPathNodeset) {
             return min(((XPathNodeset)evaluatedArgs[0]).toArgList());
         } else {

--- a/src/main/java/org/javarosa/xpath/expr/XPathNotFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathNotFunc.java
@@ -18,7 +18,7 @@ public class XPathNotFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return !FunctionUtils.toBoolean(evaluatedArgs[0]);
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathNowFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathNowFunc.java
@@ -20,7 +20,7 @@ public class XPathNowFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return new Date();
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathNumberFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathNumberFunc.java
@@ -18,7 +18,7 @@ public class XPathNumberFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return FunctionUtils.toNumeric(evaluatedArgs[0]);
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathPiFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathPiFunc.java
@@ -18,7 +18,7 @@ public class XPathPiFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return Math.PI;
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathPositionFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathPositionFunc.java
@@ -31,7 +31,7 @@ public class XPathPositionFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         if (args.length == 1) {
             XPathNodeset expr = (XPathNodeset)evaluatedArgs[0];
             try {

--- a/src/main/java/org/javarosa/xpath/expr/XPathPowFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathPowFunc.java
@@ -18,7 +18,7 @@ public class XPathPowFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return power(evaluatedArgs[0], evaluatedArgs[1]);
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathRandomFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathRandomFunc.java
@@ -20,7 +20,7 @@ public class XPathRandomFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         //calculated expressions may be recomputed w/o warning! use with caution!!
         return new Double(MathUtils.getRand().nextDouble());
     }

--- a/src/main/java/org/javarosa/xpath/expr/XPathRegexFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathRegexFunc.java
@@ -22,7 +22,7 @@ public class XPathRegexFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return regex(evaluatedArgs[0], evaluatedArgs[1]);
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathReplaceFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathReplaceFunc.java
@@ -22,7 +22,7 @@ public class XPathReplaceFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return replace(evaluatedArgs[0], evaluatedArgs[1], evaluatedArgs[2]);
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathRoundFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathRoundFunc.java
@@ -18,7 +18,7 @@ public class XPathRoundFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return new Double(Math.floor(FunctionUtils.toDouble(evaluatedArgs[0]) + 0.5));
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathSelectedAtFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathSelectedAtFunc.java
@@ -20,7 +20,7 @@ public class XPathSelectedAtFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return selectedAt(evaluatedArgs[0], evaluatedArgs[1]);
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathSelectedFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathSelectedFunc.java
@@ -25,7 +25,7 @@ public class XPathSelectedFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return multiSelected(evaluatedArgs[0], evaluatedArgs[1]);
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathSinFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathSinFunc.java
@@ -18,7 +18,7 @@ public class XPathSinFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return Math.sin(FunctionUtils.toDouble(evaluatedArgs[0]));
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathSqrtFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathSqrtFunc.java
@@ -18,7 +18,7 @@ public class XPathSqrtFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return Math.sqrt(FunctionUtils.toDouble(evaluatedArgs[0]));
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathStartsWithFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathStartsWithFunc.java
@@ -18,7 +18,7 @@ public class XPathStartsWithFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return FunctionUtils.toString(evaluatedArgs[0]).startsWith(FunctionUtils.toString(evaluatedArgs[1]));
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathStringFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathStringFunc.java
@@ -18,7 +18,7 @@ public class XPathStringFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return FunctionUtils.toString(evaluatedArgs[0]);
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathStringLengthFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathStringLengthFunc.java
@@ -18,7 +18,7 @@ public class XPathStringLengthFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         String s = FunctionUtils.toString(evaluatedArgs[0]);
         if (s == null) {
             return new Double(0.0);

--- a/src/main/java/org/javarosa/xpath/expr/XPathSubstrFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathSubstrFunc.java
@@ -27,7 +27,7 @@ public class XPathSubstrFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return substring(evaluatedArgs[0], evaluatedArgs[1], args.length == 3 ? evaluatedArgs[2] : null);
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathSubstringAfterFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathSubstringAfterFunc.java
@@ -18,7 +18,7 @@ public class XPathSubstringAfterFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return substringAfter(evaluatedArgs[0], evaluatedArgs[1]);
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathSubstringBeforeFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathSubstringBeforeFunc.java
@@ -18,7 +18,7 @@ public class XPathSubstringBeforeFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return substringBefore(evaluatedArgs[0], evaluatedArgs[1]);
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathSumFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathSumFunc.java
@@ -20,7 +20,7 @@ public class XPathSumFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         if (evaluatedArgs[0] instanceof XPathNodeset) {
             return sum(((XPathNodeset)evaluatedArgs[0]).toArgList());
         } else {

--- a/src/main/java/org/javarosa/xpath/expr/XPathTanFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathTanFunc.java
@@ -18,7 +18,7 @@ public class XPathTanFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return Math.tan(FunctionUtils.toDouble(evaluatedArgs[0]));
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathTodayFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathTodayFunc.java
@@ -21,7 +21,7 @@ public class XPathTodayFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return DateUtils.roundDate(new Date());
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathTranslateFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathTranslateFunc.java
@@ -20,7 +20,7 @@ public class XPathTranslateFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return translate(evaluatedArgs[0], evaluatedArgs[1], evaluatedArgs[2]);
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathTrueFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathTrueFunc.java
@@ -18,7 +18,7 @@ public class XPathTrueFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return Boolean.TRUE;
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathUpperCaseFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathUpperCaseFunc.java
@@ -18,7 +18,7 @@ public class XPathUpperCaseFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         return FunctionUtils.normalizeCase(evaluatedArgs[0], true);
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathUuidFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathUuidFunc.java
@@ -28,7 +28,7 @@ public class XPathUuidFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         //calculated expressions may be recomputed w/o warning! use with caution!!
         if (args.length == 0) {
             return PropertyUtils.genUUID();

--- a/src/main/java/org/javarosa/xpath/expr/XPathWeightedChecklistFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathWeightedChecklistFunc.java
@@ -28,7 +28,7 @@ public class XPathWeightedChecklistFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         if (args.length == 4 && evaluatedArgs[2] instanceof XPathNodeset && evaluatedArgs[3] instanceof XPathNodeset) {
             Object[] factors = ((XPathNodeset)evaluatedArgs[2]).toArgList();
             Object[] weights = ((XPathNodeset)evaluatedArgs[3]).toArgList();

--- a/src/main/java/org/javarosa/xpath/expr/XpathCoalesceFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XpathCoalesceFunc.java
@@ -27,7 +27,7 @@ public class XpathCoalesceFunc extends XPathFuncExpr {
     }
 
     @Override
-    public Object evalBody(DataInstance model, EvaluationContext evalContext) {
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
         // Not sure if unpacking here is quiiite right, but it seems right
         for (int i = 0; i < args.length - 1; i++) {
             Object evaluatedArg = FunctionUtils.unpack(args[i].eval(model, evalContext));


### PR DESCRIPTION
When Phillip refactored xpath functions, he moved the Arguments evaluation to be a member of the class. this causes huge problems when returning a nodeset, because the nodeset has a reference to the EvaluationContext, which was resulting in a bad memory leak where we were retaining hundreds of copies of the EvalContext for any expressions which came from persistent classes.

XPathFuncExpr has the core fix, everything else is just pushing the evaluatedArgs out to the functions again.