### PR TITLE
Use command's EvaluationContext

### DIFF
--- a/src/main/java/org/commcare/suite/model/MenuLoader.java
+++ b/src/main/java/org/commcare/suite/model/MenuLoader.java
@@ -107,13 +107,12 @@ public class MenuLoader {
                                            Vector<MenuDisplayable> items,
                                            Hashtable<String, Entry> map)
             throws XPathSyntaxException {
-        EvaluationContext ec = sessionWrapper.getEvaluationContext();
         xPathErrorMessage = "";
         for (String command : m.getCommandIds()) {
             XPathExpression mRelevantCondition = m.getCommandRelevance(m.indexOfCommand(command));
             if (mRelevantCondition != null) {
                 xPathErrorMessage = m.getCommandRelevanceRaw(m.indexOfCommand(command));
-                Object ret = mRelevantCondition.eval(ec);
+                Object ret = mRelevantCondition.eval(sessionWrapper.getEvaluationContext(command));
                 try {
                     if (!FunctionUtils.toBoolean(ret)) {
                         continue;


### PR DESCRIPTION
fixes https://manage.dimagi.com/default.asp?254666

When evaluating a menu's displayables we should be getting the properly generated new EvaluationContext rather than using the same as the parents. 