### PR TITLE
Throws error in case of space in select choices

### DIFF
--- a/src/main/java/org/javarosa/form/api/FormEntryPrompt.java
+++ b/src/main/java/org/javarosa/form/api/FormEntryPrompt.java
@@ -203,16 +203,25 @@ public class FormEntryPrompt extends FormEntryCaption {
     public Vector<SelectChoice> getSelectChoices(boolean shouldAttemptDynamicPopulation) {
         QuestionDef q = getQuestion();
         ItemsetBinding itemset = q.getDynamicChoices();
+        Vector<SelectChoice> selectChoices;
         if (itemset != null) {
             if (populatedDynamicChoices == null && shouldAttemptDynamicPopulation) {
                 form.populateDynamicChoices(itemset, mTreeElement.getRef());
                 populatedDynamicChoices = itemset.getChoices();
             }
-            return populatedDynamicChoices;
+            selectChoices = populatedDynamicChoices;
         } else {
             // static choices
-            return q.getChoices();
+            selectChoices = q.getChoices();
         }
+        if (selectChoices != null) {
+            for (int i = 0; i < selectChoices.size(); i++) {
+                if (selectChoices.get(i).getValue().contains(" ")) {
+                    throw new IllegalArgumentException("Select answer option cannot contain spaces in question '" + getLongText() + "' with option '" + getSelectChoiceText(selectChoices.get(i)) + "'");
+                }
+            }
+        }
+        return selectChoices;
     }
 
     public Vector<SelectChoice> getOldSelectChoices() {


### PR DESCRIPTION
Case: https://manage.dimagi.com/default.asp?266292#1427432

Product Note: Throw an error like 'Select answer option cannot contain spaces in question 'QuestionText' with option 'ChoiceWithSpaceText' ' in case spaces are present in lookup table options used for a lookup table select question's value field.