### PR TITLE
Ignore empty nodeset attribute in detail

### DIFF
--- a/src/main/java/org/commcare/suite/model/Detail.java
+++ b/src/main/java/org/commcare/suite/model/Detail.java
@@ -114,7 +114,7 @@ public class Detail implements Externalizable {
 
         this.id = id;
         this.title = title;
-        if (nodeset != null) {
+        if (nodeset != null && !"".equals(nodeset)) {
             this.nodeset = XPathReference.getPathExpr(nodeset).getReference();
         }
         this.details = ArrayUtilities.copyIntoArray(detailsVector, new Detail[detailsVector.size()]);


### PR DESCRIPTION
This PR makes it so that if the `nodeset` attribute is included on a `<detail>` but is empty (this is what happens if a user adds a detail tab with a nodeset on HQ but doesn't fill in any expression), we just ignore it instead of failing on app install. I know we usually favor failing hard/fast, but given the situation that would lead to this, it seemed like a good candidate to me for making an exception to that rule.

fyi @mkangia