### PR TITLE
Fix for blank indexed fixture reference bug

### DIFF
--- a/src/main/java/org/commcare/cases/model/StorageIndexedTreeElementModel.java
+++ b/src/main/java/org/commcare/cases/model/StorageIndexedTreeElementModel.java
@@ -91,11 +91,11 @@ public class StorageIndexedTreeElementModel implements Persistable, IMetaData {
             // are only made over entries with multiplicity 0
             TreeElement child = root.getChild(getElementOrAttributeFromSqlColumnName(fieldName), 0);
             if (child == null) {
-                return null;
+                return "";
             }
             IAnswerData value = child.getValue();
             if (value == null) {
-                return null;
+                return "";
             } else {
                 return value.uncast().getString();
             }


### PR DESCRIPTION
Fix for: http://manage.dimagi.com/default.asp?266851

Update indexed fixtures to use consistent metadata as other models for empty values, prevents issues with doing indexed lookups for blanks. Tests in Android PR (requires SQL to trigger the bug)

Release note:
Fix for bug when matching empty values with indexed fixture lookups

cross-request: https://github.com/dimagi/commcare-android/pull/1908