### PR TITLE
Fixes timezone for date widget

### DIFF
--- a/src/main/java/org/javarosa/xform/util/CalendarUtils.java
+++ b/src/main/java/org/javarosa/xform/util/CalendarUtils.java
@@ -346,7 +346,7 @@ public class CalendarUtils {
     }
 
     public static UniversalDate fromMillis(long millisFromJavaEpoch) {
-        return fromMillis(millisFromJavaEpoch, DateTimeZone.UTC);
+        return fromMillis(millisFromJavaEpoch, DateTimeZone.getDefault());
     }
 
     public static UniversalDate incrementMonth(UniversalDate date) {


### PR DESCRIPTION
Case: https://manage.dimagi.com/default.asp?261212

Reverting [this change ](https://github.com/dimagi/commcare-core/commit/a53cda2f99ef427b858c7415d6ec0761e3ef3bfe#diff-0abc238934c64586dac0e0aeadf616f7L319) seems to be fixing both `NepaliDateWidget` and `convertToNepaliString` for me which fails in case of applying `UTC` timezone. 

Also we are using default timezone here while converting a date string to milis [here](https://github.com/dimagi/commcare-core/blob/master/src/main/java/org/javarosa/xform/util/CalendarUtils.java#L402) so the opposite conversion from mills to date string should  use the same. 