### PR TITLE
Fix Asyncbadges by using Observable.callable

### DIFF
--- a/src/main/java/org/commcare/suite/model/Entry.java
+++ b/src/main/java/org/commcare/suite/model/Entry.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.Vector;
+import java.util.concurrent.Callable;
 
 import io.reactivex.Observable;
 
@@ -142,11 +143,16 @@ public abstract class Entry implements Externalizable, MenuDisplayable {
     }
 
     @Override
-    public Observable<String> getTextForBadge(EvaluationContext ec) {
+    public Observable<String> getTextForBadge(final EvaluationContext ec) {
         if (display.getBadgeText() == null) {
             return Observable.just("");
         }
-        return Observable.just(display.getBadgeText().evaluate(ec));
+        return Observable.fromCallable(new Callable<String>() {
+            @Override
+            public String call() throws Exception {
+                return display.getBadgeText().evaluate(ec);
+            }
+        });
     }
 
     @Override

--- a/src/main/java/org/commcare/suite/model/Menu.java
+++ b/src/main/java/org/commcare/suite/model/Menu.java
@@ -14,6 +14,7 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.Vector;
+import java.util.concurrent.Callable;
 
 import io.reactivex.Observable;
 
@@ -193,11 +194,16 @@ public class Menu implements Externalizable, MenuDisplayable {
     }
 
     @Override
-    public Observable<String> getTextForBadge(EvaluationContext ec) {
+    public Observable<String> getTextForBadge(final EvaluationContext ec) {
         if (display.getBadgeText() == null) {
             return Observable.just("");
         }
-        return Observable.just(display.getBadgeText().evaluate(ec));
+        return Observable.fromCallable(new Callable<String>() {
+            @Override
+            public String call() throws Exception {
+                return display.getBadgeText().evaluate(ec);
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
Case: https://manage.dimagi.com/default.asp?261071#1386375

I had assumed using `Observable.just(computaion())` would actually carry out the computation on the computation thread supplied on subscription but it's essentially just equal to writing - 

```
result = computation();
return Observable.just(result);
```

The remedy is `Observable.callable` operator which actually carry out the computation on the desired thread. 