### PR TITLE
Use proper exception type to prevent all-out crash

### DIFF
--- a/src/main/java/org/javarosa/form/api/FormEntryModel.java
+++ b/src/main/java/org/javarosa/form/api/FormEntryModel.java
@@ -12,6 +12,7 @@ import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.model.trace.EvaluationTrace;
 import org.javarosa.core.model.trace.EvaluationTraceSerializer;
+import org.javarosa.xpath.XPathTypeMismatchException;
 
 import java.util.Enumeration;
 import java.util.Hashtable;
@@ -340,7 +341,7 @@ public class FormEntryModel {
                 try {
                     fullcount = ((Integer)new IntegerData().cast(count.uncast()).getValue());
                 } catch (IllegalArgumentException iae) {
-                    throw new RuntimeException("The repeat count value \""
+                    throw new XPathTypeMismatchException("The repeat count value \""
                             + count.uncast().getString() + "\" at "
                             + g.getConextualizedCountReference(index.getReference()).toString()
                             + " must be a number!");


### PR DESCRIPTION
Addresses https://fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/59ee065f61b02d480d114585?time=last-thirty-days. This crash represents a real user error, but it should be manifesting as a user-facing error dialog rather than an all-out crash. The cause of this is that we were throwing a `RuntimeException` where we should have been throwing an `XPathTypeMismatchException` (to match what gets thrown [here](https://github.com/dimagi/commcare-core/blob/e27479c87cbc1147317f661b44661f74d51cb71a/src/main/java/org/javarosa/core/model/FormDef.java#L468-L468) in the same situation). 