### PR TITLE
Fix install failure on empty relevancy condition

### DIFF
--- a/src/main/java/org/commcare/suite/model/Detail.java
+++ b/src/main/java/org/commcare/suite/model/Detail.java
@@ -145,7 +145,7 @@ public class Detail implements Externalizable {
             numEntitiesToDisplayPerRow = 1;
         }
 
-        if (relevancy != null) {
+        if (relevancy != null && !"".equals(relevancy)) {
             try {
                 this.parsedRelevancyExpression = XPathParseTool.parseXPath(relevancy);
             } catch (XPathSyntaxException e) {


### PR DESCRIPTION
Ignore an empty relevancy condition on a <detail> instead of failing to install the app