### PR TITLE
Handle calcs that do not return nodeset

### DIFF
--- a/src/main/java/org/javarosa/xpath/expr/XPathExpression.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathExpression.java
@@ -39,18 +39,15 @@ public abstract class XPathExpression implements Externalizable {
     }
 
     public static void serializeResult(Object value, OutputStream output) throws IOException {
-        if (!isLeafNode(value)) {
+        if (value instanceof XPathNodeset && !isLeafNode((XPathNodeset) value)) {
             serializeElements((XPathNodeset) value, output);
         } else {
             output.write(FunctionUtils.toString(value).getBytes(StandardCharsets.UTF_8));
         }
     }
 
-    private static boolean isLeafNode(Object value) {
-        if (!(value instanceof XPathNodeset)) {
-            return false;
-        }
-        XPathNodeset nodeset = (XPathNodeset) value;
+    private static boolean isLeafNode(XPathNodeset value) {
+        XPathNodeset nodeset = value;
         Vector<TreeReference> refs = nodeset.getReferences();
         if (refs == null || refs.size() != 1) {
             return false;


### PR DESCRIPTION
@wpride dumb mistake, this allows for values that aren't xpath nodesets to work like `true()`. (tests in formplayer pr)