### PR TITLE
Killable Queries 

### DIFF
--- a/src/main/java/org/commcare/cases/instance/StorageInstanceTreeElement.java
+++ b/src/main/java/org/commcare/cases/instance/StorageInstanceTreeElement.java
@@ -297,7 +297,7 @@ public abstract class StorageInstanceTreeElement<Model extends Externalizable, T
                                 this.getStorageCacheName(),tranche.first));
 
                 LinkedHashSet<Integer>  body = tranche.second;
-                storage.bulkRead(body, recordObjectCache.getLoadedCaseMap(storageCacheKey));
+                storage.bulkRead(body, recordObjectCache.getLoadedCaseMap(storageCacheKey), context.getLifecycleSignaler());
                 loadTrace.setOutcome("Loaded: " + body.size());
                 context.reportTrace(loadTrace);
 

--- a/src/main/java/org/commcare/cases/query/QueryContext.java
+++ b/src/main/java/org/commcare/cases/query/QueryContext.java
@@ -2,7 +2,9 @@ package org.commcare.cases.query;
 
 import org.commcare.cases.query.queryset.CurrentModelQuerySet;
 import org.commcare.cases.query.queryset.QuerySetCache;
+import org.javarosa.core.model.condition.Abandonable;
 import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.model.condition.LifecycleSignaler;
 import org.javarosa.core.model.trace.EvaluationTrace;
 
 /**
@@ -39,6 +41,8 @@ public class QueryContext {
 
     private QueryContext potentialSpawnedContext;
 
+    LifecycleSignaler lifecycleSignaler;
+
     /**
      * Context scope roughly keeps track of "how many times is the current query possibly going to
      * run". For instance, when evaluating an xpath like
@@ -60,6 +64,7 @@ public class QueryContext {
         this.traceRoot = parent.traceRoot;
         this.cache = new QueryCacheHost(parent.cache);
         this.contextScope = parent.contextScope;
+        this.lifecycleSignaler = parent.lifecycleSignaler;
     }
 
     /**
@@ -151,5 +156,21 @@ public class QueryContext {
     public void setHackyOriginalContextBody(CurrentModelQuerySet hackyOriginalContextBody) {
         getQueryCache(QuerySetCache.class).
                 addModelQuerySet(CurrentModelQuerySet.CURRENT_QUERY_SET_ID, hackyOriginalContextBody);
+    }
+
+    /**
+     * Creates a new child context from this base context
+     */
+    public QueryContext forceNewChildContext() {
+        return new QueryContext(this);
+    }
+
+    public void attachLifecycleSignaler(LifecycleSignaler lifecycleSignaler) {
+        //TODO: chain?
+        this.lifecycleSignaler = lifecycleSignaler;
+    }
+
+    public LifecycleSignaler getLifecycleSignaler() {
+        return lifecycleSignaler;
     }
 }

--- a/src/main/java/org/commcare/suite/model/Entry.java
+++ b/src/main/java/org/commcare/suite/model/Entry.java
@@ -23,6 +23,7 @@ import java.util.Vector;
 import java.util.concurrent.Callable;
 
 import io.reactivex.Single;
+import io.reactivex.functions.Action;
 
 /**
  * Describes a user-initiated action, what information needs to be collected
@@ -157,14 +158,22 @@ public abstract class Entry implements Externalizable, MenuDisplayable {
     }
 
     @Override
-    public Single<String> getTextForBadge(final EvaluationContext ec) {
+    public Single<String> getTextForBadge(EvaluationContext ec) {
+        final EvaluationContext[] abandonableContext =
+                new EvaluationContext[] {ec.spawnWithCleanLifecycle()};
         if (display.getBadgeText() == null) {
             return Single.just("");
         }
         return Single.fromCallable(new Callable<String>() {
             @Override
             public String call() throws Exception {
-                return display.getBadgeText().evaluate(ec);
+                return display.getBadgeText().evaluate(abandonableContext[0]);
+            }
+        }).doOnDispose(new Action() {
+            @Override
+            public void run() throws Exception {
+                abandonableContext[0].signalAbandoned();
+                abandonableContext[0] = null;
             }
         });
     }

--- a/src/main/java/org/commcare/suite/model/Entry.java
+++ b/src/main/java/org/commcare/suite/model/Entry.java
@@ -159,23 +159,10 @@ public abstract class Entry implements Externalizable, MenuDisplayable {
 
     @Override
     public Single<String> getTextForBadge(EvaluationContext ec) {
-        final EvaluationContext[] abandonableContext =
-                new EvaluationContext[] {ec.spawnWithCleanLifecycle()};
         if (display.getBadgeText() == null) {
             return Single.just("");
         }
-        return Single.fromCallable(new Callable<String>() {
-            @Override
-            public String call() throws Exception {
-                return display.getBadgeText().evaluate(abandonableContext[0]);
-            }
-        }).doOnDispose(new Action() {
-            @Override
-            public void run() throws Exception {
-                abandonableContext[0].signalAbandoned();
-                abandonableContext[0] = null;
-            }
-        });
+        return display.getBadgeText().getDisposableSingleForEvaluation(ec);
     }
 
     @Override

--- a/src/main/java/org/commcare/suite/model/Menu.java
+++ b/src/main/java/org/commcare/suite/model/Menu.java
@@ -198,12 +198,8 @@ public class Menu implements Externalizable, MenuDisplayable {
         if (display.getBadgeText() == null) {
             return Single.just("");
         }
-        return Single.fromCallable(new Callable<String>() {
-            @Override
-            public String call() throws Exception {
-                return display.getBadgeText().evaluate(ec);
-            }
-        });
+
+        return display.getBadgeText().getDisposableSingleForEvaluation(ec);
     }
 
     @Override

--- a/src/main/java/org/javarosa/core/model/condition/Abandonable.java
+++ b/src/main/java/org/javarosa/core/model/condition/Abandonable.java
@@ -1,0 +1,33 @@
+package org.javarosa.core.model.condition;
+
+/**
+ * An implementing object can be signaled as "abandoned", which means the following:
+ *
+ * 1) The object is no longer useful, and should cease all execution immediately if possible
+ * 2) It should be acceptable for any future request or use of this object to result in an
+ * exception
+ * 3) The object should free any/all memory it is accountable for if it won't be able to halt any
+ * pending execution immediately
+ * 4) If any dependent objects are abandonable, the signal should be forwarded along to them.
+ *
+ * Created by ctsims on 9/28/2017.
+ */
+
+public interface Abandonable {
+
+    /**
+     * If the current lifecycle has been abandoned, this will throw a
+     * RequestAbandonedException in order to terminate the current process
+     */
+    void assertNotAbandoned();
+
+    /**
+     * Signal that the object and context are now abandoned.
+     *
+     * This is expected to be called from a thread other than the one where work is taking
+     * place currently. If there is cleanup work to be done that would take an appreciable
+     * amount of time, it should ideally take place _outside_ of this call, but rather when
+     * the signal is detected on the other thread
+     */
+    void signalAbandoned();
+}

--- a/src/main/java/org/javarosa/core/model/condition/LifecycleSignaler.java
+++ b/src/main/java/org/javarosa/core/model/condition/LifecycleSignaler.java
@@ -1,0 +1,41 @@
+package org.javarosa.core.model.condition;
+
+/**
+ * An object which can be passed to convey
+ *
+ * Created by ctsims on 9/28/2017.
+ */
+
+public class LifecycleSignaler implements Abandonable {
+    private boolean isAbandoned = false;
+
+    /**
+     * If the current lifecycle has been abandoned, this will throw a
+     * RequestAbandonedException in order to terminate the current process
+     */
+    @Override
+    public void assertNotAbandoned() {
+        if(isAbandoned) {
+            throw new RequestAbandonedException();
+        }
+    }
+
+    @Override
+    public void signalAbandoned() {
+        this.isAbandoned = true;
+    }
+
+    public static void AssertNotAbandoned(Abandonable abandonable) {
+        if(abandonable == null) {
+            return;
+        }
+        abandonable.assertNotAbandoned();
+    }
+
+    public static void SignalAbandoned(Abandonable abandonable) {
+        if(abandonable == null) {
+            return;
+        }
+        abandonable.signalAbandoned();
+    }
+}

--- a/src/main/java/org/javarosa/core/model/condition/LifecycleSignaler.java
+++ b/src/main/java/org/javarosa/core/model/condition/LifecycleSignaler.java
@@ -1,7 +1,8 @@
 package org.javarosa.core.model.condition;
 
 /**
- * An object which can be passed to convey
+ * An object which can be passed through a call chain to portably keep track of the abandoned
+ * status of a lifecycle.
  *
  * Created by ctsims on 9/28/2017.
  */

--- a/src/main/java/org/javarosa/core/model/condition/RequestAbandonedException.java
+++ b/src/main/java/org/javarosa/core/model/condition/RequestAbandonedException.java
@@ -1,0 +1,8 @@
+package org.javarosa.core.model.condition;
+
+/**
+ * Created by ctsims on 9/28/2017.
+ */
+
+public class RequestAbandonedException extends RuntimeException {
+}

--- a/src/main/java/org/javarosa/core/services/storage/IStorageUtilityIndexed.java
+++ b/src/main/java/org/javarosa/core/services/storage/IStorageUtilityIndexed.java
@@ -212,7 +212,13 @@ public interface IStorageUtilityIndexed<E extends Externalizable> {
      * Since this method can have a significant runtime, an abandonable is provided to enable the
      * request to be shortcircuited. Implementations should regularly assert that the request
      * has not been abandoned on long-running bulk reads
+     * 
+     * @throws RequestAbandonedException If the current request is abandoned, this method will
+     *                                   throw a RequestAbandonedException. Callers should not
+     *                                   generally catch that exception unless they rethrow it
+     *                                   or another exception, but they should anticipate that
+     *                                   they may need to clean up if the bulk read doesn't complete
      */
 
-    void bulkRead(LinkedHashSet<Integer> cuedCases, HashMap<Integer, E> recordMap, Abandonable abandonable);
+    void bulkRead(LinkedHashSet<Integer> cuedCases, HashMap<Integer, E> recordMap, Abandonable abandonable) throws RequestAbandonedException;
 }

--- a/src/main/java/org/javarosa/core/services/storage/IStorageUtilityIndexed.java
+++ b/src/main/java/org/javarosa/core/services/storage/IStorageUtilityIndexed.java
@@ -1,6 +1,7 @@
 package org.javarosa.core.services.storage;
 
 import org.javarosa.core.model.condition.Abandonable;
+import org.javarosa.core.model.condition.RequestAbandonedException;
 import org.javarosa.core.util.InvalidIndexException;
 import org.javarosa.core.util.externalizable.Externalizable;
 

--- a/src/main/java/org/javarosa/core/services/storage/IStorageUtilityIndexed.java
+++ b/src/main/java/org/javarosa/core/services/storage/IStorageUtilityIndexed.java
@@ -1,5 +1,6 @@
 package org.javarosa.core.services.storage;
 
+import org.javarosa.core.model.condition.Abandonable;
 import org.javarosa.core.util.InvalidIndexException;
 import org.javarosa.core.util.externalizable.Externalizable;
 
@@ -123,7 +124,7 @@ public interface IStorageUtilityIndexed<E extends Externalizable> {
 
     /**
      * Return an iterator to iterate through all records in this store
-     *
+     * <p>
      * if includeData is false, the iterator is only guaranteed to be able to return ID's for
      * records, not full values.
      *
@@ -159,32 +160,32 @@ public interface IStorageUtilityIndexed<E extends Externalizable> {
      */
     Vector<Integer> getIDsForValue(String fieldName, Object value);
 
-     /* Retrieves a Vector of IDs of Externalizable objects in storage for which the field
-     * specified contains the values specified.
-     *
-     * @param fieldNames A list of metadata field names to match
-     * @param value     The values which must match the field names provided
-     * @return A Vector of Integers such that retrieving the Externalizable object with any
-     * of those integer IDs will result in an object for which the fields specified are equal
-     * to the value provided.
-     * @throws RuntimeException (Fix this exception type) if the field is unrecognized by the
-     *                          meta data
-     */
+    /* Retrieves a Vector of IDs of Externalizable objects in storage for which the field
+    * specified contains the values specified.
+    *
+    * @param fieldNames A list of metadata field names to match
+    * @param value     The values which must match the field names provided
+    * @return A Vector of Integers such that retrieving the Externalizable object with any
+    * of those integer IDs will result in an object for which the fields specified are equal
+    * to the value provided.
+    * @throws RuntimeException (Fix this exception type) if the field is unrecognized by the
+    *                          meta data
+    */
     List<Integer> getIDsForValues(String[] fieldNames, Object[] values);
 
-     /* Retrieves a Vector of IDs of Externalizable objects in storage for which the field
-     * specified contains the values specified.
-     *
-     * @param fieldNames A list of metadata field names to match
-     * @param value     The values which must match the field names provided
-     * @param returnSet A LinkedHashSet of integers which match the return value 
-     * @return A Vector of Integers such that retrieving the Externalizable object with any
-     * of those integer IDs will result in an object for which the fields specified are equal
-     * to the value provided.
-     * @throws RuntimeException (Fix this exception type) if the field is unrecognized by the
-     *                          meta data
-     */
-     List<Integer> getIDsForValues(String[] fieldNames, Object[] values, LinkedHashSet<Integer> returnSet);
+    /* Retrieves a Vector of IDs of Externalizable objects in storage for which the field
+    * specified contains the values specified.
+    *
+    * @param fieldNames A list of metadata field names to match
+    * @param value     The values which must match the field names provided
+    * @param returnSet A LinkedHashSet of integers which match the return value
+    * @return A Vector of Integers such that retrieving the Externalizable object with any
+    * of those integer IDs will result in an object for which the fields specified are equal
+    * to the value provided.
+    * @throws RuntimeException (Fix this exception type) if the field is unrecognized by the
+    *                          meta data
+    */
+    List<Integer> getIDsForValues(String[] fieldNames, Object[] values, LinkedHashSet<Integer> returnSet);
 
     /**
      * Retrieves a Externalizable object from the storage which is reference by the unique index fieldName.
@@ -200,11 +201,18 @@ public interface IStorageUtilityIndexed<E extends Externalizable> {
      */
     E getRecordForValue(String fieldName, Object value) throws NoSuchElementException, InvalidIndexException;
 
+    void bulkRead(LinkedHashSet<Integer> ids, HashMap<Integer, E> recordMap);
+
     /**
      * Load multiple record objects from storage at one time from a list of record ids.
-     *
+     * <p>
      * If the provided recordMap already contains entries for any ids, it is _not_
      * required for them to be retrieved from storage again.
+     *
+     * Since this method can have a significant runtime, an abandonable is provided to enable the
+     * request to be shortcircuited. Implementations should regularly assert that the request
+     * has not been abandoned on long-running bulk reads
      */
-    void bulkRead(LinkedHashSet<Integer> ids, HashMap<Integer, E> recordMap);
+
+    void bulkRead(LinkedHashSet<Integer> cuedCases, HashMap<Integer, E> recordMap, Abandonable abandonable);
 }

--- a/src/main/java/org/javarosa/core/services/storage/util/DummyIndexedStorageUtility.java
+++ b/src/main/java/org/javarosa/core/services/storage/util/DummyIndexedStorageUtility.java
@@ -1,5 +1,7 @@
 package org.javarosa.core.services.storage.util;
 
+import org.javarosa.core.model.condition.Abandonable;
+import org.javarosa.core.model.condition.pivot.IntegerRangeHint;
 import org.javarosa.core.services.storage.EntityFilter;
 import org.javarosa.core.services.storage.IMetaData;
 import org.javarosa.core.services.storage.IStorageIterator;
@@ -288,9 +290,14 @@ public class DummyIndexedStorageUtility<T extends Persistable> implements IStora
     }
 
     @Override
-    public void bulkRead(LinkedHashSet<Integer> cuedCases, HashMap<Integer, T> recordMap) {
+    public void bulkRead(LinkedHashSet<Integer> cuedCases, HashMap<Integer, T> recordMap, Abandonable abandonable) {
         for(int i : cuedCases) {
             recordMap.put(i, data.get(i));
         }
+    }
+
+    @Override
+    public void bulkRead(LinkedHashSet<Integer> cuedCases, HashMap<Integer, T> recordMap) {
+        bulkRead(cuedCases, recordMap, null);
     }
 }

--- a/src/main/java/org/javarosa/core/services/storage/util/DummyIndexedStorageUtility.java
+++ b/src/main/java/org/javarosa/core/services/storage/util/DummyIndexedStorageUtility.java
@@ -1,6 +1,7 @@
 package org.javarosa.core.services.storage.util;
 
 import org.javarosa.core.model.condition.Abandonable;
+import org.javarosa.core.model.condition.RequestAbandonedException;
 import org.javarosa.core.model.condition.pivot.IntegerRangeHint;
 import org.javarosa.core.services.storage.EntityFilter;
 import org.javarosa.core.services.storage.IMetaData;
@@ -290,7 +291,7 @@ public class DummyIndexedStorageUtility<T extends Persistable> implements IStora
     }
 
     @Override
-    public void bulkRead(LinkedHashSet<Integer> cuedCases, HashMap<Integer, T> recordMap, Abandonable abandonable) {
+    public void bulkRead(LinkedHashSet<Integer> cuedCases, HashMap<Integer, T> recordMap, Abandonable abandonable) throws RequestAbandonedException {
         for(int i : cuedCases) {
             recordMap.put(i, data.get(i));
         }


### PR DESCRIPTION
Introduced a concept to the EC/QC stack of an 'abandonable' query object.

This lets us signal to a background thread that a really long running part of a query should be abandoned in-place in a way that is comfortable letting the entire Evaluation/Query context crash out.

Used to prevent badge calculations continue to process after they had already been disposed of.

We can expand on this a bit in master, didn't want to touch more code than I had to for the release proximity