### PR TITLE
Implement user-configurable 'blanks' preference for DetailField sorting

### DIFF
--- a/src/main/java/org/commcare/cases/entity/EntitySorter.java
+++ b/src/main/java/org/commcare/cases/entity/EntitySorter.java
@@ -60,7 +60,7 @@ public class EntitySorter implements Comparator<Entity<TreeReference>> {
 
         boolean showBlanksLast = detailFields[index].showBlanksLastInSort();
         // The user's 'blanks' preference is independent of the specified sort order, so don't
-        // worry about the 'reverse' parameter here
+        // factor in the 'reverse' parameter here
         if (a1.equals("")) {
             if (a2.equals("")) {
                 return 0;

--- a/src/main/java/org/commcare/suite/model/DetailField.java
+++ b/src/main/java/org/commcare/suite/model/DetailField.java
@@ -57,6 +57,7 @@ public class DetailField implements Externalizable {
     private int sortOrder = -1;
     private int sortDirection = DIRECTION_ASCENDING;
     private int sortType = Constants.DATATYPE_TEXT;
+    private boolean showBlanksLastInSort = false;
     private int gridX = -1;
     private int gridY = -1;
     private int gridWidth = -1;
@@ -142,6 +143,10 @@ public class DetailField implements Externalizable {
      */
     public int getSortOrder() {
         return sortOrder;
+    }
+
+    public boolean showBlanksLastInSort() {
+        return this.showBlanksLastInSort;
     }
 
     /**
@@ -313,6 +318,10 @@ public class DetailField implements Externalizable {
          */
         public void setSortDirection(int sortDirection) {
             field.sortDirection = sortDirection;
+        }
+
+        public void setShowBlanksLast(boolean blanksLast) {
+            field.showBlanksLastInSort = blanksLast;
         }
 
         public void setSortType(int sortType) {

--- a/src/main/java/org/commcare/xml/DetailFieldParser.java
+++ b/src/main/java/org/commcare/xml/DetailFieldParser.java
@@ -166,8 +166,7 @@ public class DetailFieldParser extends CommCareElementParser<DetailField> {
             //see above comment
         }
 
-        String blanksPreference = parser.getAttributeValue(null, "blanks");
-        builder.setShowBlanksLast(blanksPreference != null && "last".equals(blanksPreference));
+        parseBlanksPreference(builder, direction);
 
         //See if this has a text value for the sort
         if (nextTagInBlock("sort")) {
@@ -177,6 +176,19 @@ public class DetailFieldParser extends CommCareElementParser<DetailField> {
             //Get it if so
             Text sort = new TextParser(parser).parse();
             builder.setSort(sort);
+        }
+    }
+
+    private void parseBlanksPreference(DetailField.Builder builder, String direction) {
+        String blanksPreference = parser.getAttributeValue(null, "blanks");
+        if ("last".equals(blanksPreference)) {
+            builder.setShowBlanksLast(true);
+        } else if ("first".equals(blanksPreference)) {
+            builder.setShowBlanksLast(false);
+        } else {
+            // If HQ hasn't specified "first" or "last", default to the behavior from before the
+            // "blanks" attribute existed
+            builder.setShowBlanksLast(!"ascending".equals(direction));
         }
     }
 }

--- a/src/main/java/org/commcare/xml/DetailFieldParser.java
+++ b/src/main/java/org/commcare/xml/DetailFieldParser.java
@@ -166,6 +166,9 @@ public class DetailFieldParser extends CommCareElementParser<DetailField> {
             //see above comment
         }
 
+        String blanksPreference = parser.getAttributeValue(null, "blanks");
+        builder.setShowBlanksLast(blanksPreference != null && "last".equals(blanksPreference));
+
         //See if this has a text value for the sort
         if (nextTagInBlock("sort")) {
             //Make sure the internal element _is_ a text


### PR DESCRIPTION
Implements Jen's request from http://manage.dimagi.com/default.asp?247874 -- When a detail has a sort property, users can now configure whether cases for which the sort property is blank show up at the top of the list or the bottom. This is specified via a "blanks" attribute on a <sort> element which can take values "first" or "last". This configuration is independent of the specified sort direction (i.e. if blanks="last", blanks will always show up at the end of the case list, whether the sort order is set to ascending or descending).

@orangejenny One important question for you -- You had said to implement this such that if the "blanks" property isn't provided, it defaults to putting blanks at the top, which is what I've done currently. However, I realized via testing that the current behavior is a little more complicated than that. Right now, if the sort order is "ascending", then blanks do default to the top, but if the sort order is "descending", then blanks default to the bottom. I think this was incidental to how the code was written rather than intentional in any way. Should I change my implementation to maintain this default behavior?