### PR TITLE
Fix persistent case tile in form linking

### DIFF
--- a/src/main/java/org/commcare/session/CommCareSession.java
+++ b/src/main/java/org/commcare/session/CommCareSession.java
@@ -873,8 +873,8 @@ public class CommCareSession {
         int stepId = -1;
         //walk to our datum
         for (int i = 0; i < steps.size(); ++i) {
-            if (SessionFrame.STATE_DATUM_VAL.equals(steps.elementAt(i).getType()) &&
-                    steps.elementAt(i).getId().equals(datumId)) {
+            StackFrameStep step = steps.elementAt(i);
+            if (step.getId().equals(datumId) && stepIsOfType(step, SessionFrame.STATE_DATUM_VAL)) {
                 stepId = i;
                 break;
             }
@@ -901,6 +901,19 @@ public class CommCareSession {
             }
         }
         return null;
+    }
+
+    /**
+     *
+     * @param step
+     * @param desiredType
+     * @return true if the given step is either explicitly of the given type, or if it is of
+     * unknown type and guessUnknownType() returns the given type
+     */
+    private boolean stepIsOfType(StackFrameStep step, String desiredType) {
+        return desiredType.equals(step.getType()) ||
+                (SessionFrame.STATE_UNKNOWN.equals(step.getType())
+                        && desiredType.equals(guessUnknownType(step)));
     }
 
     private void markCurrentFrameForDeath() {


### PR DESCRIPTION
Fix for https://manage.dimagi.com/default.asp?254740. Similar to the solutions of some other tickets we've had over the last year or so, we just needed to be checking for the UNKNOWN_TYPE as well as the explicit desired type, and if it is unknown, compare against the result of guessUnknownType().