### PR TITLE
Better exception for null instance in resolveReference()

### DIFF
--- a/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
+++ b/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
@@ -4,6 +4,7 @@ import org.commcare.cases.query.QueryContext;
 import org.commcare.cases.query.QuerySensitiveTreeElementWrapper;
 import org.commcare.cases.query.queryset.CurrentModelQuerySet;
 import org.commcare.cases.util.QueryUtils;
+import org.commcare.util.LogTypes;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.instance.AbstractTreeElement;
 import org.javarosa.core.model.instance.DataInstance;
@@ -13,6 +14,7 @@ import org.javarosa.core.model.trace.BulkEvaluationTrace;
 import org.javarosa.core.model.trace.EvaluationTrace;
 import org.javarosa.core.model.trace.EvaluationTraceReporter;
 import org.javarosa.core.model.utils.CacheHost;
+import org.javarosa.core.services.Logger;
 import org.javarosa.xpath.IExprDataType;
 import org.javarosa.xpath.XPathLazyNodeset;
 import org.javarosa.xpath.expr.FunctionUtils;
@@ -518,6 +520,11 @@ public class EvaluationContext implements Abandonable {
         if (qualifiedRef.getInstanceName() != null &&
                 (instance == null || instance.getInstanceId() == null || !instance.getInstanceId().equals(qualifiedRef.getInstanceName()))) {
             instance = this.getInstance(qualifiedRef.getInstanceName());
+        }
+        if (instance == null) {
+            Logger.log(LogTypes.SOFT_ASSERT, "Instance was null in " +
+                    "EvaluationContext.resolveReference(). This means that there was no main " +
+                    "instance and the ref to resolve had no instance: " + qualifiedRef);
         }
         return instance.resolveReference(qualifiedRef, this);
     }

--- a/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
+++ b/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
@@ -4,7 +4,6 @@ import org.commcare.cases.query.QueryContext;
 import org.commcare.cases.query.QuerySensitiveTreeElementWrapper;
 import org.commcare.cases.query.queryset.CurrentModelQuerySet;
 import org.commcare.cases.util.QueryUtils;
-import org.commcare.util.LogTypes;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.instance.AbstractTreeElement;
 import org.javarosa.core.model.instance.DataInstance;
@@ -14,15 +13,14 @@ import org.javarosa.core.model.trace.BulkEvaluationTrace;
 import org.javarosa.core.model.trace.EvaluationTrace;
 import org.javarosa.core.model.trace.EvaluationTraceReporter;
 import org.javarosa.core.model.utils.CacheHost;
-import org.javarosa.core.services.Logger;
 import org.javarosa.xpath.IExprDataType;
 import org.javarosa.xpath.XPathLazyNodeset;
+import org.javarosa.xpath.XPathMissingInstanceException;
 import org.javarosa.xpath.expr.FunctionUtils;
 import org.javarosa.xpath.expr.XPathExpression;
 
 import java.util.*;
 
-import javax.management.Query;
 
 /**
  * A collection of objects that affect the evaluation of an expression, like
@@ -522,9 +520,7 @@ public class EvaluationContext implements Abandonable {
             instance = this.getInstance(qualifiedRef.getInstanceName());
         }
         if (instance == null) {
-            Logger.log(LogTypes.SOFT_ASSERT, "Instance was null in " +
-                    "EvaluationContext.resolveReference(). This means that there was no main " +
-                    "instance and the ref to resolve had no instance: " + qualifiedRef);
+            throw new XPathMissingInstanceException(qualifiedRef);
         }
         return instance.resolveReference(qualifiedRef, this);
     }

--- a/src/main/java/org/javarosa/xpath/XPathMissingInstanceException.java
+++ b/src/main/java/org/javarosa/xpath/XPathMissingInstanceException.java
@@ -2,20 +2,26 @@ package org.javarosa.xpath;
 
 import org.javarosa.core.model.instance.TreeReference;
 
-/**
- * An exception indicating either that:
- * a) An instance is declared, but doesn't actually have any data in it
- * b) An instance was required to be present to evaluate a ref, but was not
- */
 public class XPathMissingInstanceException extends XPathException {
     String instanceName;
     TreeReference ref;
 
+    /**
+     * Indicates that an instance is declared, but doesn't actually have any data in it
+     * @param instanceName - the name of the empty instance
+     * @param message
+     */
     public XPathMissingInstanceException(String instanceName, String message) {
         super(message);
         this.instanceName = instanceName;
     }
 
+    /**
+     * Indicates that an instance was required to be present to evaluate a ref, but could not be
+     * found at all
+     * @param refThatNeededInstance - the ref that we were attempting to resolve, but could not
+     *                              because no instance was found
+     */
     public XPathMissingInstanceException(TreeReference refThatNeededInstance) {
         super("No instance was found with which to resolve reference: " + refThatNeededInstance);
         this.ref = refThatNeededInstance;

--- a/src/main/java/org/javarosa/xpath/XPathMissingInstanceException.java
+++ b/src/main/java/org/javarosa/xpath/XPathMissingInstanceException.java
@@ -1,10 +1,25 @@
 package org.javarosa.xpath;
 
+import org.javarosa.core.model.instance.TreeReference;
+
+/**
+ * An exception indicating either that:
+ * a) An instance is declared, but doesn't actually have any data in it
+ * b) An instance was required to be present to evaluate a ref, but was not
+ */
 public class XPathMissingInstanceException extends XPathException {
-    final String instanceName;
+    String instanceName;
+    TreeReference ref;
 
     public XPathMissingInstanceException(String instanceName, String message) {
         super(message);
         this.instanceName = instanceName;
     }
+
+    public XPathMissingInstanceException(TreeReference refThatNeededInstance) {
+        super("No instance was found with which to resolve reference: " + refThatNeededInstance);
+        this.ref = refThatNeededInstance;
+    }
+
+
 }


### PR DESCRIPTION
This is to help get to the bottom of https://fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/59d22cacbe077a4dcc9eaa0e?time=last-seven-days.

Even after trying to reproduce with one of the apps/users that experienced this crash, I couldn't get it to happen. I also can't reason out what could make it such that `qualifiedRef.getInstanceName()` would be null in this method, though it seems that that is what must be happening to cause this crash (I'm pretty sure it's expected that `this.getMainInstance()` would be null here, since we're just in a case list, and thus `qualifiedRef.getInstanceName()` must be the failure point). 

Will or Clayton, if either of you have any insight just from looking at this, obviously let me know. But otherwise the soft assert seemed like the best middle step.