### PR TITLE
XPath Parser Error Message Fix

### DIFF
--- a/src/main/java/org/javarosa/xform/parse/XFormParser.java
+++ b/src/main/java/org/javarosa/xform/parse/XFormParser.java
@@ -1614,9 +1614,10 @@ public class XFormParser {
             tref = TreeReference.selfRef(); //only happens for <group>s with no binding
         }
 
+        TreeReference refPreContextualization = tref;
         tref = tref.parent(parentRef);
         if (tref == null) {
-            throw new XFormParseException("Binding path [" + ref.getReference().toString(true) + "] not allowed with parent binding of [" + parentRef + "]");
+            throw new XFormParseException("Binding path [" + refPreContextualization.toString(true) + "] not allowed with parent binding of [" + parentRef + "]");
         }
 
         return new XPathReference(tref);

--- a/src/main/java/org/javarosa/xform/parse/XFormParser.java
+++ b/src/main/java/org/javarosa/xform/parse/XFormParser.java
@@ -1616,7 +1616,7 @@ public class XFormParser {
 
         tref = tref.parent(parentRef);
         if (tref == null) {
-            throw new XFormParseException("Binding path [" + tref + "] not allowed with parent binding of [" + parentRef + "]");
+            throw new XFormParseException("Binding path [" + ref.getReference().toString(true) + "] not allowed with parent binding of [" + parentRef + "]");
         }
 
         return new XPathReference(tref);


### PR DESCRIPTION
Fixes an issue where an error message would always display "null" as part of its message, rather than a useful piece of context.