### PR TITLE
Rethrowing XPathException from NodeEntityFactory:getEntity function

### DIFF
--- a/src/main/java/org/commcare/cases/entity/NodeEntityFactory.java
+++ b/src/main/java/org/commcare/cases/entity/NodeEntityFactory.java
@@ -67,11 +67,17 @@ public class NodeEntityFactory {
                     sortData[count] = sortText.evaluate(nodeContext);
                 }
                 relevancyData[count] = f.isRelevant(nodeContext);
-            } catch (XPathSyntaxException e) {
-                storeErrorDetails(e, count, fieldData, relevancyData);
-            } catch (XPathException xpe) {
-                //XPathErrorLogger.INSTANCE.logErrorToCurrentApp(xpe);
-                storeErrorDetails(xpe, count, fieldData, relevancyData);
+            } catch (XPathSyntaxException | XPathException e) {
+                /**
+                 * TODO: 25/06/17 remove catch blocks from here
+                 * We are wrapping the original exception in a new XPathException to avoid
+                 * refactoring large number of functions caused by throwing XPathSyntaxException here.
+                 */
+                XPathException xe = new XPathException(e.getMessage(), e);
+                if (e instanceof XPathException) {
+                    xe.setSource(((XPathException)e).getSource());
+                }
+                throw xe;
             }
             count++;
         }
@@ -95,15 +101,6 @@ public class NodeEntityFactory {
             }
         }
         return null;
-    }
-
-    private static void storeErrorDetails(Exception e, int index,
-                                          Object[] details,
-                                          boolean[] relevancyDetails) {
-        e.printStackTrace();
-        details[index] = "<invalid xpath: " + e.getMessage() + ">";
-        // assume that if there's an error, user should see it
-        relevancyDetails[index] = true;
     }
 
     public List<TreeReference> expandReferenceList(TreeReference treeReference) {

--- a/src/main/java/org/javarosa/xpath/XPathException.java
+++ b/src/main/java/org/javarosa/xpath/XPathException.java
@@ -17,6 +17,10 @@ public class XPathException extends RuntimeException {
         super(s);
     }
 
+    public XPathException(String s, Throwable cause) {
+        super(s, cause);
+    }
+
     public void setMessagePrefix(String prefix){
         this.prefix = prefix;
     }


### PR DESCRIPTION
Case url: https://manage.dimagi.com/default.asp?255119#1353059

Ideally we should not be catching exception in NodeEntityFactory at all. Though right now throwing XPathSyntaxException is disrupting the whole function stack at various places in code and therefore we are wrapping it in XPathException(a RuntimeException) before throwing it.
