### PR TITLE
Fix Duplication of exception source in NodeEntityFactory

### DIFF
--- a/src/main/java/org/commcare/cases/entity/NodeEntityFactory.java
+++ b/src/main/java/org/commcare/cases/entity/NodeEntityFactory.java
@@ -67,7 +67,7 @@ public class NodeEntityFactory {
                     sortData[count] = sortText.evaluate(nodeContext);
                 }
                 relevancyData[count] = f.isRelevant(nodeContext);
-            } catch (XPathSyntaxException | XPathException e) {
+            } catch (XPathSyntaxException e) {
                 /**
                  * TODO: 25/06/17 remove catch blocks from here
                  * We are wrapping the original exception in a new XPathException to avoid

--- a/src/main/java/org/commcare/cases/entity/NodeEntityFactory.java
+++ b/src/main/java/org/commcare/cases/entity/NodeEntityFactory.java
@@ -73,10 +73,7 @@ public class NodeEntityFactory {
                  * We are wrapping the original exception in a new XPathException to avoid
                  * refactoring large number of functions caused by throwing XPathSyntaxException here.
                  */
-                XPathException xe = new XPathException(e.getMessage(), e);
-                if (e instanceof XPathException) {
-                    xe.setSource(((XPathException)e).getSource());
-                }
+                XPathException xe = new XPathException(e);
                 throw xe;
             }
             count++;

--- a/src/main/java/org/javarosa/xpath/XPathException.java
+++ b/src/main/java/org/javarosa/xpath/XPathException.java
@@ -17,8 +17,8 @@ public class XPathException extends RuntimeException {
         super(s);
     }
 
-    public XPathException(String s, Throwable cause) {
-        super(s, cause);
+    public XPathException(Throwable cause) {
+        super(cause);
     }
 
     public void setMessagePrefix(String prefix){


### PR DESCRIPTION
Case url: http://manage.dimagi.com/default.asp?258799

In the final error message to user the exception source was coming twice from the outer and nested exception. There is no need to set the source the outer exception as the inner exception already has that set. 