### PR TITLE
add @Streaming tags for all retrofit request methods

### DIFF
--- a/src/main/java/org/commcare/core/network/CommCareNetworkService.java
+++ b/src/main/java/org/commcare/core/network/CommCareNetworkService.java
@@ -15,20 +15,24 @@ import retrofit2.http.Multipart;
 import retrofit2.http.POST;
 import retrofit2.http.Part;
 import retrofit2.http.QueryMap;
+import retrofit2.http.Streaming;
 import retrofit2.http.Url;
 
 public interface CommCareNetworkService {
 
+    @Streaming
     @GET
     Call<ResponseBody> makeGetRequest(@Url String url, @QueryMap Map<String, String> params,
                                       @HeaderMap Map<String, String> headers);
 
+    @Streaming
     @Multipart
     @POST
     Call<ResponseBody> makeMultipartPostRequest(@Url String url, @QueryMap Map<String, String> params,
                                                 @HeaderMap Map<String, String> headers,
                                                 @Part List<MultipartBody.Part> files);
 
+    @Streaming
     @POST
     Call<ResponseBody> makePostRequest(@Url String url, @QueryMap Map<String, String> params,
                                        @HeaderMap Map<String, String> headers,


### PR DESCRIPTION
Fix for https://fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/59cce5b3be077a4dcc65a4d3?time=last-seven-days

The issue was that by default, Retrofit loads the entire response in memory upon receiving it. Adding the @Streaming tag tells it to just stream the response only.