### PR TITLE
Inrease choice limit length 32 -> 256

### DIFF
--- a/src/main/java/org/javarosa/xform/parse/XFormParser.java
+++ b/src/main/java/org/javarosa/xform/parse/XFormParser.java
@@ -1279,7 +1279,7 @@ public class XFormParser {
     }
 
     private void parseItem(QuestionDef q, Element e) {
-        final int MAX_VALUE_LEN = 32;
+        final int MAX_VALUE_LEN = 256;
 
         //catalogue of used attributes in this method/element
         Vector<String> usedAtts = new Vector<>();


### PR DESCRIPTION
Instead of https://github.com/dimagi/commcare-core/pull/710, warn only when choices are *very* long