### PR TITLE
Log exception for Crashlytics crash 

### DIFF
--- a/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
+++ b/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
@@ -13,6 +13,7 @@ import org.javarosa.core.model.trace.BulkEvaluationTrace;
 import org.javarosa.core.model.trace.EvaluationTrace;
 import org.javarosa.core.model.trace.EvaluationTraceReporter;
 import org.javarosa.core.model.utils.CacheHost;
+import org.javarosa.core.services.Logger;
 import org.javarosa.xpath.IExprDataType;
 import org.javarosa.xpath.XPathLazyNodeset;
 import org.javarosa.xpath.XPathMissingInstanceException;
@@ -520,7 +521,9 @@ public class EvaluationContext {
             instance = this.getInstance(qualifiedRef.getInstanceName());
         }
         if (instance == null) {
-            throw new XPathMissingInstanceException(qualifiedRef);
+            XPathMissingInstanceException e = new XPathMissingInstanceException(qualifiedRef);
+            Logger.exception(e.getMessage(), e);
+            throw e;
         }
         return instance.resolveReference(qualifiedRef, this);
     }


### PR DESCRIPTION
The reason I added the new exception in https://github.com/dimagi/commcare-core/pull/673 was to get more info on a crash showing up in Crashlytics (https://fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/59d22cacbe077a4dcc9eaa0e?time=last-seven-days), but that PR didn't actually log the exception in any way. 