### PR TITLE
Improve performance of DB model builds

### DIFF
--- a/src/main/java/org/commcare/cases/instance/StorageInstanceTreeElement.java
+++ b/src/main/java/org/commcare/cases/instance/StorageInstanceTreeElement.java
@@ -105,7 +105,7 @@ public abstract class StorageInstanceTreeElement<Model extends Externalizable, T
         }
         elements = new Vector<>();
         int mult = 0;
-        for (IStorageIterator i = storage.iterate(); i.hasMore(); ) {
+        for (IStorageIterator i = storage.iterate(false); i.hasMore(); ) {
             int id = i.nextID();
             elements.add(buildElement(this, id, null, mult));
             objectIdMapping.put(DataUtil.integer(id), DataUtil.integer(mult));

--- a/src/main/java/org/javarosa/core/services/storage/IStorageUtilityIndexed.java
+++ b/src/main/java/org/javarosa/core/services/storage/IStorageUtilityIndexed.java
@@ -121,6 +121,16 @@ public interface IStorageUtilityIndexed<E extends Externalizable> {
     IStorageIterator<E> iterate();
 
     /**
+     * Return an iterator to iterate through all records in this store
+     *
+     * if includeData is false, the iterator is only guaranteed to be able to return ID's for
+     * records, not full values.
+     *
+     * @return record iterator
+     */
+    IStorageIterator<E> iterate(boolean includeData);
+
+    /**
      * Close all resources associated with this StorageUtility. Any attempt to use this StorageUtility after this call will result
      * in error. Though not strictly necessary, it is a good idea to call this when you are done with the StorageUtility, as closing
      * may trigger clean-up in the underlying device storage (reclaiming unused space, etc.).

--- a/src/main/java/org/javarosa/core/services/storage/util/DummyIndexedStorageUtility.java
+++ b/src/main/java/org/javarosa/core/services/storage/util/DummyIndexedStorageUtility.java
@@ -144,6 +144,12 @@ public class DummyIndexedStorageUtility<T extends Persistable> implements IStora
     }
 
     @Override
+    public IStorageIterator<T> iterate(boolean includeData) {
+        return iterate();
+    }
+
+
+    @Override
     public T read(int id) {
         try {
             T t = prototype.newInstance();


### PR DESCRIPTION
Bootstrapping the database backed tree structures is super slow  at scale due to the initial walk. This allows them to initialize with a walk that only touches id's (pulled into core from the android/db backed code used in the CaseDB).

Still needs a platform-specific implementation for the storage backend.

Release Note: "Improvements to performance for apps that make use of large location trees"

