### PR TITLE
Fix for Badge Processing Erroneously loading Instances

### DIFF
--- a/src/main/java/org/commcare/suite/model/Entry.java
+++ b/src/main/java/org/commcare/suite/model/Entry.java
@@ -170,6 +170,12 @@ public abstract class Entry implements Externalizable, MenuDisplayable {
     }
 
     @Override
+    public Text getRawBadgeTextObject() {
+        return display.getBadgeText();
+    }
+
+
+    @Override
     public String getCommandID() {
         return commandId;
     }

--- a/src/main/java/org/commcare/suite/model/Menu.java
+++ b/src/main/java/org/commcare/suite/model/Menu.java
@@ -207,6 +207,11 @@ public class Menu implements Externalizable, MenuDisplayable {
     }
 
     @Override
+    public Text getRawBadgeTextObject() {
+        return display.getBadgeText();
+    }
+
+    @Override
     public String getCommandID() {
         return id;
     }

--- a/src/main/java/org/commcare/suite/model/MenuDisplayable.java
+++ b/src/main/java/org/commcare/suite/model/MenuDisplayable.java
@@ -21,4 +21,6 @@ public interface MenuDisplayable {
     Observable<String> getTextForBadge(EvaluationContext ec);
 
     String getCommandID();
+
+    Text getRawBadgeTextObject();
 }


### PR DESCRIPTION
The badge text processor wasn't processing what instances were needed for displaying menus, which was causing delays in loading menus for un-needed data sources.

