### PR TITLE
2.39.2 Stop-gap measure to prevent crash on relative refs with predicates

### DIFF
--- a/src/main/java/org/javarosa/core/model/instance/TreeReference.java
+++ b/src/main/java/org/javarosa/core/model/instance/TreeReference.java
@@ -841,6 +841,10 @@ public class TreeReference implements Externalizable, XPathAnalyzable {
         for (int i = 0; i < data.size(); i++) {
             TreeReferenceLevel subLevel = data.get(i);
             if (subLevel.getPredicates() != null) {
+                if (!this.isAbsolute()) {
+                    throw new AnalysisInvalidException(
+                            "Not currently capable of analyzing a relative ref with predicates");
+                }
                 TreeReference subContext = this.removePredicates().getSubReference(i);
                 XPathAnalyzer subAnalyzer = analyzer.spawnSubAnalyzer(subContext);
                 for (XPathExpression expr : subLevel.getPredicates()) {


### PR DESCRIPTION
Will prevent [this crash](https://fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/59d3bfe3be077a4dccaf5fec?time=last-seven-days), and instead result in the analysis just not returning results and therefore having to inflate the full set of instances. (which is totally fine for now since that's what would have happened before 2.39 anyway, and is preferable to crashing or us trying to make a bigger change in a hotfix).