### PR TITLE
Show proper error message when distance func receives invalid arguments

### DIFF
--- a/src/main/java/org/javarosa/xpath/expr/XPathDistanceFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathDistanceFunc.java
@@ -47,7 +47,8 @@ public class XPathDistanceFunc extends XPathFuncExpr {
 
             return new Double(GeoPointUtils.computeDistanceBetween(castedFrom, castedTo));
         } catch (NumberFormatException e) {
-            throw new XPathTypeMismatchException("distance() function requires arguments containing numeric values only");
+            throw new XPathTypeMismatchException("distance() function requires arguments containing " +
+                    "numeric values only, but received arguments: " + unpackedFrom + " and " + unpackedTo);
         }
     }
 

--- a/src/main/java/org/javarosa/xpath/expr/XPathDistanceFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathDistanceFunc.java
@@ -5,6 +5,7 @@ import org.javarosa.core.model.data.GeoPointData;
 import org.javarosa.core.model.data.UncastData;
 import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.core.model.utils.GeoPointUtils;
+import org.javarosa.xpath.XPathTypeMismatchException;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class XPathDistanceFunc extends XPathFuncExpr {
@@ -39,11 +40,15 @@ public class XPathDistanceFunc extends XPathFuncExpr {
             return new Double(-1.0);
         }
 
-        // Casting and uncasting seems strange but is consistent with the codebase
-        GeoPointData castedFrom = new GeoPointData().cast(new UncastData(unpackedFrom));
-        GeoPointData castedTo = new GeoPointData().cast(new UncastData(unpackedTo));
+        try {
+            // Casting and uncasting seems strange but is consistent with the codebase
+            GeoPointData castedFrom = new GeoPointData().cast(new UncastData(unpackedFrom));
+            GeoPointData castedTo = new GeoPointData().cast(new UncastData(unpackedTo));
 
-        return new Double(GeoPointUtils.computeDistanceBetween(castedFrom, castedTo));
+            return new Double(GeoPointUtils.computeDistanceBetween(castedFrom, castedTo));
+        } catch (NumberFormatException e) {
+            throw new XPathTypeMismatchException("distance() function requires arguments containing numeric values only");
+        }
     }
 
 }


### PR DESCRIPTION
Will fix https://fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/59d37ef1be077a4dccacbb1c/sessions/59D37EDC020D00017ADACF0A965E45BC_495bd4a3a83411e7b8e356847afe9799_0_v2?

Instead of allowing a `NumberFormatException` to be thrown here and cause a crash, we should be re-throwing this as an `XPathException`, because that will allow the error message to get displayed to the user in a useful way in either a case list or form entry context (since we catch those down the line and handle them).