### PR TITLE
Merge Formplayer CLI code into master

### DIFF
--- a/src/cli/java/org/commcare/util/screen/EntityDetailSubscreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityDetailSubscreen.java
@@ -2,9 +2,11 @@ package org.commcare.util.screen;
 
 import org.commcare.suite.model.Detail;
 import org.commcare.suite.model.DetailField;
+import org.commcare.suite.model.Style;
 import org.javarosa.core.model.condition.EvaluationContext;
 
 import java.io.PrintStream;
+import java.util.ArrayList;
 
 /**
  * An entity detail subscreen displays one of the detail screens associated with an
@@ -20,24 +22,59 @@ public class EntityDetailSubscreen extends Subscreen<EntityScreen> {
 
     private final String[] rows;
     private final String[] mDetailListTitles;
-
+    private final Object[] data ;
+    private final String[] headers;
+    private final Style[] styles;
     private final int mCurrentIndex;
+    private Detail detail;
 
     public EntityDetailSubscreen(int currentIndex, Detail detail, EvaluationContext subContext, String[] detailListTitles) {
+        this.detail = detail;
         DetailField[] fields = detail.getFields();
-        rows = new String[fields.length];
+
+        ArrayList<String> rowTemporary = new ArrayList<>();
+        ArrayList<String> headersTemporary = new ArrayList<>();
+        ArrayList<Object> dataTemporary = new ArrayList<>();
+        ArrayList<Style> stylesTemporary = new ArrayList<>();
 
         detail.populateEvaluationContextVariables(subContext);
 
-        for (int i = 0; i < fields.length; ++i) {
-            rows[i] = createRow(fields[i], subContext);
+        for (DetailField field : fields) {
+            Object data = createData(field, subContext);
+            // don't add empty details
+            if (data != null && !data.toString().trim().equals("")) {
+                dataTemporary.add(data);
+                headersTemporary.add(createHeader(field, subContext));
+                rowTemporary.add(createRow(field, subContext, data));
+                stylesTemporary.add(createStyle(field));
+            }
         }
-        mDetailListTitles = detailListTitles;
 
+        rows = new String[rowTemporary.size()];
+        headers = new String[rowTemporary.size()];
+        data = new Object[rowTemporary.size()];
+        styles = new Style[rowTemporary.size()];
+
+        rowTemporary.toArray(rows);
+        headersTemporary.toArray(headers);
+        dataTemporary.toArray(data);
+        stylesTemporary.toArray(styles);
+
+        mDetailListTitles = detailListTitles;
         mCurrentIndex = currentIndex;
     }
 
-    private String createRow(DetailField field, EvaluationContext ec) {
+    private Style createStyle(DetailField field) {
+        return new Style(field);
+    }
+
+    private String createHeader(DetailField field, EvaluationContext ec){return field.getHeader().evaluate(ec);}
+
+    private Object createData(DetailField field, EvaluationContext ec){
+        return field.getTemplate().evaluate(ec);
+    }
+
+    private String createRow(DetailField field, EvaluationContext ec, Object o) {
         StringBuilder row = new StringBuilder();
         String header = field.getHeader().evaluate(ec);
 
@@ -45,7 +82,6 @@ public class EntityDetailSubscreen extends Subscreen<EntityScreen> {
         row.append(" | ");
 
         String value;
-        Object o = field.getTemplate().evaluate(ec);
         if (!(o instanceof String)) {
             value = "{ " + field.getTemplateForm() + " data}";
         } else {
@@ -113,5 +149,27 @@ public class EntityDetailSubscreen extends Subscreen<EntityScreen> {
             //This will result in things just executing again, which is fine.
         }
         return false;
+    }
+
+    public Object[] getData() {
+        return data;
+    }
+
+    public String[] getHeaders(){
+        return headers;
+    }
+
+    public String[] getTitles() { return mDetailListTitles;}
+
+    public Detail getDetail() {
+        return detail;
+    }
+
+    public void setDetail(Detail detail) {
+        this.detail = detail;
+    }
+
+    public Style[] getStyles() {
+        return styles;
     }
 }

--- a/src/cli/java/org/commcare/util/screen/EntityListSubscreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityListSubscreen.java
@@ -1,16 +1,16 @@
 package org.commcare.util.screen;
 
+import org.commcare.modern.util.Pair;
 import org.commcare.suite.model.Action;
 import org.commcare.suite.model.Detail;
 import org.commcare.suite.model.DetailField;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.model.trace.AccumulatingReporter;
-import org.javarosa.core.model.trace.EvaluationTrace;
 import org.javarosa.core.model.trace.EvaluationTraceReporter;
 import org.javarosa.core.model.trace.ReducingTraceReporter;
-import org.javarosa.core.model.trace.StringEvaluationTraceSerializer;
 import org.javarosa.core.model.utils.InstrumentationUtils;
+import org.javarosa.core.util.DataUtil;
 import org.javarosa.xpath.XPathException;
 
 import java.io.PrintStream;
@@ -39,39 +39,45 @@ public class EntityListSubscreen extends Subscreen<EntityScreen> {
         mHeader = createHeader(shortDetail, context);
         this.shortDetail = shortDetail;
         this.rootContext = context;
-
-        rows = new String[references.size()];
-
-        int i = 0;
-        for (TreeReference entity : references) {
-            rows[i] = createRow(entity);
-            ++i;
-        }
-
         this.mChoices = new TreeReference[references.size()];
         references.copyInto(mChoices);
-
         actions = shortDetail.getCustomActions(context);
+        rows = getRows(mChoices, context, shortDetail);
     }
 
-    private String createRow(TreeReference entity) {
-        return createRow(entity, false);
+    public static String[] getRows(TreeReference[] references,
+                                   EvaluationContext evaluationContext,
+                                   Detail detail) {
+        String[] rows = new String[references.length];
+        int i = 0;
+        for (TreeReference entity : references) {
+            rows[i] = createRow(entity, evaluationContext, detail);
+            ++i;
+        }
+        return rows;
     }
 
-    private String createRow(TreeReference entity, boolean collectDebug) {
-        EvaluationContext context = new EvaluationContext(rootContext, entity);
+    private static String createRow(TreeReference entity, EvaluationContext evaluationContext, Detail detail) {
+        return createRow(entity, false, evaluationContext, detail);
+    }
+
+    private static String createRow(TreeReference entity,
+                                    boolean collectDebug,
+                                    EvaluationContext evaluationContext,
+                                    Detail detail) {
+        EvaluationContext context = new EvaluationContext(evaluationContext, entity);
         EvaluationTraceReporter reporter = new AccumulatingReporter();
 
         if (collectDebug) {
             context.setDebugModeOn(reporter);
         }
-        shortDetail.populateEvaluationContextVariables(context);
+        detail.populateEvaluationContextVariables(context);
 
         if (collectDebug) {
             InstrumentationUtils.printAndClearTraces(reporter, "Variable Traces");
         }
 
-        DetailField[] fields = shortDetail.getFields();
+        DetailField[] fields = detail.getFields();
 
         StringBuilder row = new StringBuilder();
         int i = 0;
@@ -90,17 +96,7 @@ public class EntityListSubscreen extends Subscreen<EntityScreen> {
                 s = (String)o;
             }
 
-            int widthHint = SCREEN_WIDTH / fields.length;
-            try {
-                widthHint = Integer.parseInt(field.getTemplateWidthHint());
-            } catch (Exception e) {
-                //Really don't care if it didn't work
-            }
-            ScreenUtils.addPaddedStringToBuilder(row, s, widthHint);
-            i++;
-            if (i != fields.length) {
-                row.append(" | ");
-            }
+            row.append(s);
         }
 
         if (collectDebug) {
@@ -109,6 +105,49 @@ public class EntityListSubscreen extends Subscreen<EntityScreen> {
         return row.toString();
     }
 
+    public static Pair<String[], int[]> getHeaders(Detail shortDetail, EvaluationContext context, int sortIndex){
+        DetailField[] fields = shortDetail.getFields();
+        String[] headers = new String[fields.length];
+        int[] widthHints = new int[fields.length];
+
+        boolean reverse = sortIndex < 0;
+        sortIndex = Math.abs(sortIndex) - 1;
+        int[] sorts = shortDetail.getOrderedFieldIndicesForSorting();
+
+        StringBuilder row = new StringBuilder();
+        int i = 0;
+        for (DetailField field : fields) {
+            String s = field.getHeader().evaluate(context);
+
+            int widthHint = SCREEN_WIDTH / fields.length;
+            try {
+                widthHint = Integer.parseInt(field.getHeaderWidthHint());
+            } catch (Exception e) {
+                //Really don't care if it didn't work
+            }
+
+            ScreenUtils.addPaddedStringToBuilder(row, s, widthHint);
+
+            if (DataUtil.intArrayContains(sorts, i)) {
+                if (i == sortIndex) {
+                    if (reverse) {
+                        s = s + " Λ ";
+                    } else {
+                        s = s + " V ";
+                    }
+                }
+            }
+
+            headers[i] = s;
+            widthHints[i] = widthHint;
+
+            i++;
+            if (i != fields.length) {
+                row.append(" | ");
+            }
+        }
+        return new Pair<>(headers, widthHints);
+    }
 
     //So annoying how identical this is...
     private static String createHeader(Detail shortDetail, EvaluationContext context) {
@@ -179,7 +218,7 @@ public class EntityListSubscreen extends Subscreen<EntityScreen> {
             String debugArg = input.substring("debug ".length());
             try {
                 int chosenDebugIndex = Integer.valueOf(debugArg.trim());
-                createRow(this.mChoices[chosenDebugIndex], true);
+                createRow(this.mChoices[chosenDebugIndex], rootContext, shortDetail);
             } catch (NumberFormatException e) {
                 if ("list".equals(debugArg)) {
                     host.printNodesetExpansionTrace(new AccumulatingReporter());
@@ -194,14 +233,15 @@ public class EntityListSubscreen extends Subscreen<EntityScreen> {
 
 
         try {
-            int i = Integer.parseInt(input);
-
-            host.setHighlightedEntity(this.mChoices[i]);
-
-            return !host.setCurrentScreenToDetail();
+            host.setHighlightedEntity(input);
+            return true;
         } catch (NumberFormatException e) {
             //This will result in things just executing again, which is fine.
         }
         return false;
+    }
+
+    public Detail getShortDetail() {
+        return shortDetail;
     }
 }

--- a/src/cli/java/org/commcare/util/screen/EntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreen.java
@@ -1,22 +1,22 @@
 package org.commcare.util.screen;
 
+import org.commcare.cases.entity.EntityUtil;
 import org.commcare.modern.session.SessionWrapper;
+import org.commcare.session.CommCareSession;
 import org.commcare.suite.model.Action;
 import org.commcare.suite.model.Detail;
 import org.commcare.suite.model.EntityDatum;
 import org.commcare.suite.model.SessionDatum;
 import org.commcare.util.CommCarePlatform;
-import org.commcare.session.CommCareSession;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.AbstractTreeElement;
 import org.javarosa.core.model.instance.TreeReference;
-import org.javarosa.core.model.trace.AccumulatingReporter;
 import org.javarosa.core.model.trace.EvaluationTraceReporter;
-import org.javarosa.core.model.trace.ReducingTraceReporter;
 import org.javarosa.core.model.utils.InstrumentationUtils;
 import org.javarosa.core.util.NoLocalizedTextException;
 import org.javarosa.model.xform.XPathReference;
 
+import java.util.Hashtable;
 import java.util.Vector;
 
 /**
@@ -35,7 +35,6 @@ public class EntityScreen extends CompoundScreenHost {
     private CommCarePlatform mPlatform;
 
     private Detail mShortDetail;
-    private Detail[] mLongDetailList;
 
     private EntityDatum mNeededDatum;
     private Action mPendingAction;
@@ -45,7 +44,8 @@ public class EntityScreen extends CompoundScreenHost {
     private boolean readyToSkip = false;
     private EvaluationContext evalContext;
 
-    @Override
+    private Hashtable<String, TreeReference> referenceMap;
+
     public void init(SessionWrapper session) throws CommCareSessionException {
         SessionDatum datum = session.getNeededDatum();
         if (!(datum instanceof EntityDatum)) {
@@ -70,6 +70,10 @@ public class EntityScreen extends CompoundScreenHost {
         evalContext = mSession.getEvaluationContext();
 
         Vector<TreeReference> references = expandEntityReferenceSet(evalContext);
+        referenceMap = new Hashtable<>();
+        for(TreeReference reference: references) {
+            referenceMap.put(getReturnValueFromSelection(reference, (EntityDatum) session.getNeededDatum(), evalContext), reference);
+        }
 
         // for now override 'here()' with the coords of Sao Paulo, eventually allow dynamic setting
         evalContext.addFunctionHandler(new ScreenUtils.HereDummyFunc(-23.56, -46.66));
@@ -95,7 +99,7 @@ public class EntityScreen extends CompoundScreenHost {
     }
 
     @Override
-    protected String getScreenTitle() {
+    public String getScreenTitle() {
         try {
             return mShortDetail.getTitle().evaluate(evalContext).getName();
         } catch (NoLocalizedTextException nlte) {
@@ -108,7 +112,7 @@ public class EntityScreen extends CompoundScreenHost {
         return mCurrentScreen;
     }
 
-    private String getReturnValueFromSelection(TreeReference contextRef, EntityDatum needed, EvaluationContext context) {
+    public static String getReturnValueFromSelection(TreeReference contextRef, EntityDatum needed, EvaluationContext context) {
         // grab the session's (form) element reference, and load it.
         TreeReference elementRef =
                 XPathReference.getPathExpr(needed.getValue()).getReference();
@@ -141,50 +145,61 @@ public class EntityScreen extends CompoundScreenHost {
         this.mCurrentSelection = selection;
     }
 
-    private void initDetailScreens() {
-        String longDetailId = this.mNeededDatum.getLongDetail();
-        if (longDetailId == null) {
-            mLongDetailList = null;
-            return;
-        }
-        Detail d = mPlatform.getDetail(longDetailId);
-        if (d == null) {
-            mLongDetailList = null;
-            return;
-        }
-        mLongDetailList = d.getDetails();
-        if (mLongDetailList == null || mLongDetailList.length == 0) {
-            mLongDetailList = new Detail[]{d};
+    public void setHighlightedEntity(String id) throws CommCareSessionException {
+        this.mCurrentSelection = referenceMap.get(id);
+        if (this.mCurrentSelection == null) {
+            throw new CommCareSessionException("EntityScreen " + this.toString() + " could not select case " + id + "." +
+                    " If this error persists please report a bug to CommCareHQ.");
         }
     }
 
     public boolean setCurrentScreenToDetail() throws CommCareSessionException {
-        initDetailScreens();
-
-        if (mLongDetailList == null) {
+        Detail[] longDetailList = getLongDetailList(mCurrentSelection);
+        if (longDetailList == null) {
             return false;
         }
-
         setCurrentScreenToDetail(0);
         return true;
     }
 
     public void setCurrentScreenToDetail(int index) throws CommCareSessionException {
         EvaluationContext subContext = new EvaluationContext(evalContext, this.mCurrentSelection);
-
-        TreeReference detailNodeset = this.mLongDetailList[index].getNodeset();
+        Detail[] longDetailList = getLongDetailList(this.mCurrentSelection);
+        TreeReference detailNodeset = longDetailList[index].getNodeset();
         if (detailNodeset != null) {
             TreeReference contextualizedNodeset = detailNodeset.contextualize(this.mCurrentSelection);
-            this.mCurrentScreen = new EntityListSubscreen(this.mLongDetailList[index], subContext.expandReference(contextualizedNodeset), subContext);
+            this.mCurrentScreen = new EntityListSubscreen(longDetailList[index], subContext.expandReference(contextualizedNodeset), subContext);
         } else {
-            this.mCurrentScreen = new EntityDetailSubscreen(index, this.mLongDetailList[index], subContext, getDetailListTitles(subContext));
+            this.mCurrentScreen = new EntityDetailSubscreen(index, longDetailList[index], subContext, getDetailListTitles(subContext, this.mCurrentSelection));
         }
     }
 
-    private String[] getDetailListTitles(EvaluationContext subContext) {
+    public Detail[] getLongDetailList(TreeReference ref){
+        Detail[] longDetailList;
+        String longDetailId = this.mNeededDatum.getLongDetail();
+        if (longDetailId == null) {
+            return null;
+        }
+        Detail d = mPlatform.getDetail(longDetailId);
+        if (d == null) {
+            return null;
+        }
+
+        EvaluationContext contextForChildDetailDisplayConditions =
+                EntityUtil.prepareCompoundEvaluationContext(ref, d, evalContext);
+
+        longDetailList = d.getDisplayableChildDetails(contextForChildDetailDisplayConditions);
+        if (longDetailList == null || longDetailList.length == 0) {
+            longDetailList = new Detail[]{d};
+        }
+        return longDetailList;
+    }
+
+    public String[] getDetailListTitles(EvaluationContext subContext, TreeReference reference) {
+        Detail[] mLongDetailList = getLongDetailList(reference);
         String[] titles = new String[mLongDetailList.length];
         for (int i = 0; i < mLongDetailList.length; ++i) {
-            titles[i] = this.mLongDetailList[i].getTitle().getText().evaluate(subContext);
+            titles[i] = mLongDetailList[i].getTitle().getText().evaluate(subContext);
         }
         return titles;
     }
@@ -193,9 +208,33 @@ public class EntityScreen extends CompoundScreenHost {
         this.mPendingAction = pendingAction;
     }
 
+    public Detail getShortDetail(){
+        return mShortDetail;
+    }
+    public SessionWrapper getSession() {
+        return mSession;
+    }
+
     public void printNodesetExpansionTrace(EvaluationTraceReporter reporter) {
         evalContext.setDebugModeOn(reporter);
         this.expandEntityReferenceSet(evalContext);
         InstrumentationUtils.printAndClearTraces(reporter, "Entity Nodeset");
+    }
+
+    public TreeReference resolveTreeReference(String reference) {
+        return referenceMap.get(reference);
+    }
+
+    public EvaluationContext getEvalContext() {
+        return evalContext;
+    }
+
+    public TreeReference getCurrentSelection() {
+        return mCurrentSelection;
+    }
+
+    @Override
+    public String toString() {
+        return "EntityScreen [Detail=" + mShortDetail + ", selection=" + mCurrentSelection + "]";
     }
 }

--- a/src/cli/java/org/commcare/util/screen/MenuScreen.java
+++ b/src/cli/java/org/commcare/util/screen/MenuScreen.java
@@ -1,5 +1,6 @@
 package org.commcare.util.screen;
 
+
 import org.commcare.modern.session.SessionWrapper;
 import org.commcare.session.CommCareSession;
 import org.commcare.suite.model.Entry;
@@ -8,8 +9,12 @@ import org.commcare.suite.model.MenuDisplayable;
 import org.commcare.suite.model.MenuLoader;
 import org.commcare.util.LoggerInterface;
 import org.javarosa.core.services.Logger;
+import org.javarosa.core.services.locale.Localization;
+import org.javarosa.core.util.NoLocalizedTextException;
 
 import java.io.PrintStream;
+import java.util.Arrays;
+
 
 /**
  * Screen to allow users to choose items from session menus.
@@ -19,8 +24,17 @@ import java.io.PrintStream;
 public class MenuScreen extends Screen {
 
     private MenuDisplayable[] mChoices;
+    private String[] badges;
 
     private String mTitle;
+
+    public String[] getBadges() {
+        return badges;
+    }
+
+    public void setBadges(String[] badges) {
+        this.badges = badges;
+    }
 
     class ScreenLogger implements LoggerInterface {
 
@@ -40,6 +54,8 @@ public class MenuScreen extends Screen {
         String root = deriveMenuRoot(session);
         MenuLoader menuLoader = new MenuLoader(session.getPlatform(), session, root, new ScreenLogger(), false);
         this.mChoices = menuLoader.getMenus();
+        this.mTitle = this.getBestTitle();
+        this.badges = menuLoader.getBadgeText();
         Exception loadException = menuLoader.getLoadException();
         if (loadException != null) {
             throw new CommCareSessionException(menuLoader.getErrorMessage());
@@ -47,7 +63,7 @@ public class MenuScreen extends Screen {
     }
 
     @Override
-    protected String getScreenTitle() {
+    public String getScreenTitle() {
         return mTitle;
     }
 
@@ -94,5 +110,22 @@ public class MenuScreen extends Screen {
             //This will result in things just executing again, which is fine.
         }
         return true;
+    }
+
+    public MenuDisplayable[] getMenuDisplayables(){
+        return mChoices;
+    }
+
+    private String getBestTitle(){
+        try {
+            return Localization.get("app.display.name");
+        } catch (NoLocalizedTextException nlte) {
+            return "CommCare";
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "MenuScreen " + mTitle + " with choices " + Arrays.toString(mChoices);
     }
 }

--- a/src/main/java/org/commcare/suite/model/MenuLoader.java
+++ b/src/main/java/org/commcare/suite/model/MenuLoader.java
@@ -27,6 +27,7 @@ public class MenuLoader {
     private Exception loadException;
     private String xPathErrorMessage;
     private MenuDisplayable[] menus;
+    private String[] badges;
     private LoggerInterface loggerInterface;
 
     private ReducingTraceReporter traceReporter;
@@ -53,19 +54,20 @@ public class MenuLoader {
 
     private void getMenuDisplayables(CommCarePlatform platform,
                                      SessionWrapperInterface sessionWrapper,
-                                                        String menuID) {
+                                     String menuID) {
 
         Vector<MenuDisplayable> items = new Vector<>();
+        Vector<String> badges = new Vector<>();
         Hashtable<String, Entry> map = platform.getMenuMap();
         for (Suite s : platform.getInstalledSuites()) {
             for (Menu m : s.getMenus()) {
                 try {
                     if (m.getId().equals(menuID)) {
                         if (menuIsRelevant(sessionWrapper, m)) {
-                            addRelevantCommandEntries(sessionWrapper, m, items, map);
+                            addRelevantCommandEntries(sessionWrapper, m, items, badges, map);
                         }
                     } else {
-                        addUnaddedMenu(sessionWrapper, menuID, m, items);
+                        addUnaddedMenu(sessionWrapper, menuID, m, items, badges);
                     }
                 } catch (CommCareInstanceInitializer.FixtureInitializationException
                         | XPathSyntaxException | XPathException xpe) {
@@ -77,11 +79,14 @@ public class MenuLoader {
         }
         menus = new MenuDisplayable[items.size()];
         items.copyInto(menus);
+        this.badges = new String[badges.size()];
+        badges.copyInto(this.badges);
     }
 
     private void addUnaddedMenu(SessionWrapperInterface sessionWrapper,
-                                       String menuID, Menu m,
-                                       Vector<MenuDisplayable> items) throws XPathSyntaxException {
+                                String menuID, Menu m,
+                                Vector<MenuDisplayable> items,
+                                Vector<String> badges) throws XPathSyntaxException {
         if (menuID.equals(m.getRoot())) {
             //make sure we didn't already add this ID
             boolean idExists = false;
@@ -96,6 +101,7 @@ public class MenuLoader {
             if (!idExists) {
                 if (menuIsRelevant(sessionWrapper, m)) {
                     items.add(m);
+                    badges.add(m.getTextForBadge(sessionWrapper.getEvaluationContext(m.getCommandID())).blockingGet());
                 }
             }
         }
@@ -126,6 +132,7 @@ public class MenuLoader {
     private void addRelevantCommandEntries(SessionWrapperInterface sessionWrapper,
                                            Menu m,
                                            Vector<MenuDisplayable> items,
+                                           Vector<String> badges,
                                            Hashtable<String, Entry> map)
             throws XPathSyntaxException {
         xPathErrorMessage = "";
@@ -164,6 +171,7 @@ public class MenuLoader {
             }
 
             items.add(e);
+            badges.add(e.getTextForBadge(sessionWrapper.getEvaluationContext(e.getCommandId())).blockingGet());
         }
     }
 
@@ -189,5 +197,13 @@ public class MenuLoader {
 
     public void setMenus(MenuDisplayable[] menus) {
         this.menus = menus;
+    }
+
+    public String[] getBadgeText() {
+        return badges;
+    }
+
+    public void setBadgeText(String[] badgeText) {
+        this.badges = badgeText;
     }
 }

--- a/src/main/java/org/commcare/suite/model/Style.java
+++ b/src/main/java/org/commcare/suite/model/Style.java
@@ -1,0 +1,87 @@
+package org.commcare.suite.model;
+
+/**
+ * Created by willpride on 4/13/16.
+ */
+public class Style {
+
+    private DisplayFormat displayFormats;
+    private int fontSize;
+    private int widthHint;
+
+    public Style(){}
+
+    public Style(DetailField detail){
+        if(detail.getFontSize() != null) {
+            try {
+                setFontSize(Integer.parseInt(detail.getFontSize()));
+            } catch (NumberFormatException nfe) {
+                setFontSize(12);
+            }
+        }
+        // For width, default to -1 since '0' is reserved for hidden (Search) fiekds
+        if(detail.getTemplateWidthHint() != null) {
+            try {
+                setWidthHint(Integer.parseInt(detail.getTemplateWidthHint()));
+            } catch (NumberFormatException nfe) {
+                setWidthHint(-1);
+            }
+        } else {
+            setWidthHint(-1);
+        }
+        setDisplayFormatFromString(detail.getTemplateForm());
+    }
+
+    enum DisplayFormat {
+        Image,
+        Audio,
+        Text,
+        Graph
+    }
+
+    public DisplayFormat getDisplayFormat() {
+        return displayFormats;
+    }
+
+    private void setDisplayFormat(DisplayFormat displayFormats) {
+        this.displayFormats = displayFormats;
+    }
+
+    public int getFontSize() {
+        return fontSize;
+    }
+
+    private void setFontSize(int fontSize) {
+        this.fontSize = fontSize;
+    }
+
+    public int getWidthHint() {
+        return widthHint;
+    }
+
+    private void setWidthHint(int widthHint) {
+        this.widthHint = widthHint;
+    }
+
+    private void setDisplayFormatFromString(String displayFormat){
+        switch (displayFormat) {
+            case "image":
+                setDisplayFormat(DisplayFormat.Image);
+                break;
+            case "audio":
+                setDisplayFormat(DisplayFormat.Audio);
+                break;
+            case "text":
+                setDisplayFormat(DisplayFormat.Text);
+                break;
+            case "graph":
+                setDisplayFormat(DisplayFormat.Graph);
+                break;
+        }
+    }
+
+    @Override
+    public String toString(){
+        return "Style: [displayFormat=" + displayFormats + ", fontSize=" + fontSize + "]";
+    }
+}

--- a/src/main/java/org/javarosa/core/util/DataUtil.java
+++ b/src/main/java/org/javarosa/core/util/DataUtil.java
@@ -67,6 +67,15 @@ public class DataUtil {
         return s.split("[ ]+");
     }
 
+    public static boolean intArrayContains(int[] source, int target) {
+        for (int sort: source) {
+            if (sort == target) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public static String[] splitOnDash(String s) {
         return s.split("-");
     }

--- a/src/main/java/org/javarosa/core/util/DataUtil.java
+++ b/src/main/java/org/javarosa/core/util/DataUtil.java
@@ -68,8 +68,8 @@ public class DataUtil {
     }
 
     public static boolean intArrayContains(int[] source, int target) {
-        for (int sort: source) {
-            if (sort == target) {
+        for (int current: source) {
+            if (current == target) {
                 return true;
             }
         }


### PR DESCRIPTION
Moves over most of the CLI-level updates made for Formplayer. This mostly involves loading up a richer set of data than the CLI was previously, making this accessible via getters (rather than solely through the `prompt` call), and more lazily loading some information that might not be necessary for each screen usage.

This arguably loads more information for the CLI than would ever be necessary, but I don't see that as a huge problem (though open to being pushed back on) 