### PR TITLE
Return instead of crash when rootLookup is null

### DIFF
--- a/src/main/java/org/commcare/cases/query/queryset/DerivedCaseQueryLookup.java
+++ b/src/main/java/org/commcare/cases/query/queryset/DerivedCaseQueryLookup.java
@@ -60,7 +60,7 @@ public abstract class DerivedCaseQueryLookup implements QuerySetLookup {
     public List<Integer> performSetLookup(TreeReference lookupIdKey, QueryContext queryContext) {
         List<Integer> rootLookup = root.performSetLookup(lookupIdKey, queryContext);
         ModelQuerySet set = getOrLoadCachedQuerySet(queryContext);
-        if(set == null) {
+        if (set == null || rootLookup == null) {
             return null;
         }
 


### PR DESCRIPTION
@ctsims L10K's app was crashing on one case list where this value was null. Returning null (instead of NPE crashing) seems to have resolved the issue. Root cause might be that this case's owner was deleted. Not sure if this will break other things so Don't Pull until confirmed this change is safe. 