### PR TITLE
CommCareConfigEngine in line with Formplayer

### DIFF
--- a/src/cli/java/org/commcare/util/cli/CliCommand.java
+++ b/src/cli/java/org/commcare/util/cli/CliCommand.java
@@ -66,7 +66,7 @@ public abstract class CliCommand {
     }
 
     protected static CommCareConfigEngine configureApp(String resourcePath, PrototypeFactory factory) {
-        CommCareConfigEngine engine = new CommCareConfigEngine(System.out, factory);
+        CommCareConfigEngine engine = new CommCareConfigEngine(factory);
 
         //TODO: check arg for whether it's a local or global file resource and
         //make sure it's absolute

--- a/src/cli/java/org/commcare/util/engine/CommCareConfigEngine.java
+++ b/src/cli/java/org/commcare/util/engine/CommCareConfigEngine.java
@@ -72,11 +72,7 @@ public class CommCareConfigEngine {
     }
 
     public CommCareConfigEngine(PrototypeFactory prototypeFactory) {
-        this(System.out, prototypeFactory);
-    }
-
-    public CommCareConfigEngine(OutputStream output, PrototypeFactory prototypeFactory) {
-        this.print = new PrintStream(output);
+        this.print = new PrintStream(System.out);
         this.platform = new CommCarePlatform(MAJOR_VERSION, MINOR_VERSION);
         this.liveFactory = prototypeFactory;
 

--- a/src/cli/java/org/commcare/util/engine/CommCareConfigEngine.java
+++ b/src/cli/java/org/commcare/util/engine/CommCareConfigEngine.java
@@ -64,6 +64,9 @@ public class CommCareConfigEngine {
 
     private static IStorageIndexedFactory storageFactory;
 
+    public static final int MAJOR_VERSION = 2;
+    public static final int MINOR_VERSION = 41;
+
     public CommCareConfigEngine() {
         this(new LivePrototypeFactory());
     }
@@ -74,7 +77,7 @@ public class CommCareConfigEngine {
 
     public CommCareConfigEngine(OutputStream output, PrototypeFactory prototypeFactory) {
         this.print = new PrintStream(output);
-        this.platform = new CommCarePlatform(2, 41);
+        this.platform = new CommCarePlatform(MAJOR_VERSION, MINOR_VERSION);
         this.liveFactory = prototypeFactory;
 
         if (storageFactory == null) {


### PR DESCRIPTION
Some refactors of `CommCareConfigEngine` to unify with how we use this class in Formplayer

1. Pull out version numbers so that we can access statically
2. Allow configuration of `StorageFactory` and `InstallerFactory`, with default constructors
3. Remove `output` param since this was only ever `System.out`