### PR TITLE
Fix Performance for back-to-back queries with mixed contexts

### DIFF
--- a/src/main/java/org/commcare/cases/util/StorageBackedTreeRoot.java
+++ b/src/main/java/org/commcare/cases/util/StorageBackedTreeRoot.java
@@ -283,11 +283,14 @@ public abstract class StorageBackedTreeRoot<T extends AbstractTreeElement> imple
         //Get matches if it works
         List<Integer> ids = storage.getIDsForValue(op.key, op.value);
 
+        boolean triggeredRecordSetCache = false;
+
         if(getStorageCacheName() != null &&
                 ids.size() > 50 && ids.size() < PerformanceTuningUtil.getMaxPrefetchCaseBlock()) {
             RecordSetResultCache cue = currentQueryContext.getQueryCache(RecordSetResultCache.class);
             String bulkRecordSetKey = String.format("%s|%s", op.key, op.value);
             cue.reportBulkRecordSet(bulkRecordSetKey, getStorageCacheName(), new LinkedHashSet(ids));
+            triggeredRecordSetCache = true;
         }
 
 
@@ -297,7 +300,10 @@ public abstract class StorageBackedTreeRoot<T extends AbstractTreeElement> imple
             currentQueryContext.reportTrace(trace);
         }
 
-        if(defaultCacher != null) {
+        //Don't cache anything that's recorded as a record set, since it will prevent that set
+        //from being cued into future contexts (storing the defaultCacher outside of the
+        //QueryContext gives it some bad semantics that should be reviewed...)
+        if(defaultCacher != null && !triggeredRecordSetCache) {
             defaultCacher.cacheResult(op.key, op.value, ids);
         }
 


### PR DESCRIPTION
When we loaded itemsets back-to-back we would end up using the default cacher to store the results of large query results _outside_ of the QueryContext, which would mean that when we loaded the second time the results would come from the cache and fail to make it into RecordSetResultCache, preventing additional bulk optimizations from firing.

Long story short, something that took ~20s the first time you load it can take 3-8 times as long the next time, and end up triggering OOM issues due to loading things that should be bulk in serial