### PR TITLE
Record Cache Conflict Resolution

### DIFF
--- a/src/main/java/org/commcare/cases/instance/StorageInstanceTreeElement.java
+++ b/src/main/java/org/commcare/cases/instance/StorageInstanceTreeElement.java
@@ -16,6 +16,8 @@ import org.javarosa.core.services.storage.IStorageUtilityIndexed;
 import org.javarosa.core.util.DataUtil;
 import org.javarosa.core.util.Interner;
 import org.javarosa.core.util.externalizable.Externalizable;
+import org.javarosa.xpath.XPathParseTool;
+import org.javarosa.xpath.expr.FunctionUtils;
 
 import java.util.LinkedHashSet;
 import java.util.Vector;
@@ -280,24 +282,27 @@ public abstract class StorageInstanceTreeElement<Model extends Externalizable, T
 
         RecordObjectCache<Model> recordObjectCache = getRecordObjectCacheIfRelevant(context);
 
+        String storageCacheKey = getStorageCacheName();
+
         if(recordObjectCache != null) {
-            if (recordObjectCache.isLoaded(recordId)) {
-                return recordObjectCache.getLoadedRecordObject(recordId);
+            if (recordObjectCache.isLoaded(storageCacheKey, recordId)) {
+                return recordObjectCache.getLoadedRecordObject(storageCacheKey, recordId);
             }
+            FunctionUtils.toString(XPathParseTool.parseXPath().eval(evalContext));
 
             if (canLoadRecordFromGroup(recordSetCache, recordId)) {
                 Pair<String, LinkedHashSet<Integer>> tranche =
-                        recordSetCache.getRecordSetForRecordId(getStorageCacheName(), recordId);
+                        recordSetCache.getRecordSetForRecordId(storageCacheKey, recordId);
                 EvaluationTrace loadTrace =
                         new EvaluationTrace(String.format("Model [%s]: Bulk Load [%s}",
                                 this.getStorageCacheName(),tranche.first));
 
                 LinkedHashSet<Integer>  body = tranche.second;
-                storage.bulkRead(body, recordObjectCache.getLoadedCaseMap());
+                storage.bulkRead(body, recordObjectCache.getLoadedCaseMap(storageCacheKey));
                 loadTrace.setOutcome("Loaded: " + body.size());
                 context.reportTrace(loadTrace);
 
-                return recordObjectCache.getLoadedRecordObject(recordId);
+                return recordObjectCache.getLoadedRecordObject(storageCacheKey, recordId);
             }
         }
 

--- a/src/main/java/org/commcare/cases/instance/StorageInstanceTreeElement.java
+++ b/src/main/java/org/commcare/cases/instance/StorageInstanceTreeElement.java
@@ -288,7 +288,6 @@ public abstract class StorageInstanceTreeElement<Model extends Externalizable, T
             if (recordObjectCache.isLoaded(storageCacheKey, recordId)) {
                 return recordObjectCache.getLoadedRecordObject(storageCacheKey, recordId);
             }
-            FunctionUtils.toString(XPathParseTool.parseXPath().eval(evalContext));
 
             if (canLoadRecordFromGroup(recordSetCache, recordId)) {
                 Pair<String, LinkedHashSet<Integer>> tranche =

--- a/src/main/java/org/commcare/modern/engine/cases/RecordObjectCache.java
+++ b/src/main/java/org/commcare/modern/engine/cases/RecordObjectCache.java
@@ -16,17 +16,28 @@ import java.util.HashMap;
 
 public class RecordObjectCache<T> implements QueryCache {
 
-    private HashMap<Integer, T> cachedRecordObjects = new HashMap<>();
+    private HashMap<String,HashMap<Integer, T>> caches = new HashMap<>();
 
-    public boolean isLoaded(int recordId) {
-        return cachedRecordObjects.containsKey(recordId);
+    public boolean isLoaded(String storageSetID, int recordId) {
+        return getCache(storageSetID).containsKey(recordId);
     }
 
-    public HashMap<Integer, T> getLoadedCaseMap() {
-        return cachedRecordObjects;
+    public HashMap<Integer, T> getLoadedCaseMap(String storageSetID) {
+        return getCache(storageSetID);
     }
 
-    public T getLoadedRecordObject(int recordId) {
-        return cachedRecordObjects.get(recordId);
+    public T getLoadedRecordObject(String storageSetID, int recordId) {
+        return getCache(storageSetID).get(recordId);
+    }
+
+    private HashMap<Integer, T> getCache(String storageSetID) {
+        HashMap<Integer, T> cache;
+        if(!caches.containsKey(storageSetID)) {
+            cache = new HashMap<>();
+            caches.put(storageSetID, cache);
+        } else {
+            cache = caches.get(storageSetID);
+        }
+        return cache;
     }
 }


### PR DESCRIPTION
Bugfix for serious issue where Record object caches get re-used between models

Randomly reported as part of:
http://manage.dimagi.com/default.asp?258491