### PR TITLE
remove no-longer-helpful choices warning

### DIFF
--- a/src/main/java/org/javarosa/core/model/ItemsetBinding.java
+++ b/src/main/java/org/javarosa/core/model/ItemsetBinding.java
@@ -56,7 +56,6 @@ public class ItemsetBinding implements Externalizable {
 
     public void setChoices(Vector<SelectChoice> choices) {
         if (this.choices != null) {
-            System.out.println("warning: previous choices not cleared out");
             clearChoices();
         }
         this.choices = choices;


### PR DESCRIPTION
when you call ItemsetBinding.setChoices and this.choices is not null