### PR TITLE
Date Formatting w/Other Calendar Schemes

### DIFF
--- a/src/main/java/org/commcare/util/DefaultArrayDataSource.java
+++ b/src/main/java/org/commcare/util/DefaultArrayDataSource.java
@@ -1,6 +1,10 @@
 package org.commcare.util;
 
 /**
+ * The default source of month name data in alternate calendars.
+ *
+ * Should be maintained for any calendars which are in the core system and not extensions.
+ *
  * Created by ctsims on 7/19/2017.
  */
 

--- a/src/main/java/org/commcare/util/DefaultArrayDataSource.java
+++ b/src/main/java/org/commcare/util/DefaultArrayDataSource.java
@@ -1,0 +1,47 @@
+package org.commcare.util;
+
+/**
+ * Created by ctsims on 7/19/2017.
+ */
+
+public class DefaultArrayDataSource implements ArrayDataSource {
+
+    private String[] ethiopian = new String[]{
+            "Mäskäräm",
+            "T’ïk’ïmt",
+            "Hïdar",
+            "Tahsas",
+            "T’ïr",
+            "Yäkatit",
+            "Mägabit",
+            "Miyaziya",
+            "Gïnbot",
+            "Säne",
+            "Hämle",
+            "Nähäse",
+            "P’agume"};
+
+    private String[] nepali = new String[]{
+            "Baishakh",
+            "Jestha",
+            "Ashadh",
+            "Shrawan",
+            "Bhadra",
+            "Ashwin",
+            "Kartik",
+            "Mangsir",
+            "Poush",
+            "Magh",
+            "Falgun",
+            "Chaitra"};
+
+    @Override
+    public String[] getArray(String key) {
+        if("ethiopian_months".equals(key)) {
+            return ethiopian;
+        } else if("nepali_months".equals(key)) {
+            return nepali;
+        }
+        throw new RuntimeException("No supported fallback month names for calendar: " + key);
+    }
+}

--- a/src/main/java/org/commcare/util/LocaleArrayDataSource.java
+++ b/src/main/java/org/commcare/util/LocaleArrayDataSource.java
@@ -1,14 +1,34 @@
 package org.commcare.util;
 
 import org.javarosa.core.services.locale.Localization;
+import org.javarosa.core.util.NoLocalizedTextException;
 
 /**
  * Get localized arrays from the Localization file system (stored as comma separated lists)
  */
 
 public class LocaleArrayDataSource implements ArrayDataSource{
+
+    ArrayDataSource fallback = null;
+
+    public LocaleArrayDataSource() {
+
+    }
+
+    public LocaleArrayDataSource(ArrayDataSource fallback) {
+        this.fallback = fallback;
+    }
+
     @Override
     public String[] getArray(String key) {
-        return Localization.getArray(key);
+        try {
+            return Localization.getArray(key);
+        } catch (NoLocalizedTextException e) {
+            if (fallback != null) {
+                return fallback.getArray(key);
+            } else {
+                throw e;
+            }
+        }
     }
 }

--- a/src/main/java/org/javarosa/core/model/utils/DateUtils.java
+++ b/src/main/java/org/javarosa/core/model/utils/DateUtils.java
@@ -37,6 +37,33 @@ public class DateUtils {
         super();
     }
 
+    private static CalendarStrings defaultCalendarStrings = new CalendarStrings();
+
+    public static class CalendarStrings {
+        public String[] monthNamesLong;
+        public String[] monthNamesShort;
+        public String[] dayNamesLong;
+        public String[] dayNamesShort;
+
+        public CalendarStrings(String[] monthNamesLong, String[] monthNamesShort,
+                               String[] dayNamesLong, String[] dayNamesShort) {
+            this.monthNamesLong = monthNamesLong;
+            this.monthNamesShort = monthNamesShort;
+            this.dayNamesLong = dayNamesLong;
+            this.dayNamesShort = dayNamesShort;
+
+        }
+
+        public CalendarStrings() {
+            this(
+                    new String[]{"January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"},
+                    new String[]{"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"},
+                    new String[]{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"},
+                    new String[]{"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"}
+            );
+        }
+    };
+
     public static class DateFields {
         public DateFields() {
             year = 1970;
@@ -47,6 +74,8 @@ public class DateUtils {
             second = 0;
             secTicks = 0;
             dow = 0;
+
+            noValidation = false;
 
 //            tzStr = "Z";
 //            tzOffset = 0;
@@ -59,6 +88,7 @@ public class DateUtils {
         public int minute; //0-59
         public int second; //0-59
         public int secTicks; //0-999 (ms)
+        boolean noValidation = false; // true or false. Set to true when using foreign calendars
 
         /**
          * NOTE: CANNOT BE USED TO SPECIFY A DATE *
@@ -69,9 +99,18 @@ public class DateUtils {
 //        public int tzOffset; //s ahead of UTC
 
         public boolean check() {
-            return (inRange(month, 1, 12) && inRange(day, 1, daysInMonth(month - MONTH_OFFSET, year)) &&
-                    inRange(hour, 0, 23) && inRange(minute, 0, 59) && inRange(second, 0, 59) && inRange(secTicks, 0, 999));
+            return noValidation ||
+                    ((inRange(month, 1, 12) && inRange(day, 1, daysInMonth(month - MONTH_OFFSET, year)) &&
+                    inRange(hour, 0, 23) && inRange(minute, 0, 59) && inRange(second, 0, 59) && inRange(secTicks, 0, 999)));
         }
+    }
+
+    public static DateFields getFieldsForNonGregorianCalendar(int year, int monthOfYear, int dayOfMonth) {
+        DateFields nonGregorian = new DateFields();
+        nonGregorian.year = year;
+        nonGregorian.month = monthOfYear;
+        nonGregorian.day = dayOfMonth;
+        return nonGregorian;
     }
 
     public static DateFields getFields(Date d) {
@@ -287,6 +326,10 @@ public class DateUtils {
     }
 
     public static String format(DateFields f, String format) {
+        return format(f, format, defaultCalendarStrings);
+    }
+
+    public static String format(DateFields f, String format, CalendarStrings stringsSource) {
         StringBuilder sb = new StringBuilder();
 
         for (int i = 0; i < format.length(); i++) {
@@ -311,11 +354,9 @@ public class DateUtils {
                 } else if (c == 'n') {    //numeric month
                     sb.append(f.month);
                 } else if (c == 'B') {    //long text month
-                    String[] months = new String[]{"January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"};
-                    sb.append(months[f.month - 1]);
+                    sb.append(stringsSource.monthNamesLong[f.month - 1]);
                 } else if (c == 'b') {    //short text month
-                    String[] months = new String[]{"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
-                    sb.append(months[f.month - 1]);
+                    sb.append(stringsSource.monthNamesShort[f.month - 1]);
                 } else if (c == 'd') {    //0-padded day of month
                     sb.append(intPad(f.day, 2));
                 } else if (c == 'e') {    //day of month
@@ -331,11 +372,9 @@ public class DateUtils {
                 } else if (c == '3') {    //0-padded millisecond ticks (000-999)
                     sb.append(intPad(f.secTicks, 3));
                 } else if (c == 'A') {    //long text day
-                    String[] dayNames = new String[]{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"};
-                    sb.append(dayNames[f.dow - 1]);
+                    sb.append(stringsSource.dayNamesLong[f.dow - 1]);
                 } else if (c == 'a') {    //Three letter short text day
-                    String[] dayNames = new String[]{"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
-                    sb.append(dayNames[f.dow - 1]);
+                    sb.append(stringsSource.dayNamesShort[f.dow - 1]);
                 } else if (c == 'w') {    //Day of the week (0 through 6), Sunday being 0.
                     sb.append(f.dow - 1);
                 } else if (Arrays.asList('c', 'C', 'D', 'F', 'g', 'G', 'I', 'j', 'k', 'l', 'p', 'P', 'r', 'R', 's', 't', 'T', 'u', 'U', 'V', 'W', 'x', 'X', 'z', 'Z').contains(c)) {

--- a/src/main/java/org/javarosa/xpath/expr/XPathFormatDateFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathFormatDateFunc.java
@@ -32,5 +32,4 @@ public class XPathFormatDateFunc extends XPathFuncExpr {
         }
         return DateUtils.format(expandedDate, FunctionUtils.toString(of));
     }
-
 }

--- a/src/test/java/org/javarosa/core/model/utils/test/LocalizerTest.java
+++ b/src/test/java/org/javarosa/core/model/utils/test/LocalizerTest.java
@@ -680,10 +680,15 @@ public class LocalizerTest {
     private void runAsync(Runnable test, String label) {
         Thread t = new Thread(test);
         t.start();
-        try {
-            t.join(50);
-        } catch (InterruptedException e) {
+        int attempts = 4;
 
+        for(int i = 0 ; i < attempts ; ++i) {
+            try {
+                t.join(50);
+                break;
+            } catch (InterruptedException e) {
+
+            }
         }
         if (t.isAlive()) {
             t.stop();

--- a/src/test/java/org/javarosa/xpath/test/XPathEvalTest.java
+++ b/src/test/java/org/javarosa/xpath/test/XPathEvalTest.java
@@ -252,6 +252,12 @@ public class XPathEvalTest {
         testEval("date(convertible())", null, ec, new XPathTypeMismatchException());
         testEval("format-date-for-calendar('', 'ethiopian')", null, null, "");
         testEval("format-date-for-calendar(date('1970-01-01'), 'neverland')", null, null, new XPathUnsupportedException());
+
+        testEval("format-date-for-calendar('2017-07-15', 'ethiopian', '%Y-%m-%d')", null, null, "2009-11-08");
+        testEval("format-date-for-calendar('2017-07-15', 'nepali', '%Y-%m-%d')", null, null, "2074-03-31");
+
+
+
         //note: there are lots of time and timezone-like issues with dates that should be tested (particularly DST changes),
         //    but it's just too hard and client-dependent, so not doing it now
         //  basically:


### PR DESCRIPTION
Allows using date format strings in the `format-date-for-calendar` the same as they are used in the `format-date` function

The month behavior still depends on platform, but makes it possible to use alternative calendars in a more predictable way around the numeric components.

Needed by L10k

IE:

`format-date-for-calendar('2017-07-15', 'ethiopian', '%Y-%m-%d')` -> `2009-11-08`

Old behaviors for the function calls should be unaffected