### PR TITLE
Fix CLI

### DIFF
--- a/src/cli/java/org/commcare/util/engine/CommCareConfigEngine.java
+++ b/src/cli/java/org/commcare/util/engine/CommCareConfigEngine.java
@@ -318,7 +318,7 @@ public class CommCareConfigEngine {
     }
 
     public FormDef loadFormByXmlns(String xmlns) {
-        IStorageUtilityIndexed<FormDef> formStorage = storageFactory.newStorage(FormDef.STORAGE_KEY, FormDef.class);
+        IStorageUtilityIndexed<FormDef> formStorage = StorageManager.getStorage(FormDef.STORAGE_KEY);
         return formStorage.getRecordForValue("XMLNS", xmlns);
     }
 

--- a/src/test/java/org/commcare/test/utilities/MockApp.java
+++ b/src/test/java/org/commcare/test/utilities/MockApp.java
@@ -40,13 +40,6 @@ public class MockApp {
         final LivePrototypeFactory mPrototypeFactory = setupStaticStorage();
         MockUserDataSandbox mSandbox = new MockUserDataSandbox(mPrototypeFactory);
         CommCareConfigEngine mEngine = new CommCareConfigEngine(mPrototypeFactory);
-        
-        mEngine.setStorageFactory(new IStorageIndexedFactory() {
-            @Override
-            public IStorageUtilityIndexed newStorage(String name, Class type) {
-                return new DummyIndexedStorageUtility(type, mPrototypeFactory);
-            }
-        });
 
         mEngine.installAppFromReference("jr://resource" + APP_BASE + "profile.ccpr");
         mEngine.initEnvironment();


### PR DESCRIPTION
Looks like the CLI was broken by my last `commcare-core` Formplayer refactor; specifically, you couldn't load XForms from storage. As shown below, we were calling `storageFactory.newStorage` when we retrieved the Form storage. This works fine on Formplayer when the Storage objects are just transient wrappers and the actual data is written to the file system, but breaks when the Java objects themselves actually contain the data (as is the case with the `DummyStorageFactory`).

Also remove redundant initialization. 