### PR TITLE
2.36 hotfix - Quarantine on read failure

### DIFF
--- a/src/main/java/org/javarosa/core/io/StreamsUtil.java
+++ b/src/main/java/org/javarosa/core/io/StreamsUtil.java
@@ -93,8 +93,8 @@ public class StreamsUtil {
      * Writes input stream to output stream in a buffered fasion, but doesn't
      * close either stream.
      */
-    public static void writeFromInputToOutputUnmanaged(InputStream is,
-                                                       OutputStream os) throws IOException {
+    public static void writeFromInputToOutputUnmanaged(InputStream is, OutputStream os)
+            throws InputIOException, OutputIOException {
         int count;
         byte[] buffer = new byte[8192];
         try {

--- a/src/main/java/org/javarosa/core/io/StreamsUtil.java
+++ b/src/main/java/org/javarosa/core/io/StreamsUtil.java
@@ -95,11 +95,24 @@ public class StreamsUtil {
      */
     public static void writeFromInputToOutputUnmanaged(InputStream is,
                                                        OutputStream os) throws IOException {
+        int count;
         byte[] buffer = new byte[8192];
-        int count = is.read(buffer);
-        while (count != -1) {
-            os.write(buffer, 0, count);
+        try {
             count = is.read(buffer);
+        } catch (IOException e) {
+            throw new StreamsUtil().new InputIOException(e);
+        }
+        while (count != -1) {
+            try {
+                os.write(buffer, 0, count);
+            } catch (IOException e) {
+                throw new StreamsUtil().new OutputIOException(e);
+            }
+            try {
+                count = is.read(buffer);
+            } catch (IOException e) {
+                throw new StreamsUtil().new InputIOException(e);
+            }
         }
     }
 


### PR DESCRIPTION
Addresses http://manage.dimagi.com/default.asp?255101.

We think this should fix https://manage.dimagi.com/default.asp?254634, but I have thus far been unable to replicate the error they are getting, so not positive. Clayton is going to take a stab at it, but either way this is clearly an improved state, so I think we should go forward with it even if we can't verify it ourselves.