### PR TITLE
fix suite regression

### DIFF
--- a/src/main/java/org/commcare/util/CommCarePlatform.java
+++ b/src/main/java/org/commcare/util/CommCarePlatform.java
@@ -68,14 +68,6 @@ public class CommCarePlatform {
     }
 
     public Vector<Suite> getInstalledSuites() {
-        Vector<Suite> installedSuites = new Vector<>();
-        IStorageUtilityIndexed utility = StorageManager.getStorage(Suite.STORAGE_KEY);
-
-        IStorageIterator iterator = utility.iterate();
-
-        while(iterator.hasMore()){
-            installedSuites.addElement((Suite)utility.read(iterator.nextID()));
-        }
         return installedSuites;
     }
     


### PR DESCRIPTION
This change snuck in with the 2.33 back merge:

https://github.com/dimagi/commcare-core/commit/473d42a08f01880e79f876e5a8a89a032efc7abf

I had gotten rid of this in favor of just storing the suites objects directly