### PR TITLE
Add a way to evaluate traces into a single string output

### DIFF
--- a/src/main/java/org/javarosa/core/model/utils/InstrumentationUtils.java
+++ b/src/main/java/org/javarosa/core/model/utils/InstrumentationUtils.java
@@ -31,4 +31,27 @@ public class InstrumentationUtils {
             reporter.reset();
         }
     }
+
+    /**
+     * Prints out traces (if any exist) from the provided reporter with a description into sysout
+     */
+    public static String collectAndClearTraces(EvaluationTraceReporter reporter, String description) {
+        String returnValue = "";
+        if (reporter != null) {
+            if (reporter.wereTracesReported()) {
+                returnValue += description + "\n";
+            }
+
+            StringEvaluationTraceSerializer serializer = new StringEvaluationTraceSerializer();
+
+            for (EvaluationTrace trace : reporter.getCollectedTraces()) {
+                returnValue += trace.getExpression() + ": " + trace.getValue()  + "\n";
+                returnValue += serializer.serializeEvaluationLevels(trace);
+            }
+
+            reporter.reset();
+        }
+        return returnValue;
+    }
+
 }


### PR DESCRIPTION
Add the ability to output xpath traces as strings, rather than dumping to stdout

Note: This PR is invisible and can be pulled ~immediately.