### PR TITLE
 empty ledger query regression fix

### DIFF
--- a/src/main/java/org/commcare/cases/util/QueryUtils.java
+++ b/src/main/java/org/commcare/cases/util/QueryUtils.java
@@ -21,7 +21,7 @@ public class QueryUtils {
 
     public static Vector<Integer> wrapSingleResult(Integer result) {
         Vector<Integer> results = new Vector<>();
-        if(result != null) {
+        if (result != null) {
             results.add(result);
         }
         return results;

--- a/src/main/java/org/commcare/cases/util/QueryUtils.java
+++ b/src/main/java/org/commcare/cases/util/QueryUtils.java
@@ -21,7 +21,9 @@ public class QueryUtils {
 
     public static Vector<Integer> wrapSingleResult(Integer result) {
         Vector<Integer> results = new Vector<>();
-        results.add(result);
+        if(result != null) {
+            results.add(result);
+        }
         return results;
     }
 

--- a/src/test/java/org/commcare/cases/ledger/test/LedgerEmptyReferenceTests.java
+++ b/src/test/java/org/commcare/cases/ledger/test/LedgerEmptyReferenceTests.java
@@ -16,10 +16,9 @@ import org.junit.runners.Parameterized;
 import java.util.Collection;
 
 /**
- * Test ledger parsing, loading, and referencing ledgers. No case data is
- * present in these tests.
+ * Test handling of empty ledger queries
  *
- * @author Phillip Mates (pmates@dimagi.com)
+ * @author Clayton Sims
  */
 @RunWith(value = Parameterized.class)
 public class LedgerEmptyReferenceTests {

--- a/src/test/java/org/commcare/cases/ledger/test/LedgerEmptyReferenceTests.java
+++ b/src/test/java/org/commcare/cases/ledger/test/LedgerEmptyReferenceTests.java
@@ -1,0 +1,72 @@
+package org.commcare.cases.ledger.test;
+
+import org.commcare.test.utilities.CaseTestUtils;
+import org.commcare.test.utilities.TestProfileConfiguration;
+import org.commcare.util.mocks.MockDataUtils;
+import org.commcare.util.mocks.MockUserDataSandbox;
+import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.xpath.XPathMissingInstanceException;
+import org.javarosa.xpath.parser.XPathSyntaxException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+
+/**
+ * Test ledger parsing, loading, and referencing ledgers. No case data is
+ * present in these tests.
+ *
+ * @author Phillip Mates (pmates@dimagi.com)
+ */
+@RunWith(value = Parameterized.class)
+public class LedgerEmptyReferenceTests {
+    private EvaluationContext evalContextWithLedger;
+
+    TestProfileConfiguration config;
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection data() {
+        return TestProfileConfiguration.BulkOffOn();
+    }
+
+    public LedgerEmptyReferenceTests(TestProfileConfiguration config) {
+        this.config = config;
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        MockUserDataSandbox sandbox = MockDataUtils.getStaticStorage();
+
+        config.parseIntoSandbox(this.getClass().getResourceAsStream("/ledger_tests/no_data_restore.xml"), sandbox, true);
+
+        evalContextWithLedger =
+                MockDataUtils.buildContextWithInstance(sandbox, "ledger", CaseTestUtils.LEDGER_INSTANCE);
+    }
+    @Test
+    public void queryMissingLedgerPath() throws XPathSyntaxException {
+        Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(evalContextWithLedger,
+                "instance('ledger')/ledgerdb/ledger[@entity-id='H_mart']",
+                ""));
+        Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(evalContextWithLedger,
+                "instance('ledger')/ledgerdb/ledger[@entity-id='market_basket']/section[@section-id='amphibious_stock']",
+                ""));
+        Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(evalContextWithLedger,
+                "instance('ledger')/ledgerdb/ledger[@entity-id='market_basket']/section[@section-id='cleaning_stock']/entry[@id='bleach']",
+                ""));
+
+        Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(evalContextWithLedger,
+                "instance('ledger')/ledgerdb/ledger[@entity-id='H_mart']/section[@section-id='edible_stock']/entry[@id='beans']",
+                ""));
+        Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(evalContextWithLedger,
+                "instance('ledger')/ledgerdb/ledger[@entity-id='market_basket']/section[@section-id='amphibious_stock']/entry[@id='beans']",
+                ""));
+    }
+
+    @Test(expected = XPathMissingInstanceException.class)
+    public void ledgerQueriesWithNoLedgerInstance() throws XPathSyntaxException {
+        EvaluationContext emptyEvalContext = new EvaluationContext(null);
+        CaseTestUtils.xpathEval(emptyEvalContext, "instance('ledger')/ledgerdb/ledger[@entity-id='H_mart']");
+    }
+}

--- a/src/test/resources/ledger_tests/no_data_restore.xml
+++ b/src/test/resources/ledger_tests/no_data_restore.xml
@@ -1,0 +1,12 @@
+<OpenRosaResponse>
+    <message nature="ota_restore_success">Successfully restored account test!</message>
+    <Sync xmlns="http://commcarehq.org/sync">
+        <restore_id>sync_token_a</restore_id>
+    </Sync>
+    <Registration xmlns="http://openrosa.org/user/registration">
+        <username>test</username>
+        <password>sha1$60441$53cf77c2ac3608a944db96af177a6dfe1579e4ba</password>
+        <uuid>test_example</uuid>
+        <date>2012-04-30</date>
+    </Registration>
+</OpenRosaResponse>


### PR DESCRIPTION
Tests and fix for empty ledger queries getting incorrectly populated with a null index

cross-request: https://github.com/dimagi/commcare-android/pull/1683