### PR TITLE
Fix failure mode for missing index lookups

### DIFF
--- a/src/main/java/org/commcare/cases/query/queryset/DerivedCaseQueryLookup.java
+++ b/src/main/java/org/commcare/cases/query/queryset/DerivedCaseQueryLookup.java
@@ -59,7 +59,7 @@ public abstract class DerivedCaseQueryLookup implements QuerySetLookup {
     @Override
     public List<Integer> performSetLookup(TreeReference lookupIdKey, QueryContext queryContext) {
         List<Integer> rootLookup = root.performSetLookup(lookupIdKey, queryContext);
-        if(rootLookup = null) {
+        if(rootLookup == null) {
             return null;
         }
         ModelQuerySet set = getOrLoadCachedQuerySet(queryContext);

--- a/src/main/java/org/commcare/cases/query/queryset/DerivedCaseQueryLookup.java
+++ b/src/main/java/org/commcare/cases/query/queryset/DerivedCaseQueryLookup.java
@@ -59,6 +59,9 @@ public abstract class DerivedCaseQueryLookup implements QuerySetLookup {
     @Override
     public List<Integer> performSetLookup(TreeReference lookupIdKey, QueryContext queryContext) {
         List<Integer> rootLookup = root.performSetLookup(lookupIdKey, queryContext);
+        if(rootLookup = null) {
+            return null;
+        }
         ModelQuerySet set = getOrLoadCachedQuerySet(queryContext);
         if(set == null) {
             return null;


### PR DESCRIPTION
Replicate 
https://github.com/dimagi/commcare-core/pull/558

onto 2.39. Fixes issues that come when a derived query set gets back a missing match from its context.