### PR TITLE
Test downgrading the model cache size

### DIFF
--- a/src/main/java/org/commcare/modern/engine/cases/CaseGroupResultCache.java
+++ b/src/main/java/org/commcare/modern/engine/cases/CaseGroupResultCache.java
@@ -12,7 +12,7 @@ import java.util.LinkedHashSet;
 
 public class CaseGroupResultCache implements QueryCache {
 
-    public static final int MAX_PREFETCH_CASE_BLOCK = 7500;
+    public static final int MAX_PREFETCH_CASE_BLOCK = 2000;
 
     private HashMap<String,LinkedHashSet<Integer>> bulkFetchBodies = new HashMap<>();
 


### PR DESCRIPTION
This is a quick test to see if it will fix

https://manage.dimagi.com/default.asp?255503

or https://manage.dimagi.com/default.asp?255507

Should never be pulled until it's adjusted to set the targets dynamically based on heap or something, or generally allows some tuning to retain the original functionality.
