### PR TITLE
Memory Tuning for Optimizations

### DIFF
--- a/src/main/java/org/commcare/cases/entity/NodeEntityFactory.java
+++ b/src/main/java/org/commcare/cases/entity/NodeEntityFactory.java
@@ -125,7 +125,7 @@ public class NodeEntityFactory {
      * we're currently iterating over a potentially large set of elements and should batch
      * appropriately
      */
-    private void setEvaluationContextDefaultQuerySet(EvaluationContext ec,
+    protected void setEvaluationContextDefaultQuerySet(EvaluationContext ec,
                                                      List<TreeReference> result) {
 
         QueryContext newContext = ec.getCurrentQueryContext()

--- a/src/main/java/org/commcare/cases/query/QueryContext.java
+++ b/src/main/java/org/commcare/cases/query/QueryContext.java
@@ -39,9 +39,17 @@ public class QueryContext {
 
     private QueryContext potentialSpawnedContext;
 
-    //Until we can keep track more robustly of the individual spheres of 'bulk' models
-    //we'll just keep track of the dominant factor in our queries to know what to expect
-    //WRT whether optimizatons will help or hurt
+    /**
+     * Context scope roughly keeps track of "how many times is the current query possibly going to
+     * run". For instance, when evaluating an xpath like
+     *
+     * instance('casedb')/casedb/case[@case_type='person'][complex_filter = 'pass']
+     *
+     * If 500 <case/> nodes match the first predicate (='person') the context scope will escalate
+     * to 500. This lets individual expressions later (like 'complex_filter' )identify that it's
+     * worth them doing a bit of extra work if they can anticipate making the 'next' evaluation
+     * faster.
+     */
     private int contextScope = 1;
 
     public QueryContext() {

--- a/src/main/java/org/commcare/modern/engine/cases/CaseGroupResultCache.java
+++ b/src/main/java/org/commcare/modern/engine/cases/CaseGroupResultCache.java
@@ -7,15 +7,21 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 
 /**
+ * A case group result cache keeps track of different sets of "Bulk" cases which are
+ * likely to have data or operations tracked about them (IE: results of a common query which
+ * are likely to have further filtering applied.
+ *
+ * Since these results are often captured/reported before a context is escalated, this cache
+ * doesn't directly hold the resulting cached cases themselves. Rather a CaseObjectCache should
+ * be used to track the resulting cases. This will ensure that cache can be attached to the
+ * appropriate lifecycle
+ *
  * Created by ctsims on 1/25/2017.
  */
 
 public class CaseGroupResultCache implements QueryCache {
 
     private HashMap<String,LinkedHashSet<Integer>> bulkFetchBodies = new HashMap<>();
-
-    private HashMap<Integer, Case> cachedCases = new HashMap<>();
-
 
     public void reportBulkCaseBody(String key, LinkedHashSet<Integer> ids) {
         if(bulkFetchBodies.containsKey(key)) {
@@ -25,7 +31,7 @@ public class CaseGroupResultCache implements QueryCache {
     }
 
     public boolean hasMatchingCaseSet(int recordId) {
-        return isLoaded(recordId) || getTranche(recordId) != null;
+        return getTranche(recordId) != null;
     }
 
     public LinkedHashSet<Integer> getTranche(int recordId) {
@@ -35,17 +41,5 @@ public class CaseGroupResultCache implements QueryCache {
             }
         }
         return null;
-    }
-
-    public boolean isLoaded(int recordId) {
-        return cachedCases.containsKey(recordId);
-    }
-
-    public HashMap<Integer, Case> getLoadedCaseMap() {
-        return cachedCases;
-    }
-
-    public Case getLoadedCase(int recordId) {
-        return cachedCases.get(recordId);
     }
 }

--- a/src/main/java/org/commcare/modern/engine/cases/CaseGroupResultCache.java
+++ b/src/main/java/org/commcare/modern/engine/cases/CaseGroupResultCache.java
@@ -2,6 +2,7 @@ package org.commcare.modern.engine.cases;
 
 import org.commcare.cases.model.Case;
 import org.commcare.cases.query.QueryCache;
+import org.commcare.modern.util.Pair;
 
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -34,10 +35,11 @@ public class CaseGroupResultCache implements QueryCache {
         return getTranche(recordId) != null;
     }
 
-    public LinkedHashSet<Integer> getTranche(int recordId) {
-        for(LinkedHashSet<Integer> tranche: bulkFetchBodies.values()) {
+    public Pair<String, LinkedHashSet<Integer>> getTranche(int recordId) {
+        for(String key : bulkFetchBodies.keySet()) {
+            LinkedHashSet<Integer> tranche = bulkFetchBodies.get(key);
             if(tranche.contains(recordId)){
-                return tranche;
+                return new Pair<>(key, tranche);
             }
         }
         return null;

--- a/src/main/java/org/commcare/modern/engine/cases/CaseGroupResultCache.java
+++ b/src/main/java/org/commcare/modern/engine/cases/CaseGroupResultCache.java
@@ -25,7 +25,7 @@ public class CaseGroupResultCache implements QueryCache {
     private HashMap<String,LinkedHashSet<Integer>> bulkFetchBodies = new HashMap<>();
 
     public void reportBulkCaseBody(String key, LinkedHashSet<Integer> ids) {
-        if(bulkFetchBodies.containsKey(key)) {
+        if (bulkFetchBodies.containsKey(key)) {
             return;
         }
         bulkFetchBodies.put(key, ids);
@@ -36,9 +36,9 @@ public class CaseGroupResultCache implements QueryCache {
     }
 
     public Pair<String, LinkedHashSet<Integer>> getTranche(int recordId) {
-        for(String key : bulkFetchBodies.keySet()) {
+        for (String key : bulkFetchBodies.keySet()) {
             LinkedHashSet<Integer> tranche = bulkFetchBodies.get(key);
-            if(tranche.contains(recordId)){
+            if (tranche.contains(recordId)) {
                 return new Pair<>(key, tranche);
             }
         }

--- a/src/main/java/org/commcare/modern/engine/cases/CaseGroupResultCache.java
+++ b/src/main/java/org/commcare/modern/engine/cases/CaseGroupResultCache.java
@@ -12,8 +12,6 @@ import java.util.LinkedHashSet;
 
 public class CaseGroupResultCache implements QueryCache {
 
-    public static final int MAX_PREFETCH_CASE_BLOCK = 7500;
-
     private HashMap<String,LinkedHashSet<Integer>> bulkFetchBodies = new HashMap<>();
 
     private HashMap<Integer, Case> cachedCases = new HashMap<>();

--- a/src/main/java/org/commcare/modern/engine/cases/CaseIndexQuerySetTransform.java
+++ b/src/main/java/org/commcare/modern/engine/cases/CaseIndexQuerySetTransform.java
@@ -68,7 +68,7 @@ public class CaseIndexQuerySetTransform implements QuerySetTransform {
         private void cacheCaseModelQuerySet(QueryContext queryContext, DualTableSingleMatchModelQuerySet ret) {
             int modelQueryMagnitude = ret.getSetBody().size();
             if(modelQueryMagnitude > QueryContext.BULK_QUERY_THRESHOLD && modelQueryMagnitude < PerformanceTuningUtil.getMaxPrefetchCaseBlock()) {
-                queryContext.getQueryCache(CaseGroupResultCache.class).reportBulkCaseBody(this.getCurrentQuerySetId(), ret.getSetBody());
+                queryContext.getQueryCache(CaseSetResultCache.class).reportBulkCaseSet(this.getCurrentQuerySetId(), ret.getSetBody());
             }
         }
 

--- a/src/main/java/org/commcare/modern/engine/cases/CaseIndexQuerySetTransform.java
+++ b/src/main/java/org/commcare/modern/engine/cases/CaseIndexQuerySetTransform.java
@@ -7,6 +7,7 @@ import org.commcare.cases.query.queryset.DualTableSingleMatchModelQuerySet;
 import org.commcare.cases.query.queryset.ModelQuerySet;
 import org.commcare.cases.query.queryset.QuerySetLookup;
 import org.commcare.cases.query.queryset.QuerySetTransform;
+import org.commcare.modern.util.PerformanceTuningUtil;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.model.trace.EvaluationTrace;
 
@@ -66,7 +67,7 @@ public class CaseIndexQuerySetTransform implements QuerySetTransform {
 
         private void cacheCaseModelQuerySet(QueryContext queryContext, DualTableSingleMatchModelQuerySet ret) {
             int modelQueryMagnitude = ret.getSetBody().size();
-            if(modelQueryMagnitude > QueryContext.BULK_QUERY_THRESHOLD && modelQueryMagnitude < CaseGroupResultCache.MAX_PREFETCH_CASE_BLOCK) {
+            if(modelQueryMagnitude > QueryContext.BULK_QUERY_THRESHOLD && modelQueryMagnitude < PerformanceTuningUtil.getMaxPrefetchCaseBlock()) {
                 queryContext.getQueryCache(CaseGroupResultCache.class).reportBulkCaseBody(this.getCurrentQuerySetId(), ret.getSetBody());
             }
         }

--- a/src/main/java/org/commcare/modern/engine/cases/CaseObjectCache.java
+++ b/src/main/java/org/commcare/modern/engine/cases/CaseObjectCache.java
@@ -1,0 +1,32 @@
+package org.commcare.modern.engine.cases;
+
+import org.commcare.cases.model.Case;
+import org.commcare.cases.query.QueryCache;
+
+import java.util.HashMap;
+
+/**
+ * A straightforward cache object query cache. Stores cases by their record ID.
+ *
+ * Used by other optimizations to isolate doing bulk loads and ensure that they are relevant
+ * when they occur
+ *
+ * Created by ctsims on 6/22/2017.
+ */
+
+public class CaseObjectCache implements QueryCache {
+
+    private HashMap<Integer, Case> cachedCases = new HashMap<>();
+
+    public boolean isLoaded(int recordId) {
+        return cachedCases.containsKey(recordId);
+    }
+
+    public HashMap<Integer, Case> getLoadedCaseMap() {
+        return cachedCases;
+    }
+
+    public Case getLoadedCase(int recordId) {
+        return cachedCases.get(recordId);
+    }
+}

--- a/src/main/java/org/commcare/modern/engine/cases/CaseSetResultCache.java
+++ b/src/main/java/org/commcare/modern/engine/cases/CaseSetResultCache.java
@@ -1,6 +1,5 @@
 package org.commcare.modern.engine.cases;
 
-import org.commcare.cases.model.Case;
 import org.commcare.cases.query.QueryCache;
 import org.commcare.modern.util.Pair;
 
@@ -20,11 +19,11 @@ import java.util.LinkedHashSet;
  * Created by ctsims on 1/25/2017.
  */
 
-public class CaseGroupResultCache implements QueryCache {
+public class CaseSetResultCache implements QueryCache {
 
     private HashMap<String,LinkedHashSet<Integer>> bulkFetchBodies = new HashMap<>();
 
-    public void reportBulkCaseBody(String key, LinkedHashSet<Integer> ids) {
+    public void reportBulkCaseSet(String key, LinkedHashSet<Integer> ids) {
         if (bulkFetchBodies.containsKey(key)) {
             return;
         }
@@ -32,10 +31,10 @@ public class CaseGroupResultCache implements QueryCache {
     }
 
     public boolean hasMatchingCaseSet(int recordId) {
-        return getTranche(recordId) != null;
+        return getCaseSetForRecord(recordId) != null;
     }
 
-    public Pair<String, LinkedHashSet<Integer>> getTranche(int recordId) {
+    public Pair<String, LinkedHashSet<Integer>> getCaseSetForRecord(int recordId) {
         for (String key : bulkFetchBodies.keySet()) {
             LinkedHashSet<Integer> tranche = bulkFetchBodies.get(key);
             if (tranche.contains(recordId)) {

--- a/src/main/java/org/commcare/modern/util/PerformanceTuningUtil.java
+++ b/src/main/java/org/commcare/modern/util/PerformanceTuningUtil.java
@@ -27,19 +27,20 @@ public class PerformanceTuningUtil {
      * @return A heuristic for the largest safe value for block prefetch based on the
      * current device runtime.
      */
-    public static int identifyDefaultPrefetchBlockSize() {
+    public static int guessLargestSupportedBulkCaseFetchSizeFromHeap() {
         Runtime rt = Runtime.getRuntime();
         long maxMemory = rt.maxMemory();
 
-        return identifyDefaultPrefetchBlockSize(maxMemory);
+        return guessLargestSupportedBulkCaseFetchSizeFromHeap(maxMemory);
     }
 
     /**
      * @return A heuristic for the largest safe value for block prefetch based on a provided
      * amount of memory which should be available for optimizations.
      */
-    public static int identifyDefaultPrefetchBlockSize(long availableMemoryInBytes) {
+    public static int guessLargestSupportedBulkCaseFetchSizeFromHeap(long availableMemoryInBytes) {
         if (availableMemoryInBytes == 0 || availableMemoryInBytes == -1) {
+            //This was the existing tuned default, so don't change it until we have a better guess.
             return 7500;
         } else {
             if (availableMemoryInBytes <= MB_64) {
@@ -59,7 +60,7 @@ public class PerformanceTuningUtil {
      */
     public static int getMaxPrefetchCaseBlock() {
         if (MAX_PREFETCH_CASE_BLOCK == -1) {
-            updateMaxPrefetchCaseBlock(identifyDefaultPrefetchBlockSize());
+            updateMaxPrefetchCaseBlock(guessLargestSupportedBulkCaseFetchSizeFromHeap());
         }
         return MAX_PREFETCH_CASE_BLOCK;
     }

--- a/src/main/java/org/commcare/modern/util/PerformanceTuningUtil.java
+++ b/src/main/java/org/commcare/modern/util/PerformanceTuningUtil.java
@@ -39,6 +39,10 @@ public class PerformanceTuningUtil {
      * amount of memory which should be available for optimizations.
      */
     public static int guessLargestSupportedBulkCaseFetchSizeFromHeap(long availableMemoryInBytes) {
+        //NOTE: These are just tuned from experience and testing on mobile devices around values
+        //which prevent them from running out of memory. It would be well worth it in the
+        //future to take a more comprehensive approach.
+
         if (availableMemoryInBytes == 0 || availableMemoryInBytes == -1) {
             //This was the existing tuned default, so don't change it until we have a better guess.
             return 7500;

--- a/src/main/java/org/commcare/modern/util/PerformanceTuningUtil.java
+++ b/src/main/java/org/commcare/modern/util/PerformanceTuningUtil.java
@@ -39,12 +39,12 @@ public class PerformanceTuningUtil {
      * amount of memory which should be available for optimizations.
      */
     public static int identifyDefaultPrefetchBlockSize(long availableMemoryInBytes) {
-        if(availableMemoryInBytes ==0 || availableMemoryInBytes == -1) {
+        if (availableMemoryInBytes == 0 || availableMemoryInBytes == -1) {
             return 7500;
         } else {
-            if(availableMemoryInBytes <= MB_64) {
+            if (availableMemoryInBytes <= MB_64) {
                 return 2500;
-            } else if(availableMemoryInBytes <= MB_256) {
+            } else if (availableMemoryInBytes <= MB_256) {
                 return 7500;
             } else if (availableMemoryInBytes <= MB_1024) {
                 return 15000;
@@ -58,7 +58,7 @@ public class PerformanceTuningUtil {
      * @return The maximum number of cases which will be included in a "Pre-Fetch Batch".
      */
     public static int getMaxPrefetchCaseBlock() {
-        if(MAX_PREFETCH_CASE_BLOCK == -1) {
+        if (MAX_PREFETCH_CASE_BLOCK == -1) {
             updateMaxPrefetchCaseBlock(identifyDefaultPrefetchBlockSize());
         }
         return MAX_PREFETCH_CASE_BLOCK;

--- a/src/main/java/org/commcare/modern/util/PerformanceTuningUtil.java
+++ b/src/main/java/org/commcare/modern/util/PerformanceTuningUtil.java
@@ -1,0 +1,66 @@
+package org.commcare.modern.util;
+
+/**
+ * A catch-all for centralizing hooks and state for tuning on performance optimizations which may
+ * need to shift constants or boundaries based on the current platform
+ *
+ * Created by ctsims on 6/21/2017.
+ */
+
+public class PerformanceTuningUtil {
+    private static int MAX_PREFETCH_CASE_BLOCK = -1;
+
+    private static final long MB_64 = 64 * 1024 * 2014;
+    private static final long MB_256 = 256 * 1024 * 2014;
+    private static final long MB_1024 = 1024 * 1024 * 2014;
+
+    /**
+     * Update the constant size of cases eligible for batch "pre-fetch" in db ops. This
+     * is roughly the number of cases which can be expected to reliably fit into memory without
+     * lowering the available heap sufficiently to introduce stability concerns.
+     */
+    public static void updateMaxPrefetchCaseBlock(int newMaxSize) {
+        MAX_PREFETCH_CASE_BLOCK = newMaxSize;
+    }
+
+    /**
+     * @return A heuristic for the largest safe value for block prefetch based on the
+     * current device runtime.
+     */
+    public static int identifyDefaultPrefetchBlockSize() {
+        Runtime rt = Runtime.getRuntime();
+        long maxMemory = rt.maxMemory();
+
+        return identifyDefaultPrefetchBlockSize(maxMemory);
+    }
+
+    /**
+     * @return A heuristic for the largest safe value for block prefetch based on a provided
+     * amount of memory which should be available for optimizations.
+     */
+    public static int identifyDefaultPrefetchBlockSize(long availableMemoryInBytes) {
+        if(availableMemoryInBytes ==0 || availableMemoryInBytes == -1) {
+            return 7500;
+        } else {
+            if(availableMemoryInBytes <= MB_64) {
+                return 2500;
+            } else if(availableMemoryInBytes <= MB_256) {
+                return 7500;
+            } else if (availableMemoryInBytes <= MB_1024) {
+                return 15000;
+            } else {
+                return 50000;
+            }
+        }
+    }
+
+    /*
+     * @return The maximum number of cases which will be included in a "Pre-Fetch Batch".
+     */
+    public static int getMaxPrefetchCaseBlock() {
+        if(MAX_PREFETCH_CASE_BLOCK == -1) {
+            updateMaxPrefetchCaseBlock(identifyDefaultPrefetchBlockSize());
+        }
+        return MAX_PREFETCH_CASE_BLOCK;
+    }
+}


### PR DESCRIPTION
Fix for:

https://manage.dimagi.com/default.asp?255503
and
https://manage.dimagi.com/default.asp?255507

This effectively disables a lot of the optimizations for async factory restores, because the async cases end up loading quite differently in a way that tanks the memory.

Specifically this splits up the case group bulk fetch process to allow _reporting_ in an un-escalated context, but caching into only the bulk context, then allows the async process to prevent a carryforward of the escalated scope.

It also implements a process which allows platforms to define their own boundaries for the bulk fetches based on available memory. This should both prevent issues on small heap devices, and enable platforms like Touchforms to grow their heap

I tested the impact against a the UATBC list and confirmed that the downside is limited to needing to load the bulk query context twice (between the "search" and "Expand" phases of a case list) which is a small impact on performance.

cross-request: https://github.com/dimagi/commcare-android/pull/1746