### PR TITLE
Demonstrating issue with today()

### DIFF
--- a/src/main/java/org/javarosa/core/model/utils/DateUtils.java
+++ b/src/main/java/org/javarosa/core/model/utils/DateUtils.java
@@ -113,15 +113,15 @@ public class DateUtils {
         return nonGregorian;
     }
 
-    public static DateFields getFields(Date d) {
+    public static DateFields getFieldsInDefaultTimezone(Date d) {
         return getFields(d, null);
     }
 
-    public static DateFields getFields(Date d, String timezone) {
+    public static DateFields getFields(Date d, TimeZone timezone) {
         Calendar cd = Calendar.getInstance();
         cd.setTime(d);
         if (timezone != null) {
-            cd.setTimeZone(TimeZone.getTimeZone(timezone));
+            cd.setTimeZone(timezone);
         }
 
         DateFields fields = new DateFields();
@@ -194,7 +194,8 @@ public class DateUtils {
             return "";
         }
 
-        DateFields fields = getFields(d, format == FORMAT_TIMESTAMP_HTTP ? "UTC" : null);
+        TimeZone tz = format == FORMAT_TIMESTAMP_HTTP ? TimeZone.getTimeZone("UTC") : null;
+        DateFields fields = getFields(d, tz);
 
         String delim;
         switch (format) {
@@ -216,11 +217,13 @@ public class DateUtils {
     }
 
     public static String formatDate(Date d, int format) {
-        return (d == null ? "" : formatDate(getFields(d, format == FORMAT_TIMESTAMP_HTTP ? "UTC" : null), format));
+        TimeZone tz = format == FORMAT_TIMESTAMP_HTTP ? TimeZone.getTimeZone("UTC") : null;
+        return (d == null ? "" : formatDate(getFields(d, tz), format));
     }
 
     public static String formatTime(Date d, int format) {
-        return (d == null ? "" : formatTime(getFields(d, format == FORMAT_TIMESTAMP_HTTP ? "UTC" : null), format));
+        TimeZone tz = format == FORMAT_TIMESTAMP_HTTP ? TimeZone.getTimeZone("UTC") : null;
+        return (d == null ? "" : formatTime(getFields(d, tz), format));
     }
 
     private static String formatDate(DateFields f, int format) {
@@ -322,7 +325,7 @@ public class DateUtils {
     }
 
     public static String format(Date d, String format) {
-        return format(getFields(d), format);
+        return format(getFieldsInDefaultTimezone(d), format);
     }
 
     public static String format(DateFields f, String format) {
@@ -511,7 +514,7 @@ public class DateUtils {
 
         c.setTimeZone(TimeZone.getDefault());
 
-        DateFields adjusted = getFields(c.getTime());
+        DateFields adjusted = getFieldsInDefaultTimezone(c.getTime());
 
         df.hour = adjusted.hour;
         df.minute = adjusted.minute;
@@ -567,11 +570,18 @@ public class DateUtils {
     /* ==== DATE UTILITY FUNCTIONS ==== */
 
     /**
+     *
+     * @param d -- the date to round
+     * @param tz -- the timezone that the original date was in, to ensure proper rounding
      * @return new Date object with same date but time set to midnight (in current timezone)
      */
-    public static Date roundDate(Date d) {
-        DateFields f = getFields(d);
+    public static Date roundDate(Date d, TimeZone tz) {
+        DateFields f = getFields(d, tz);
         return getDate(f.year, f.month, f.day);
+    }
+
+    public static Date roundDate(Date d) {
+        return roundDate(d, TimeZone.getDefault());
     }
 
     public static Date today() {

--- a/src/test/java/org/javarosa/core/model/data/test/DateDataTests.java
+++ b/src/test/java/org/javarosa/core/model/data/test/DateDataTests.java
@@ -89,9 +89,4 @@ public class DateDataTests {
         Assert.assertEquals(0, rounded.getMinutes());
     }
 
-    @Test
-    public void testToday() {
-        Date now = new Date();
-
-    }
 }

--- a/src/test/java/org/javarosa/core/model/data/test/DateDataTests.java
+++ b/src/test/java/org/javarosa/core/model/data/test/DateDataTests.java
@@ -80,7 +80,7 @@ public class DateDataTests {
         Calendar c = Calendar.getInstance(tz);
         c.set(2017, 0, 2, 2, 0); // Jan 2, 2017 2:00 AM
 
-        Date rounded = DateUtils.roundDate(c.getTime(), tz);
+        Date rounded = DateUtils.roundDate(c.getTime());
 
         Assert.assertEquals(2017 - 1900, rounded.getYear());
         Assert.assertEquals(0, rounded.getMonth());

--- a/src/test/java/org/javarosa/core/model/data/test/DateDataTests.java
+++ b/src/test/java/org/javarosa/core/model/data/test/DateDataTests.java
@@ -2,10 +2,13 @@ package org.javarosa.core.model.data.test;
 
 import org.javarosa.core.model.data.DateData;
 import org.javarosa.core.model.utils.DateUtils;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -69,5 +72,26 @@ public class DateDataTests {
         }
         assertTrue("DateData failed to throw an exception when setting null data", exceptionThrown);
         assertTrue("DateData overwrote existing value on incorrect input", data.getValue().equals(today));
+    }
+
+    @Test
+    public void testRoundDate() {
+        TimeZone tz = TimeZone.getTimeZone("Europe/London");
+        Calendar c = Calendar.getInstance(tz);
+        c.set(2017, 0, 2, 2, 0); // Jan 2, 2017 2:00 AM
+
+        Date rounded = DateUtils.roundDate(c.getTime(), tz);
+
+        Assert.assertEquals(2017 - 1900, rounded.getYear());
+        Assert.assertEquals(0, rounded.getMonth());
+        Assert.assertEquals(2, rounded.getDate());
+        Assert.assertEquals(0, rounded.getHours());
+        Assert.assertEquals(0, rounded.getMinutes());
+    }
+
+    @Test
+    public void testToday() {
+        Date now = new Date();
+
     }
 }


### PR DESCRIPTION
@wpride @shubham1g5 So I have most of an explanation for https://manage.dimagi.com/default.asp?266188, but with a small question mark, so want to run it by you guys and see what you think. 

The "hole" I identified is this: `XPathTodayFunc` computes its result by doing `DateUtils.roundDate(new Date())`, and `roundDate()` in turn calls `getFields()` with an optional timezone argument. If no timezone is passed, then `getFields()` uses the default timezone from the host. So if you look at the test I added to `DateDataTests`, the behavior that REC is seeing is replicable if you create a `Date` that is just past midnight in a timezone that is "earlier"/more-east than the current default, and then call `roundDate()` on it _without_ specifying a timezone. In the test I've written, `roundDate()` returns the day before the original date due to the timezone offset between EST and GMT being greater than the time between the original `Date` object's time and midnight. 

The inconsistency with the value of `now()` is explained by the fact that the implementation of `XPathNowFunc` simply returns `new Date()`, so it isn't working with timezones at all (java.util.Dates do not have any timezone associated with them). So the timezone that is showing up on HQ for the `timeStart` value must be getting inferred by HQ in some way.

The reason I put "hole" in quotes above is that the only way this could cause the bug that REC is seeing is if the devices in question are set to the incorrect timezone. I believe this is possible, but I don't think there's anything we can do about it from a code perspective? I don't know of any way to be smarter about getting the right timezone other than using the default; do you guys? If not, then I think we just need to tell them to check the device timezones and make sure they're set properly.