### PR TITLE
Throw IllegalArgumentException when Selection has invalid XML

### DIFF
--- a/src/main/java/org/javarosa/core/model/data/helper/Selection.java
+++ b/src/main/java/org/javarosa/core/model/data/helper/Selection.java
@@ -121,7 +121,7 @@ public class Selection implements Externalizable {
         if (xmlValue != null && xmlValue.length() > 0) {
             return xmlValue;
         } else {
-            throw new RuntimeException("don't know xml value! perhaps selection was stored as index only and has not yet been linked up to a formdef?");
+            throw new IllegalArgumentException("Invalid XML Value for Select Option");
         }
     }
 


### PR DESCRIPTION
Fixes https://manage.dimagi.com/default.asp?263403#1405109

This change causes the exception to be caught and handled here https://github.com/dimagi/commcare-core/blob/bf0e9042999dbe5a833b4030199fcd0efd043852/src/main/java/org/javarosa/core/model/actions/SetValueAction.java#L147-L147

![device-2017-10-11-065638](https://user-images.githubusercontent.com/2293064/31436919-6adf636e-ae51-11e7-9731-6efd57263297.png)
