### PR TITLE
Move query planning classes into core from android

### DIFF
--- a/src/main/java/org/commcare/modern/engine/cases/CaseGroupResultCache.java
+++ b/src/main/java/org/commcare/modern/engine/cases/CaseGroupResultCache.java
@@ -1,0 +1,53 @@
+package org.commcare.modern.engine.cases;
+
+import org.commcare.cases.model.Case;
+import org.commcare.cases.query.QueryCache;
+
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+
+/**
+ * Created by ctsims on 1/25/2017.
+ */
+
+public class CaseGroupResultCache implements QueryCache {
+
+    public static final int MAX_PREFETCH_CASE_BLOCK = 7500;
+
+    private HashMap<String,LinkedHashSet<Integer>> bulkFetchBodies = new HashMap<>();
+
+    private HashMap<Integer, Case> cachedCases = new HashMap<>();
+
+
+    public void reportBulkCaseBody(String key, LinkedHashSet<Integer> ids) {
+        if(bulkFetchBodies.containsKey(key)) {
+            return;
+        }
+        bulkFetchBodies.put(key, ids);
+    }
+
+    public boolean hasMatchingCaseSet(int recordId) {
+        return isLoaded(recordId) || getTranche(recordId) != null;
+    }
+
+    public LinkedHashSet<Integer> getTranche(int recordId) {
+        for(LinkedHashSet<Integer> tranche: bulkFetchBodies.values()) {
+            if(tranche.contains(recordId)){
+                return tranche;
+            }
+        }
+        return null;
+    }
+
+    public boolean isLoaded(int recordId) {
+        return cachedCases.containsKey(recordId);
+    }
+
+    public HashMap<Integer, Case> getLoadedCaseMap() {
+        return cachedCases;
+    }
+
+    public Case getLoadedCase(int recordId) {
+        return cachedCases.get(recordId);
+    }
+}

--- a/src/main/java/org/commcare/modern/engine/cases/CaseIndexQuerySetTransform.java
+++ b/src/main/java/org/commcare/modern/engine/cases/CaseIndexQuerySetTransform.java
@@ -18,9 +18,9 @@ import java.util.Set;
 
 public class CaseIndexQuerySetTransform implements QuerySetTransform {
 
-    private final IndexTable table;
+    private final CaseIndexTable table;
 
-    public CaseIndexQuerySetTransform(IndexTable table) {
+    public CaseIndexQuerySetTransform(CaseIndexTable table) {
         this.table = table;
     }
 
@@ -39,9 +39,9 @@ public class CaseIndexQuerySetTransform implements QuerySetTransform {
 
     public static class CaseIndexQuerySetLookup extends DerivedCaseQueryLookup {
         String indexName;
-        IndexTable table;
+        CaseIndexTable table;
 
-        public CaseIndexQuerySetLookup(String indexName, QuerySetLookup incoming, IndexTable table) {
+        public CaseIndexQuerySetLookup(String indexName, QuerySetLookup incoming, CaseIndexTable table) {
             super(incoming);
             this.indexName = indexName;
             this.table = table;

--- a/src/main/java/org/commcare/modern/engine/cases/CaseIndexQuerySetTransform.java
+++ b/src/main/java/org/commcare/modern/engine/cases/CaseIndexQuerySetTransform.java
@@ -1,0 +1,84 @@
+package org.commcare.modern.engine.cases;
+
+import org.commcare.cases.query.QueryContext;
+import org.commcare.cases.query.queryset.CaseQuerySetLookup;
+import org.commcare.cases.query.queryset.DerivedCaseQueryLookup;
+import org.commcare.cases.query.queryset.DualTableSingleMatchModelQuerySet;
+import org.commcare.cases.query.queryset.ModelQuerySet;
+import org.commcare.cases.query.queryset.QuerySetLookup;
+import org.commcare.cases.query.queryset.QuerySetTransform;
+import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.core.model.trace.EvaluationTrace;
+
+import java.util.Set;
+
+/**
+ * Created by ctsims on 2/6/2017.
+ */
+
+public class CaseIndexQuerySetTransform implements QuerySetTransform {
+
+    private final IndexTable table;
+
+    public CaseIndexQuerySetTransform(IndexTable table) {
+        this.table = table;
+    }
+
+    @Override
+    public QuerySetLookup getTransformedLookup(QuerySetLookup incoming, TreeReference relativeLookup) {
+        if(incoming.getQueryModelId().equals(CaseQuerySetLookup.CASE_MODEL_ID)) {
+            if(relativeLookup.size() == 2 && "index".equals(relativeLookup.getName(0))) {
+                String indexName = relativeLookup.getName(1);
+                return new CaseIndexQuerySetLookup(indexName, incoming, table);
+            }
+        }
+        return null;
+    }
+
+
+
+    public static class CaseIndexQuerySetLookup extends DerivedCaseQueryLookup {
+        String indexName;
+        IndexTable table;
+
+        public CaseIndexQuerySetLookup(String indexName, QuerySetLookup incoming, IndexTable table) {
+            super(incoming);
+            this.indexName = indexName;
+            this.table = table;
+        }
+
+        @Override
+        protected ModelQuerySet loadModelQuerySet(QueryContext queryContext) {
+            EvaluationTrace trace = new EvaluationTrace("Load Query Set Transform[" +
+                    getRootLookup().getCurrentQuerySetId() + "]=>[" +
+                    this.getCurrentQuerySetId()+ "]");
+
+
+            Set<Integer> querySetBody = getRootLookup().getLookupSetBody(queryContext);
+            DualTableSingleMatchModelQuerySet ret = table.bulkReadIndexToCaseIdMatch(indexName, querySetBody);
+            cacheCaseModelQuerySet(queryContext, ret);
+
+            trace.setOutcome("Loaded: " + ret.getSetBody().size());
+
+            queryContext.reportTrace(trace);
+            return ret;
+        }
+
+        private void cacheCaseModelQuerySet(QueryContext queryContext, DualTableSingleMatchModelQuerySet ret) {
+            int modelQueryMagnitude = ret.getSetBody().size();
+            if(modelQueryMagnitude > QueryContext.BULK_QUERY_THRESHOLD && modelQueryMagnitude < CaseGroupResultCache.MAX_PREFETCH_CASE_BLOCK) {
+                queryContext.getQueryCache(CaseGroupResultCache.class).reportBulkCaseBody(this.getCurrentQuerySetId(), ret.getSetBody());
+            }
+        }
+
+        @Override
+        public String getQueryModelId() {
+            return getRootLookup().getQueryModelId();
+        }
+
+        @Override
+        public String getCurrentQuerySetId() {
+            return getRootLookup().getCurrentQuerySetId() + "|index|"+indexName;
+        }
+    }
+}

--- a/src/main/java/org/commcare/modern/engine/cases/CaseIndexTable.java
+++ b/src/main/java/org/commcare/modern/engine/cases/CaseIndexTable.java
@@ -7,7 +7,7 @@ import java.util.*;
 /**
  * Created by willpride on 2/21/17.
  */
-public interface IndexTable {
+public interface CaseIndexTable {
     int loadIntoIndexTable(HashMap<String, Vector<Integer>> indexCache, String indexName);
 
     DualTableSingleMatchModelQuerySet bulkReadIndexToCaseIdMatch(String indexName, Collection<Integer> cuedCases);

--- a/src/main/java/org/commcare/modern/engine/cases/IndexTable.java
+++ b/src/main/java/org/commcare/modern/engine/cases/IndexTable.java
@@ -1,0 +1,18 @@
+package org.commcare.modern.engine.cases;
+
+import org.commcare.cases.query.queryset.DualTableSingleMatchModelQuerySet;
+
+import java.util.*;
+
+/**
+ * Created by willpride on 2/21/17.
+ */
+public interface IndexTable {
+    int loadIntoIndexTable(HashMap<String, Vector<Integer>> indexCache, String indexName);
+
+    DualTableSingleMatchModelQuerySet bulkReadIndexToCaseIdMatch(String indexName, Collection<Integer> cuedCases);
+
+    LinkedHashSet<Integer> getCasesMatchingValueSet(String indexName, String[] valueSet);
+
+    LinkedHashSet<Integer> getCasesMatchingIndex(String indexName, String value);
+}

--- a/src/main/java/org/commcare/modern/engine/cases/query/CaseIndexPrefetchHandler.java
+++ b/src/main/java/org/commcare/modern/engine/cases/query/CaseIndexPrefetchHandler.java
@@ -1,0 +1,94 @@
+package org.commcare.modern.engine.cases.query;
+
+import org.commcare.cases.model.Case;
+import org.commcare.cases.query.IndexedValueLookup;
+import org.commcare.cases.query.PredicateProfile;
+import org.commcare.cases.query.QueryCache;
+import org.commcare.cases.query.QueryContext;
+import org.commcare.cases.query.QueryHandler;
+import org.commcare.cases.util.QueryUtils;
+import org.commcare.modern.engine.cases.IndexTable;
+import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.model.trace.EvaluationTrace;
+import org.javarosa.xpath.expr.XPathExpression;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Vector;
+
+/**
+ * This handler detects contexts in which the query is likely to trip many index lookups and will
+ * strategically perform a cache of relevant indexes
+ *
+ * Created by ctsims on 1/25/2017.
+ */
+
+public class CaseIndexPrefetchHandler implements QueryHandler<IndexedValueLookup> {
+
+    /**
+     * This should be roughly the point at which 1 query of N items in the db will be faster
+     * than N queries of 1 item, even if only one item ends up being used.
+     */
+    private static final int BULK_LOAD_THRESHOLD = 500;
+
+    private final IndexTable mCaseIndexTable;
+
+    public static final class Cache implements QueryCache {
+        Vector<String> currentlyFetchedIndexKeys = new Vector<>();
+        private HashMap<String, Vector<Integer>> indexCache = new HashMap<>();
+    }
+
+    public CaseIndexPrefetchHandler(IndexTable caseIndexTable) {
+        this.mCaseIndexTable = caseIndexTable;
+        //TODO: Profile table by each type of index for size to identify threshold changes.
+    }
+
+    @Override
+    public int getExpectedRuntime() {
+        return 1;
+    }
+
+    @Override
+    public IndexedValueLookup profileHandledQuerySet(Vector<PredicateProfile> profiles) {
+        IndexedValueLookup ret = QueryUtils.getFirstKeyIndexedValue(profiles);
+        if(ret != null){
+            if (ret.getKey().startsWith(Case.INDEX_CASE_INDEX_PRE)) {
+                return ret;
+            }
+        }
+        return null;
+
+    }
+
+    @Override
+    public List<Integer> loadProfileMatches(IndexedValueLookup querySet, QueryContext context) {
+        String indexName = querySet.getKey().substring(Case.INDEX_CASE_INDEX_PRE.length());
+        String value = (String)querySet.value;
+
+        Cache cache = context.getQueryCache(Cache.class);
+        if(!cache.currentlyFetchedIndexKeys.contains(indexName)) {
+            if(context.getScope() < BULK_LOAD_THRESHOLD) {
+                return null;
+            }
+
+            EvaluationTrace trace = new EvaluationTrace("Index Bulk Prefetch [" + indexName + "]");
+            int indexFetchSize = mCaseIndexTable.loadIntoIndexTable(cache.indexCache, indexName);
+            trace.setOutcome("Loaded: " + indexFetchSize);
+            context.reportTrace(trace);
+            cache.currentlyFetchedIndexKeys.add(indexName);
+        }
+        String cacheKey = indexName + "|" + value;
+        return cache.indexCache.get(cacheKey);
+    }
+
+    @Override
+    public void updateProfiles(IndexedValueLookup querySet, Vector<PredicateProfile> profiles) {
+        profiles.remove(querySet);
+    }
+
+    @Override
+    public Collection<PredicateProfile> collectPredicateProfiles(Vector<XPathExpression> predicates, QueryContext context, EvaluationContext evaluationContext) {
+        return null;
+    }
+}

--- a/src/main/java/org/commcare/modern/engine/cases/query/CaseIndexPrefetchHandler.java
+++ b/src/main/java/org/commcare/modern/engine/cases/query/CaseIndexPrefetchHandler.java
@@ -7,7 +7,7 @@ import org.commcare.cases.query.QueryCache;
 import org.commcare.cases.query.QueryContext;
 import org.commcare.cases.query.QueryHandler;
 import org.commcare.cases.util.QueryUtils;
-import org.commcare.modern.engine.cases.IndexTable;
+import org.commcare.modern.engine.cases.CaseIndexTable;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.trace.EvaluationTrace;
 import org.javarosa.xpath.expr.XPathExpression;
@@ -32,14 +32,14 @@ public class CaseIndexPrefetchHandler implements QueryHandler<IndexedValueLookup
      */
     private static final int BULK_LOAD_THRESHOLD = 500;
 
-    private final IndexTable mCaseIndexTable;
+    private final CaseIndexTable mCaseIndexTable;
 
     public static final class Cache implements QueryCache {
         Vector<String> currentlyFetchedIndexKeys = new Vector<>();
         private HashMap<String, Vector<Integer>> indexCache = new HashMap<>();
     }
 
-    public CaseIndexPrefetchHandler(IndexTable caseIndexTable) {
+    public CaseIndexPrefetchHandler(CaseIndexTable caseIndexTable) {
         this.mCaseIndexTable = caseIndexTable;
         //TODO: Profile table by each type of index for size to identify threshold changes.
     }


### PR DESCRIPTION
Moving some classes into core for usage in formplayer

cross-request: https://github.com/dimagi/commcare-android/pull/1646