### PR TITLE
Modified detail sort order to include cache and index fields at end

### DIFF
--- a/src/main/java/org/commcare/suite/model/Detail.java
+++ b/src/main/java/org/commcare/suite/model/Detail.java
@@ -305,9 +305,13 @@ public class Detail implements Externalizable {
      */
     public int[] getOrderedFieldIndicesForSorting() {
         Vector<Integer> indices = new Vector<>();
+        Vector<Integer> cacheAndIndexedIndices = new Vector<>();
         outer:
         for (int i = 0; i < fields.length; ++i) {
             int order = fields[i].getSortOrder();
+            if (order == -2) {
+                cacheAndIndexedIndices.addElement(i);
+            }
             if (order < 1) {
                 continue;
             }
@@ -321,15 +325,18 @@ public class Detail implements Externalizable {
             indices.addElement(i);
             continue;
         }
-        if (indices.size() == 0) {
-            return new int[]{};
-        } else {
-            int[] ret = new int[indices.size()];
-            for (int i = 0; i < ret.length; ++i) {
-                ret[i] = indices.elementAt(i);
-            }
-            return ret;
+
+        int resultLength = indices.size() + cacheAndIndexedIndices.size();
+        int[] ret = new int[resultLength];
+        int i = 0;
+        for (;i < indices.size(); ++i) {
+            ret[i] = indices.elementAt(i);
         }
+        // add all cacheAndIndexed element at end
+        for (; i < resultLength; ++i) {
+            ret[i] = cacheAndIndexedIndices.elementAt(i - indices.size());
+        }
+        return ret;
     }
 
     //These are just helpers around the old structure. Shouldn't really be
@@ -505,7 +512,7 @@ public class Detail implements Externalizable {
     }
 
     public HashMap<String, DetailFieldPrintInfo> getKeyValueMapForPrint(TreeReference selectedEntityRef,
-                                                          EvaluationContext baseContext) {
+                                                                        EvaluationContext baseContext) {
         HashMap<String, DetailFieldPrintInfo> mapping = new HashMap<>();
         populateMappingWithDetailFields(mapping, selectedEntityRef, baseContext, null);
         return mapping;

--- a/src/main/java/org/commcare/suite/model/Detail.java
+++ b/src/main/java/org/commcare/suite/model/Detail.java
@@ -2,6 +2,7 @@ package org.commcare.suite.model;
 
 import org.commcare.cases.entity.Entity;
 import org.commcare.cases.entity.NodeEntityFactory;
+import org.commcare.util.CollectionUtils;
 import org.commcare.util.DetailFieldPrintInfo;
 import org.commcare.cases.entity.EntityUtil;
 import org.commcare.util.GridCoordinate;
@@ -325,18 +326,7 @@ public class Detail implements Externalizable {
             indices.addElement(i);
             continue;
         }
-
-        int resultLength = indices.size() + cacheAndIndexedIndices.size();
-        int[] ret = new int[resultLength];
-        int i = 0;
-        for (;i < indices.size(); ++i) {
-            ret[i] = indices.elementAt(i);
-        }
-        // add all cacheAndIndexed element at end
-        for (; i < resultLength; ++i) {
-            ret[i] = cacheAndIndexedIndices.elementAt(i - indices.size());
-        }
-        return ret;
+        return CollectionUtils.mergeIntegerVectorsInArray(indices, cacheAndIndexedIndices);
     }
 
     //These are just helpers around the old structure. Shouldn't really be

--- a/src/main/java/org/commcare/util/CollectionUtils.java
+++ b/src/main/java/org/commcare/util/CollectionUtils.java
@@ -1,0 +1,31 @@
+package org.commcare.util;
+
+import java.util.Vector;
+
+/**
+ * Created by shubham on 07/11/17.
+ */
+
+/**
+ * Common operations on Collections
+ */
+public class CollectionUtils {
+
+    /**
+     * @param first  First Integer Vector to be merged
+     * @param second Second Integer Vector to be merged
+     * @return single merged int array of first and second
+     */
+    public static int[] mergeIntegerVectorsInArray(Vector<Integer> first, Vector<Integer> second) {
+        int resultLength = first.size() + second.size();
+        int[] result = new int[resultLength];
+        int i = 0;
+        for (; i < first.size(); ++i) {
+            result[i] = first.elementAt(i);
+        }
+        for (; i < resultLength; ++i) {
+            result[i] = second.elementAt(i - first.size());
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
case: https://manage.dimagi.com/default.asp?262590#1415995

This will make sure that cache and index fields are included at the end whenever we are doing a default sort. In case of all fields marked as cahce and indexed, we don't call sort functions at all, so this change will have no effect in that case. 

Product Note: Currently we don't include sort properties marked as cache and index in HQ while sorting by default, this PR makes a change to include all those properties in default sort with least preference (non cache and index properties will take preference over cache and index properties). 