### PR TITLE
Allow concurrent install/upgrade actions between sandboxes

### DIFF
--- a/src/main/java/org/commcare/resources/ResourceManager.java
+++ b/src/main/java/org/commcare/resources/ResourceManager.java
@@ -22,12 +22,6 @@ public class ResourceManager {
     protected final ResourceTable upgradeTable;
     protected final ResourceTable tempTable;
 
-    /**
-     * Lock to synchronize update logic so that multiple threads don't try to
-     * manipulate tables simultaneously.
-     */
-    protected final static Object updateLock = new Object();
-
     public ResourceManager(CommCarePlatform platform,
                            ResourceTable masterTable,
                            ResourceTable upgradeTable,
@@ -55,7 +49,7 @@ public class ResourceManager {
             throws UnfullfilledRequirementsException,
             UnresolvedResourceException,
             InstallCancelledException {
-        synchronized (updateLock) {
+        synchronized (platform) {
             if (!global.isReady()) {
                 global.prepareResources(null, platform);
             }
@@ -87,7 +81,7 @@ public class ResourceManager {
      */
     public void stageUpgradeTable(String profileRef, boolean clearProgress) throws
             UnfullfilledRequirementsException, UnresolvedResourceException, InstallCancelledException {
-        synchronized (updateLock) {
+        synchronized (platform) {
             ensureMasterTableValid();
 
             if (clearProgress) {
@@ -147,7 +141,7 @@ public class ResourceManager {
             throws UnfullfilledRequirementsException,
             UnresolvedResourceException, IllegalArgumentException,
             InstallCancelledException {
-        synchronized (updateLock) {
+        synchronized (platform) {
             ensureMasterTableValid();
 
             // TODO: Table's acceptable states here may be incomplete
@@ -170,7 +164,7 @@ public class ResourceManager {
      */
     public void upgrade()
             throws UnresolvedResourceException, IllegalArgumentException {
-        synchronized (updateLock) {
+        synchronized (platform) {
             boolean upgradeSuccess = false;
             try {
                 Logger.log("Resource", "Upgrade table fetched, beginning upgrade");

--- a/src/main/java/org/javarosa/xpath/XPathLazyNodeset.java
+++ b/src/main/java/org/javarosa/xpath/XPathLazyNodeset.java
@@ -28,7 +28,9 @@ import java.util.Vector;
  */
 public class XPathLazyNodeset extends XPathNodeset {
 
-    private Boolean evaluated = Boolean.FALSE;
+    private boolean evaluated = false;
+    public Object evaluationLock = new Object();
+
     private final TreeReference unExpandedRef;
 
     /**
@@ -41,7 +43,7 @@ public class XPathLazyNodeset extends XPathNodeset {
 
 
     private void performEvaluation() {
-        synchronized (evaluated) {
+        synchronized (evaluationLock) {
             if (evaluated) {
                 return;
             }
@@ -67,7 +69,7 @@ public class XPathLazyNodeset extends XPathNodeset {
      */
     @Override
     public Object unpack() {
-        synchronized (evaluated) {
+        synchronized (evaluationLock) {
             if (evaluated) {
                 return super.unpack();
             }


### PR DESCRIPTION
Shift Resource Manager to use a platform level lock rather than a VM level lock.

I believe this change should be safe for FormPlayer and Android clients, although once formplayer is properly merged back into master we should validate.