### PR TITLE
Fix for a bug where Lazy Nodesets all relied on the same JVM-Wide static lock

### DIFF
--- a/src/main/java/org/commcare/suite/model/Entry.java
+++ b/src/main/java/org/commcare/suite/model/Entry.java
@@ -22,7 +22,7 @@ import java.util.Set;
 import java.util.Vector;
 import java.util.concurrent.Callable;
 
-import io.reactivex.Observable;
+import io.reactivex.Single;
 
 /**
  * Describes a user-initiated action, what information needs to be collected
@@ -157,11 +157,11 @@ public abstract class Entry implements Externalizable, MenuDisplayable {
     }
 
     @Override
-    public Observable<String> getTextForBadge(final EvaluationContext ec) {
+    public Single<String> getTextForBadge(final EvaluationContext ec) {
         if (display.getBadgeText() == null) {
-            return Observable.just("");
+            return Single.just("");
         }
-        return Observable.fromCallable(new Callable<String>() {
+        return Single.fromCallable(new Callable<String>() {
             @Override
             public String call() throws Exception {
                 return display.getBadgeText().evaluate(ec);

--- a/src/main/java/org/commcare/suite/model/Menu.java
+++ b/src/main/java/org/commcare/suite/model/Menu.java
@@ -16,7 +16,7 @@ import java.io.IOException;
 import java.util.Vector;
 import java.util.concurrent.Callable;
 
-import io.reactivex.Observable;
+import io.reactivex.Single;
 
 /**
  * A Menu definition describes the structure of how
@@ -194,11 +194,11 @@ public class Menu implements Externalizable, MenuDisplayable {
     }
 
     @Override
-    public Observable<String> getTextForBadge(final EvaluationContext ec) {
+    public Single<String> getTextForBadge(final EvaluationContext ec) {
         if (display.getBadgeText() == null) {
-            return Observable.just("");
+            return Single.just("");
         }
-        return Observable.fromCallable(new Callable<String>() {
+        return Single.fromCallable(new Callable<String>() {
             @Override
             public String call() throws Exception {
                 return display.getBadgeText().evaluate(ec);

--- a/src/main/java/org/commcare/suite/model/MenuDisplayable.java
+++ b/src/main/java/org/commcare/suite/model/MenuDisplayable.java
@@ -3,6 +3,7 @@ package org.commcare.suite.model;
 import org.javarosa.core.model.condition.EvaluationContext;
 
 import io.reactivex.Observable;
+import io.reactivex.Single;
 
 /**
  * Created by wpride1 on 4/27/15.
@@ -18,7 +19,7 @@ public interface MenuDisplayable {
 
     String getDisplayText();
 
-    Observable<String> getTextForBadge(EvaluationContext ec);
+    Single<String> getTextForBadge(EvaluationContext ec);
 
     String getCommandID();
 

--- a/src/main/java/org/javarosa/xpath/XPathLazyNodeset.java
+++ b/src/main/java/org/javarosa/xpath/XPathLazyNodeset.java
@@ -28,7 +28,9 @@ import java.util.Vector;
  */
 public class XPathLazyNodeset extends XPathNodeset {
 
-    private Boolean evaluated = Boolean.FALSE;
+    //Since we're using this as a lock, we need to be very careful to ensure that each
+    //nodeset gets its own new object.
+    private Boolean evaluated = new Boolean(false);
     private final TreeReference unExpandedRef;
 
     /**
@@ -55,7 +57,7 @@ public class XPathLazyNodeset extends XPathNodeset {
                 }
             }
             this.setReferences(nodes);
-            evaluated = true;
+            evaluated = new Boolean(true);
         }
     }
 


### PR DESCRIPTION
Since Boolean.FALSE is a static object only one un-evaluated XPathLazyNodeset object could be evaluating at any given time.