### PR TITLE
Add Multi-Key storage optimizations

### DIFF
--- a/src/main/java/org/commcare/cases/instance/StorageInstanceTreeElement.java
+++ b/src/main/java/org/commcare/cases/instance/StorageInstanceTreeElement.java
@@ -19,6 +19,7 @@ import org.javarosa.core.util.externalizable.Externalizable;
 import org.javarosa.xpath.XPathParseTool;
 import org.javarosa.xpath.expr.FunctionUtils;
 
+import java.util.Hashtable;
 import java.util.LinkedHashSet;
 import java.util.Vector;
 

--- a/src/main/java/org/commcare/cases/instance/StorageInstanceTreeElement.java
+++ b/src/main/java/org/commcare/cases/instance/StorageInstanceTreeElement.java
@@ -19,7 +19,6 @@ import org.javarosa.core.util.externalizable.Externalizable;
 import org.javarosa.xpath.XPathParseTool;
 import org.javarosa.xpath.expr.FunctionUtils;
 
-import java.util.Hashtable;
 import java.util.LinkedHashSet;
 import java.util.Vector;
 

--- a/src/main/java/org/commcare/cases/util/StorageBackedTreeRoot.java
+++ b/src/main/java/org/commcare/cases/util/StorageBackedTreeRoot.java
@@ -309,11 +309,13 @@ public abstract class StorageBackedTreeRoot<T extends AbstractTreeElement> imple
         mMostRecentBatchFetch[0] = namesToMatch;
         mMostRecentBatchFetch[1] = valuesToMatch;
 
+        String storageTreeName = this.getStorageCacheName();
+
         LinkedHashSet<Integer> ids;
         if(mIndexResultCache.containsKey(cacheKey)) {
             ids = mIndexResultCache.get(cacheKey);
         } else {
-            EvaluationTrace trace = new EvaluationTrace("Storage Lookup" + "["+keyDescription + "]");
+            EvaluationTrace trace = new EvaluationTrace(String.format("Storage [%s] Key Lookup [%s]", storageTreeName, keyDescription));
             ids = new LinkedHashSet<>();
             storage.getIDsForValues(namesToMatch, valuesToMatch, ids);
             trace.setOutcome("Results: " + ids.size());

--- a/src/main/java/org/commcare/cases/util/StorageBackedTreeRoot.java
+++ b/src/main/java/org/commcare/cases/util/StorageBackedTreeRoot.java
@@ -36,6 +36,18 @@ public abstract class StorageBackedTreeRoot<T extends AbstractTreeElement> imple
 
     protected final Hashtable<Integer, Integer> objectIdMapping = new Hashtable<>();
 
+    /**
+     * Super basic cache for Key/Index responses from the DB
+     */
+    private Hashtable<String, LinkedHashSet<Integer>> mIndexResultCache = new Hashtable<>();
+
+    /**
+     * Get the key/value meta lookups for the most recent batch fetch. Used to prime a couple
+     * of other caches, although this should eventually migrate to use the new cueing framework
+     */
+    protected String[][] mMostRecentBatchFetch = null;
+
+
     protected abstract String getChildHintName();
 
     protected abstract Hashtable<XPathPathExpr, String> getStorageIndexMap();
@@ -272,45 +284,78 @@ public abstract class StorageBackedTreeRoot<T extends AbstractTreeElement> imple
     protected Collection<Integer> getNextIndexMatch(Vector<PredicateProfile> profiles,
                                                     IStorageUtilityIndexed<?> storage,
                                                     QueryContext currentQueryContext) throws IllegalArgumentException {
-        if(!(profiles.elementAt(0) instanceof IndexedValueLookup)) {
+        int numKeysToProcess = this.getNumberOfBatchableKeysInProfileSet(profiles);
+
+        if(numKeysToProcess == -1) {
             throw new IllegalArgumentException("No optimization path found for optimization type");
         }
 
-        IndexedValueLookup op = (IndexedValueLookup)profiles.elementAt(0);
 
-        EvaluationTrace trace = new EvaluationTrace("Model Index[" + op.key + "] Lookup");
+        String[] namesToMatch = new String[numKeysToProcess];
+        String[] valuesToMatch = new String[numKeysToProcess];
 
-        //Get matches if it works
-        List<Integer> ids = storage.getIDsForValue(op.key, op.value);
+        String cacheKey = "";
+        String keyDescription ="";
 
-        boolean triggeredRecordSetCache = false;
+        for (int i = numKeysToProcess - 1; i >= 0; i--) {
+            namesToMatch[i] = profiles.elementAt(i).getKey();
+            valuesToMatch[i] = (String)
+                    (((IndexedValueLookup)profiles.elementAt(i)).value);
 
-        if(getStorageCacheName() != null &&
-                ids.size() > 50 && ids.size() < PerformanceTuningUtil.getMaxPrefetchCaseBlock()) {
-            RecordSetResultCache cue = currentQueryContext.getQueryCache(RecordSetResultCache.class);
-            String bulkRecordSetKey = String.format("%s|%s", op.key, op.value);
-            cue.reportBulkRecordSet(bulkRecordSetKey, getStorageCacheName(), new LinkedHashSet(ids));
-            triggeredRecordSetCache = true;
+            cacheKey += "|" + namesToMatch[i] + "=" + valuesToMatch[i];
+            keyDescription += namesToMatch[i] + "|";
         }
+        mMostRecentBatchFetch = new String[2][];
+        mMostRecentBatchFetch[0] = namesToMatch;
+        mMostRecentBatchFetch[1] = valuesToMatch;
 
-
-        trace.setOutcome("results: " + ids.size());
-
-        if (currentQueryContext != null) {
+        LinkedHashSet<Integer> ids;
+        if(mIndexResultCache.containsKey(cacheKey)) {
+            ids = mIndexResultCache.get(cacheKey);
+        } else {
+            EvaluationTrace trace = new EvaluationTrace("Storage Lookup" + "["+keyDescription + "]");
+            ids = new LinkedHashSet<>();
+            storage.getIDsForValues(namesToMatch, valuesToMatch, ids);
+            trace.setOutcome("Results: " + ids.size());
             currentQueryContext.reportTrace(trace);
+
+            mIndexResultCache.put(cacheKey, ids);
         }
 
-        //Don't cache anything that's recorded as a record set, since it will prevent that set
-        //from being cued into future contexts (storing the defaultCacher outside of the
-        //QueryContext gives it some bad semantics that should be reviewed...)
-        if(defaultCacher != null && !triggeredRecordSetCache) {
-            defaultCacher.cacheResult(op.key, op.value, ids);
+        if(ids.size() > 50 && ids.size() < PerformanceTuningUtil.getMaxPrefetchCaseBlock()) {
+            RecordSetResultCache cue = currentQueryContext.getQueryCache(RecordSetResultCache.class);
+            cue.reportBulkRecordSet(cacheKey, getStorageCacheName(), ids);
         }
 
-        //If we processed this, pop it off the queue
-        profiles.removeElementAt(0);
-
+        //Ok, we matched! Remove all of the keys that we matched
+        for (int i = 0; i < numKeysToProcess; ++i) {
+            profiles.removeElementAt(0);
+        }
         return ids;
+    }
+
+    /**
+     * Provide the number of keys that should be included in a general multi-key metadata lookup
+     * from the provided set. Each key in the returned set should be an indexed value lookup
+     * which can be matched in flat metadata with no additional processing.
+     *
+     * @param profiles A set of potential predicate profiles for bulk processing
+     * @return The number of elements to process from the provided set. If only the first
+     * profile would be processed, for instance, this method should return 1
+     */
+    protected int getNumberOfBatchableKeysInProfileSet(Vector<PredicateProfile> profiles) {
+        int keysToBatch = 0;
+        //Otherwise see how many of these we can bulk process
+        for (int i = 0; i < profiles.size(); ++i) {
+            //If the current key isn't an indexedvalue lookup, we can't process in this step
+            if (!(profiles.elementAt(i) instanceof IndexedValueLookup)) {
+                break;
+            }
+
+            //otherwise, it's now in our queue
+            keysToBatch++;
+        }
+        return keysToBatch;
     }
 
     /**

--- a/src/main/java/org/commcare/modern/engine/cases/RecordSetResultCache.java
+++ b/src/main/java/org/commcare/modern/engine/cases/RecordSetResultCache.java
@@ -43,6 +43,14 @@ public class RecordSetResultCache implements QueryCache {
         return getRecordSetForRecordId(recordSetName, recordId) != null;
     }
 
+    /**
+     * Retrieves a record set result which contains the provided record ID and record set.
+     *
+     * If no record sets contain the provided record, returns null.
+     *
+     * If multiple record set results contain the provided record, this method will return the
+     * result of the smallest size.
+     */
     public Pair<String, LinkedHashSet<Integer>> getRecordSetForRecordId(String recordSetName,
                                                                         int recordId) {
         Pair<String, LinkedHashSet<Integer>> match = null;

--- a/src/main/java/org/commcare/modern/engine/cases/RecordSetResultCache.java
+++ b/src/main/java/org/commcare/modern/engine/cases/RecordSetResultCache.java
@@ -45,12 +45,15 @@ public class RecordSetResultCache implements QueryCache {
 
     public Pair<String, LinkedHashSet<Integer>> getRecordSetForRecordId(String recordSetName,
                                                                         int recordId) {
+        Pair<String, LinkedHashSet<Integer>> match = null;
         for (String key : bulkFetchBodies.keySet()) {
             Pair<String, LinkedHashSet<Integer>> tranche = bulkFetchBodies.get(key);
             if (tranche.second.contains(recordId) && tranche.first.equals(recordSetName)) {
-                return new Pair<>(key, tranche.second);
+                if(match == null || (tranche.second.size() < match.second.size())) {
+                    match = new Pair<>(key, tranche.second);
+                }
             }
         }
-        return null;
+        return match;
     }
 }

--- a/src/main/java/org/javarosa/core/services/storage/IStorageUtilityIndexed.java
+++ b/src/main/java/org/javarosa/core/services/storage/IStorageUtilityIndexed.java
@@ -5,6 +5,7 @@ import org.javarosa.core.util.externalizable.Externalizable;
 
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Vector;
 
@@ -157,6 +158,33 @@ public interface IStorageUtilityIndexed<E extends Externalizable> {
      *                          meta data
      */
     Vector<Integer> getIDsForValue(String fieldName, Object value);
+
+     /* Retrieves a Vector of IDs of Externalizable objects in storage for which the field
+     * specified contains the values specified.
+     *
+     * @param fieldNames A list of metadata field names to match
+     * @param value     The values which must match the field names provided
+     * @return A Vector of Integers such that retrieving the Externalizable object with any
+     * of those integer IDs will result in an object for which the fields specified are equal
+     * to the value provided.
+     * @throws RuntimeException (Fix this exception type) if the field is unrecognized by the
+     *                          meta data
+     */
+    List<Integer> getIDsForValues(String[] fieldNames, Object[] values);
+
+     /* Retrieves a Vector of IDs of Externalizable objects in storage for which the field
+     * specified contains the values specified.
+     *
+     * @param fieldNames A list of metadata field names to match
+     * @param value     The values which must match the field names provided
+     * @param returnSet A LinkedHashSet of integers which match the return value 
+     * @return A Vector of Integers such that retrieving the Externalizable object with any
+     * of those integer IDs will result in an object for which the fields specified are equal
+     * to the value provided.
+     * @throws RuntimeException (Fix this exception type) if the field is unrecognized by the
+     *                          meta data
+     */
+     List<Integer> getIDsForValues(String[] fieldNames, Object[] values, LinkedHashSet<Integer> returnSet);
 
     /**
      * Retrieves a Externalizable object from the storage which is reference by the unique index fieldName.

--- a/src/main/java/org/javarosa/core/services/storage/util/DummyIndexedStorageUtility.java
+++ b/src/main/java/org/javarosa/core/services/storage/util/DummyIndexedStorageUtility.java
@@ -16,10 +16,12 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Vector;
 
@@ -81,6 +83,27 @@ public class DummyIndexedStorageUtility<T extends Persistable> implements IStora
             return new Vector<>();
         }
         return meta.get(fieldName).get(value);
+    }
+
+    @Override
+    public List<Integer> getIDsForValues(String[] fieldNames, Object[] values) {
+        return getIDsForValues(fieldNames, values, new LinkedHashSet<Integer>());
+    }
+
+    @Override
+    public List<Integer> getIDsForValues(String[] fieldNames, Object[] values, LinkedHashSet<Integer> returnSet) {
+        List<Integer> accumulator = null;
+        for(int i = 0; i < fieldNames.length; ++i) {
+            Vector<Integer> matches = getIDsForValue(fieldNames[i], values[i]);
+            if (accumulator == null) {
+                accumulator = new Vector<>(matches);
+            } else {
+                accumulator = DataUtil.intersection(accumulator, matches);
+            }
+        }
+
+        returnSet.addAll(accumulator);
+        return accumulator;
     }
 
     @Override

--- a/src/test/java/org/javarosa/core/storage/IndexedStorageUtilityTests.java
+++ b/src/test/java/org/javarosa/core/storage/IndexedStorageUtilityTests.java
@@ -104,12 +104,12 @@ public abstract class IndexedStorageUtilityTests {
         List<Integer> matches =
                 storage.getIDsForValue(Shoe.META_SIZE, "3");
 
-        Assert.assertEquals("Failed single index match [size][3]", sizeMatch, new HashSet<Integer>(matches));
+        Assert.assertEquals("Failed single index match [size][3]", sizeMatch, new HashSet<>(matches));
 
         List<Integer> matchesOnVector =
                 storage.getIDsForValues(new String[]{Shoe.META_SIZE}, new String[] {"3"});
 
-        Assert.assertEquals("Failed single vector index match [size][3]", sizeMatch, new HashSet<Integer>(matchesOnVector));
+        Assert.assertEquals("Failed single vector index match [size][3]", sizeMatch, new HashSet<>(matchesOnVector));
 
     }
 

--- a/src/test/java/org/javarosa/core/storage/IndexedStorageUtilityTests.java
+++ b/src/test/java/org/javarosa/core/storage/IndexedStorageUtilityTests.java
@@ -1,0 +1,155 @@
+package org.javarosa.core.storage;
+
+import org.javarosa.core.services.storage.IStorageUtilityIndexed;
+import org.javarosa.core.services.storage.util.DummyIndexedStorageUtility;
+import org.javarosa.core.util.Interner;
+import org.javarosa.core.util.externalizable.LivePrototypeFactory;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.Vector;
+
+/**
+ * Tests for basic storage utility functions
+ *
+ * Created by ctsims on 9/22/2017.
+ */
+
+public class IndexedStorageUtilityTests {
+
+    IStorageUtilityIndexed<Shoe> storage;
+
+    Shoe nike;
+
+    Shoe[] tenSizesOfMensNikes;
+
+    Shoe[] eightSizesOfWomensNikes;
+
+    Shoe[] fiveSizesOfMensVans;
+
+    protected IStorageUtilityIndexed<Shoe> createStorageUtility() {
+        return new DummyIndexedStorageUtility<>(Shoe.class, new LivePrototypeFactory());
+    }
+
+    @Before
+    public void setupStorageContainer() {
+        storage = createStorageUtility();
+
+        nike = new Shoe("nike", "mens", "10");
+
+        tenSizesOfMensNikes = new Shoe[10];
+        for(int i = 0; i < 10; ++i) {
+            tenSizesOfMensNikes[i] =
+                    new Shoe("nike", "mens", String.valueOf(i+1));
+        }
+
+        eightSizesOfWomensNikes = new Shoe[8];
+        for(int i = 0; i < 8; ++i) {
+            eightSizesOfWomensNikes[i] =
+                    new Shoe("nike", "womens", String.valueOf(i+1));
+        }
+
+        fiveSizesOfMensVans = new Shoe[5];
+        for(int i = 0; i < 5; ++i) {
+            fiveSizesOfMensVans[i] =
+                    new Shoe("vans", "mens", String.valueOf(i+1));
+        }
+
+
+
+    }
+
+    @Test
+    public void ensureIdIssuance() {
+        assert nike.getID() == -1;
+        storage.write(nike);
+        Assert.assertNotEquals("No ID issued to persistable", nike.getID(), -1);
+    }
+
+    @Test
+    public void testWrite() {
+        storage.write(nike);
+        int id= nike.getID();
+        Shoe shouldBeNike = storage.read(id);
+        Assert.assertNotNull("Failed to read record from DB", shouldBeNike);
+        Assert.assertEquals("Incorrect record read from DB", nike, shouldBeNike);
+    }
+
+    @Test
+    public void testOverwrite() {
+        String review = "This shoe is fly";
+        storage.write(nike);
+        assert nike.getReviewText().equals("");
+        nike.setReview(review);
+        storage.write(nike);
+
+        Shoe shouldBeNewNike = storage.read(nike.getID());
+
+        Assert.assertEquals("Persistable was not ovewritten correctly", review, shouldBeNewNike.getReviewText());
+    }
+
+    @Test
+    public void testSingleMatch() {
+        writeBulkSets();
+
+        Set<Integer> sizeMatch = new HashSet<>();
+        sizeMatch.add(tenSizesOfMensNikes[2].getID());
+        sizeMatch.add(eightSizesOfWomensNikes[2].getID());
+        sizeMatch.add(fiveSizesOfMensVans[2].getID());
+
+        List<Integer> matches =
+                storage.getIDsForValue(Shoe.META_SIZE, "3");
+
+        Assert.assertEquals("Failed single index match [size][3]", sizeMatch, new HashSet<Integer>(matches));
+
+        List<Integer> matchesOnVector =
+                storage.getIDsForValues(new String[]{Shoe.META_SIZE}, new String[] {"3"});
+
+        Assert.assertEquals("Failed single vector index match [size][3]", sizeMatch, new HashSet<Integer>(matchesOnVector));
+
+    }
+
+    @Test
+    public void testBulkMetaMatching() {
+        writeBulkSets();
+
+        List<Integer> matches =
+                storage.getIDsForValues(new String[] {Shoe.META_BRAND, Shoe.META_STYLE}, new String[] {"nike", "mens"});
+
+        Assert.assertEquals("Failed index match [brand,style][nike,mens]", getIdsFromModels(tenSizesOfMensNikes), new HashSet<>(matches));
+
+        LinkedHashSet<Integer> newResultPath = new LinkedHashSet<>();
+        storage.getIDsForValues(new String[] {Shoe.META_BRAND, Shoe.META_STYLE}, new String[] {"nike", "mens"}, newResultPath);
+
+        Assert.assertEquals("Failed index match [brand,style][nike,mens]", new HashSet<>(matches), newResultPath);
+
+
+    }
+
+    private void writeBulkSets() {
+        writeAll(tenSizesOfMensNikes);
+        writeAll(eightSizesOfWomensNikes);
+        writeAll(fiveSizesOfMensVans);
+    }
+
+    Set<Integer> getIdsFromModels(Shoe[] shoes){
+        Set<Integer> set = new HashSet<>();
+        for(Shoe s : shoes) {
+            set.add(s.getID());
+        }
+        return set;
+    }
+
+    private void writeAll(Shoe[] shoes) {
+        for(Shoe s : shoes) {
+            storage.write(s);
+        }
+    }
+
+}

--- a/src/test/java/org/javarosa/core/storage/IndexedStorageUtilityTests.java
+++ b/src/test/java/org/javarosa/core/storage/IndexedStorageUtilityTests.java
@@ -21,7 +21,7 @@ import java.util.Vector;
  * Created by ctsims on 9/22/2017.
  */
 
-public class IndexedStorageUtilityTests {
+public abstract class IndexedStorageUtilityTests {
 
     IStorageUtilityIndexed<Shoe> storage;
 
@@ -33,9 +33,7 @@ public class IndexedStorageUtilityTests {
 
     Shoe[] fiveSizesOfMensVans;
 
-    protected IStorageUtilityIndexed<Shoe> createStorageUtility() {
-        return new DummyIndexedStorageUtility<>(Shoe.class, new LivePrototypeFactory());
-    }
+    protected abstract IStorageUtilityIndexed<Shoe> createStorageUtility();
 
     @Before
     public void setupStorageContainer() {

--- a/src/test/java/org/javarosa/core/storage/MockStorageUtilityTests.java
+++ b/src/test/java/org/javarosa/core/storage/MockStorageUtilityTests.java
@@ -1,0 +1,19 @@
+package org.javarosa.core.storage;
+
+import org.javarosa.core.services.storage.IStorageUtilityIndexed;
+import org.javarosa.core.services.storage.util.DummyIndexedStorageUtility;
+import org.javarosa.core.util.externalizable.LivePrototypeFactory;
+
+/**
+ * Tests for the mock object, important since it's used in various in-memory implementations
+ *
+ * Created by ctsims on 9/25/2017.
+ */
+
+public class MockStorageUtilityTests extends IndexedStorageUtilityTests{
+
+    @Override
+    protected IStorageUtilityIndexed<Shoe> createStorageUtility() {
+        return new DummyIndexedStorageUtility<>(Shoe.class, new LivePrototypeFactory());
+    }
+}

--- a/src/test/java/org/javarosa/core/storage/Shoe.java
+++ b/src/test/java/org/javarosa/core/storage/Shoe.java
@@ -1,0 +1,122 @@
+package org.javarosa.core.storage;
+
+import org.javarosa.core.services.storage.IMetaData;
+import org.javarosa.core.services.storage.Persistable;
+import org.javarosa.core.util.externalizable.DeserializationException;
+import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.ExtWrapNullable;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+/**
+ * Basic model for storage
+ *
+ * Created by ctsims on 9/22/2017.
+ */
+
+public class Shoe implements Persistable, IMetaData {
+    public static final String META_BRAND = "brand";
+    public static final String META_SIZE = "size";
+    public static final String META_STYLE = "style";
+
+    String brand;
+    String size;
+    String style;
+
+    int recordId = -1;
+    private String reviewText = "";
+
+    public Shoe() {
+
+    }
+
+    public Shoe(String brand, String style, String size) {
+        if(brand == null || style == null || size == null) {
+            throw new IllegalArgumentException("No values can be null");
+        }
+        this.brand = brand;
+        this.size = size;
+        this.style = style;
+    }
+
+    public void setReview(String reviewText) {
+        if(reviewText == null) {
+            reviewText = "";
+        }
+        this.reviewText = reviewText;
+    }
+
+
+
+    @Override
+    public String[] getMetaDataFields() {
+        return new String[] {META_BRAND, META_SIZE, META_STYLE};
+    }
+
+    @Override
+    public Object getMetaData(String fieldName) {
+        if(fieldName.equals(META_BRAND)) {
+            return brand;
+        } else if(fieldName.equals(META_SIZE)) {
+            return size;
+        } else if(fieldName.equals(META_STYLE)) {
+            return style;
+        }
+        throw new IllegalArgumentException("No meta field: " + fieldName);
+    }
+
+    @Override
+    public void setID(int ID) {
+        this.recordId = ID;
+    }
+
+    @Override
+    public int getID() {
+        return this.recordId;
+    }
+
+    @Override
+    public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
+        brand = ExtUtil.readString(in);
+        style = ExtUtil.readString(in);
+        size = ExtUtil.readString(in);
+        reviewText = ExtUtil.readString(in);
+    }
+
+    @Override
+    public void writeExternal(DataOutputStream out) throws IOException {
+        ExtUtil.writeString(out, brand);
+        ExtUtil.writeString(out, style);
+        ExtUtil.writeString(out, size);
+
+        ExtUtil.writeString(out, reviewText);
+
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if(!(o instanceof Shoe)) {
+            return false;
+        }
+        Shoe s = (Shoe)o;
+        return this.size.equals(s.size) &&
+                this.style.equals(s.style) &&
+                this.brand.equals(s.brand) &&
+                this.reviewText.equals(s.reviewText);
+    }
+
+    @Override
+    public int hashCode() {
+        return this.size.hashCode() ^
+                this.style.hashCode() ^
+                this.brand.hashCode() ^
+                this.reviewText.hashCode();
+    }
+
+    public String getReviewText() {
+        return reviewText;
+    }
+}


### PR DESCRIPTION
Moved multi-key StorageBacked profile lookups to the core functionality.  

Allows multiple profiles to be combined in one bulk lookup, both preventing multiple IO passes, and also providing stronger RecordSet cues (which result in more limited bulk reads).

This also includes core storage utility tests that we've never explicitly written.

cross-request: https://github.com/dimagi/commcare-android/pull/1829