### PR TITLE
Allow Select questions to accept mismatched answers as empty strings

### DIFF
--- a/src/api/java/org/commcare/api/json/PromptToJson.java
+++ b/src/api/java/org/commcare/api/json/PromptToJson.java
@@ -152,15 +152,20 @@ public class PromptToJson {
             case Constants.DATATYPE_CHOICE:
                 Selection singleSelection = ((Selection) answerValue.getValue());
                 singleSelection.attachChoice(prompt.getQuestion());
-                obj.put("answer", ((Selection) answerValue.getValue()).getTouchformsIndex());
+                int singleOrdinal = singleSelection.getTouchformsIndex();
+                if (singleOrdinal > 0) {
+                    obj.put("answer", singleOrdinal);
+                }
                 return;
             case Constants.DATATYPE_CHOICE_LIST:
                 Vector<Selection> selections = ((SelectMultiData) answerValue).getValue();
                 JSONArray acc = new JSONArray();
                 for (Selection selection : selections) {
                     selection.attachChoice(prompt.getQuestion());
-                    int ordinal = selection.getTouchformsIndex();
-                    acc.put(ordinal);
+                    int multiOrdinal = selection.getTouchformsIndex();
+                    if (multiOrdinal > 0){
+                        acc.put(multiOrdinal);
+                    }
                 }
                 obj.put("answer", acc);
                 return;

--- a/src/api/java/org/commcare/api/json/PromptToJson.java
+++ b/src/api/java/org/commcare/api/json/PromptToJson.java
@@ -10,6 +10,7 @@ import org.javarosa.form.api.FormEntryCaption;
 import org.javarosa.form.api.FormEntryController;
 import org.javarosa.form.api.FormEntryModel;
 import org.javarosa.form.api.FormEntryPrompt;
+import org.javarosa.xpath.XPathTypeMismatchException;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.json.JSONArray;

--- a/src/main/java/org/javarosa/core/model/data/helper/Selection.java
+++ b/src/main/java/org/javarosa/core/model/data/helper/Selection.java
@@ -112,17 +112,14 @@ public class Selection implements Externalizable {
         if (choice != null) {
             attachChoice(choice);
         } else {
-            throw new XPathTypeMismatchException("value " + xmlValue + " could not be loaded into question " + q.getTextID()
-                    + ".  Check to see if value " + xmlValue + " is a valid option for question " + q.getTextID() + ".");
+            this.choice = null;
+            this.xmlValue = "";
+            this.index = -1;
         }
     }
 
     public String getValue() {
-        if (xmlValue != null && xmlValue.length() > 0) {
-            return xmlValue;
-        } else {
-            throw new RuntimeException("don't know xml value! perhaps selection was stored as index only and has not yet been linked up to a formdef?");
-        }
+        return xmlValue;
     }
 
     @Override


### PR DESCRIPTION
Fixes https://manage.dimagi.com/default.asp?246509 for formplayer

cc @benrudolph 

@ctsims I'm not sure if there are implications I've not thought of to doing this. Currently in Android we handle this at the getAnswer() level; however, allowing the underlying model to handle mis-matched answers seems reasonable to me. 