### PR TITLE
Refactor PropertyManager

### DIFF
--- a/src/cli/java/org/commcare/util/cli/ApplicationHost.java
+++ b/src/cli/java/org/commcare/util/cli/ApplicationHost.java
@@ -431,13 +431,15 @@ public class ApplicationHost {
                     syncToken, caseStateHash));
         }
 
+        PropertyManager propertyManager = session.getPlatform().getPropertyManager();
+
         //fetch the restore data and set credentials
-        String otaFreshRestoreUrl = PropertyManager.instance().getSingularProperty("ota-restore-url") +
+        String otaFreshRestoreUrl = propertyManager.getSingularProperty("ota-restore-url") +
                 "?version=2.0";
 
         String otaSyncUrl = otaFreshRestoreUrl + urlStateParams;
 
-        String domain = PropertyManager.instance().getSingularProperty("cc_user_domain");
+        String domain = propertyManager.getSingularProperty("cc_user_domain");
         final String qualifiedUsername = username + "@" + domain;
 
         Authenticator.setDefault(new Authenticator() {

--- a/src/cli/java/org/commcare/util/engine/CommCareConfigEngine.java
+++ b/src/cli/java/org/commcare/util/engine/CommCareConfigEngine.java
@@ -31,6 +31,7 @@ import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.reference.ResourceReferenceFactory;
 import org.javarosa.core.services.PropertyManager;
 import org.javarosa.core.services.locale.Localization;
+import org.javarosa.core.services.properties.Property;
 import org.javarosa.core.services.storage.*;
 import org.javarosa.core.services.storage.util.DummyIndexedStorageUtility;
 import org.javarosa.core.util.externalizable.LivePrototypeFactory;
@@ -77,7 +78,6 @@ public class CommCareConfigEngine {
     public CommCareConfigEngine(IStorageIndexedFactory storageFactory,
                                 InstallerFactory installerFactory) {
         this.print = new PrintStream(System.out);
-        this.platform = new CommCarePlatform(MAJOR_VERSION, MINOR_VERSION);
         setStorageFactory(storageFactory);
 
         setRoots();
@@ -92,12 +92,15 @@ public class CommCareConfigEngine {
         //per device.
         StorageManager.forceClear();
         StorageManager.setStorageFactory(storageFactory);
-        PropertyManager.initDefaultPropertyManager();
+        StorageManager.registerStorage(PropertyManager.STORAGE_KEY, Property.class);
         StorageManager.registerStorage(Profile.STORAGE_KEY, Profile.class);
         StorageManager.registerStorage(Suite.STORAGE_KEY, Suite.class);
         StorageManager.registerStorage(FormDef.STORAGE_KEY, FormDef.class);
         StorageManager.registerStorage(FormInstance.STORAGE_KEY, FormInstance.class);
         StorageManager.registerStorage(OfflineUserRestore.STORAGE_KEY, OfflineUserRestore.class);
+
+        this.platform = new CommCarePlatform(MAJOR_VERSION, MINOR_VERSION,
+                new PropertyManager(StorageManager.getStorage(PropertyManager.STORAGE_KEY)));
     }
 
     private static IStorageIndexedFactory setupDummyStorageFactory(final PrototypeFactory prototypeFactory) {

--- a/src/main/java/org/commcare/resources/ResourceManager.java
+++ b/src/main/java/org/commcare/resources/ResourceManager.java
@@ -170,7 +170,7 @@ public class ResourceManager {
                 Logger.log("Resource", "Upgrade table fetched, beginning upgrade");
 
                 // Try to stage the upgrade table to replace the incoming table
-                masterTable.upgradeTable(upgradeTable);
+                masterTable.upgradeTable(upgradeTable, platform);
 
                 if (upgradeTable.getTableReadiness() != ResourceTable.RESOURCE_TABLE_INSTALLED) {
                     throw new RuntimeException("not all incoming resources were installed!!");

--- a/src/main/java/org/commcare/resources/model/ResourceInstaller.java
+++ b/src/main/java/org/commcare/resources/model/ResourceInstaller.java
@@ -102,7 +102,7 @@ public interface ResourceInstaller<T extends CommCarePlatform> extends Externali
      * @return True if the upgrade step was completed successfully.
      * @throws UnresolvedResourceException If the local resource definition could not be found
      */
-    boolean upgrade(Resource r) throws UnresolvedResourceException;
+    boolean upgrade(Resource r, T instance) throws UnresolvedResourceException;
 
     /**
      * Called to clean up or close any interstitial state that was created by managing this resource.

--- a/src/main/java/org/commcare/resources/model/ResourceInstaller.java
+++ b/src/main/java/org/commcare/resources/model/ResourceInstaller.java
@@ -102,7 +102,7 @@ public interface ResourceInstaller<T extends CommCarePlatform> extends Externali
      * @return True if the upgrade step was completed successfully.
      * @throws UnresolvedResourceException If the local resource definition could not be found
      */
-    boolean upgrade(Resource r, T instance) throws UnresolvedResourceException;
+    boolean upgrade(Resource r, T platform) throws UnresolvedResourceException;
 
     /**
      * Called to clean up or close any interstitial state that was created by managing this resource.

--- a/src/main/java/org/commcare/resources/model/ResourceTable.java
+++ b/src/main/java/org/commcare/resources/model/ResourceTable.java
@@ -631,7 +631,7 @@ public class ResourceTable {
      *
      * @param incoming Table for which resource upgrades are applied
      */
-    public void upgradeTable(ResourceTable incoming) throws UnresolvedResourceException {
+    public void upgradeTable(ResourceTable incoming, CommCarePlatform platform) throws UnresolvedResourceException {
         if (!incoming.isReady()) {
             throw new RuntimeException("Incoming table is not ready to be upgraded");
         }
@@ -663,7 +663,7 @@ public class ResourceTable {
 
                     if (r.getStatus() == Resource.RESOURCE_STATUS_UPGRADE) {
                         incoming.commit(r, Resource.RESOURCE_STATUS_UPGRADE_TO_INSTALL);
-                        if (r.getInstaller().upgrade(r)) {
+                        if (r.getInstaller().upgrade(r, platform)) {
                             incoming.commit(r, Resource.RESOURCE_STATUS_INSTALLED);
                         } else {
                             Logger.log("Resource",

--- a/src/main/java/org/commcare/resources/model/installers/BasicInstaller.java
+++ b/src/main/java/org/commcare/resources/model/installers/BasicInstaller.java
@@ -66,7 +66,7 @@ public class BasicInstaller implements ResourceInstaller<CommCarePlatform> {
     }
 
     @Override
-    public boolean upgrade(Resource r) throws UnresolvedResourceException {
+    public boolean upgrade(Resource r, CommCarePlatform instance) throws UnresolvedResourceException {
         throw new RuntimeException("Basic Installer resources can't be marked as upgradable");
     }
 

--- a/src/main/java/org/commcare/resources/model/installers/BasicInstaller.java
+++ b/src/main/java/org/commcare/resources/model/installers/BasicInstaller.java
@@ -66,7 +66,7 @@ public class BasicInstaller implements ResourceInstaller<CommCarePlatform> {
     }
 
     @Override
-    public boolean upgrade(Resource r, CommCarePlatform instance) throws UnresolvedResourceException {
+    public boolean upgrade(Resource r, CommCarePlatform platform) throws UnresolvedResourceException {
         throw new RuntimeException("Basic Installer resources can't be marked as upgradable");
     }
 

--- a/src/main/java/org/commcare/resources/model/installers/CacheInstaller.java
+++ b/src/main/java/org/commcare/resources/model/installers/CacheInstaller.java
@@ -56,7 +56,7 @@ public abstract class CacheInstaller<T extends Persistable> implements ResourceI
     }
 
     @Override
-    public boolean upgrade(Resource r) throws UnresolvedResourceException {
+    public boolean upgrade(Resource r, CommCarePlatform instance) throws UnresolvedResourceException {
         //Don't need to do anything, since the resource is in the RMS already.
         throw new UnresolvedResourceException(r, "Attempt to upgrade installed resource suite");
     }

--- a/src/main/java/org/commcare/resources/model/installers/CacheInstaller.java
+++ b/src/main/java/org/commcare/resources/model/installers/CacheInstaller.java
@@ -56,7 +56,7 @@ public abstract class CacheInstaller<T extends Persistable> implements ResourceI
     }
 
     @Override
-    public boolean upgrade(Resource r, CommCarePlatform instance) throws UnresolvedResourceException {
+    public boolean upgrade(Resource r, CommCarePlatform platform) throws UnresolvedResourceException {
         //Don't need to do anything, since the resource is in the RMS already.
         throw new UnresolvedResourceException(r, "Attempt to upgrade installed resource suite");
     }

--- a/src/main/java/org/commcare/resources/model/installers/LocaleFileInstaller.java
+++ b/src/main/java/org/commcare/resources/model/installers/LocaleFileInstaller.java
@@ -206,7 +206,7 @@ public class LocaleFileInstaller implements ResourceInstaller<CommCarePlatform> 
     }
 
     @Override
-    public boolean upgrade(Resource r, CommCarePlatform instance) throws UnresolvedResourceException {
+    public boolean upgrade(Resource r, CommCarePlatform platform) throws UnresolvedResourceException {
         //TODO: Rename file to take off ".N"?
         return true;
     }

--- a/src/main/java/org/commcare/resources/model/installers/LocaleFileInstaller.java
+++ b/src/main/java/org/commcare/resources/model/installers/LocaleFileInstaller.java
@@ -206,7 +206,7 @@ public class LocaleFileInstaller implements ResourceInstaller<CommCarePlatform> 
     }
 
     @Override
-    public boolean upgrade(Resource r) throws UnresolvedResourceException {
+    public boolean upgrade(Resource r, CommCarePlatform instance) throws UnresolvedResourceException {
         //TODO: Rename file to take off ".N"?
         return true;
     }

--- a/src/main/java/org/commcare/resources/model/installers/ProfileInstaller.java
+++ b/src/main/java/org/commcare/resources/model/installers/ProfileInstaller.java
@@ -52,7 +52,7 @@ public class ProfileInstaller extends CacheInstaller<Profile> {
         //Certain properties may not have been able to set during install, so we'll make sure they're
         //set here.
         Profile p = storage().read(cacheLocation);
-        p.initializeProperties(false);
+        p.initializeProperties(instance, false);
 
         instance.setProfile(p);
         return true;
@@ -119,7 +119,7 @@ public class ProfileInstaller extends CacheInstaller<Profile> {
                     getlocal().put(r.getRecordGuid(), p);
                     table.commitCompoundResource(r, Resource.RESOURCE_STATUS_LOCAL, p.getVersion());
                 } else {
-                    p.initializeProperties(true);
+                    p.initializeProperties(instance, true);
                     installInternal(p);
                     //TODO: What if this fails? Maybe we should be throwing exceptions...
                     table.commitCompoundResource(r, Resource.RESOURCE_STATUS_INSTALLED, p.getVersion());
@@ -154,7 +154,7 @@ public class ProfileInstaller extends CacheInstaller<Profile> {
     }
 
     @Override
-    public boolean upgrade(Resource r) throws UnresolvedResourceException {
+    public boolean upgrade(Resource r, CommCarePlatform instance) throws UnresolvedResourceException {
         //TODO: Hm... how to do this property setting for reverting?
 
         Profile p;
@@ -163,7 +163,7 @@ public class ProfileInstaller extends CacheInstaller<Profile> {
         } else {
             p = storage().read(cacheLocation);
         }
-        p.initializeProperties(true);
+        p.initializeProperties(instance, true);
         storage().write(p);
         return true;
     }

--- a/src/main/java/org/commcare/resources/model/installers/ProfileInstaller.java
+++ b/src/main/java/org/commcare/resources/model/installers/ProfileInstaller.java
@@ -154,7 +154,7 @@ public class ProfileInstaller extends CacheInstaller<Profile> {
     }
 
     @Override
-    public boolean upgrade(Resource r, CommCarePlatform instance) throws UnresolvedResourceException {
+    public boolean upgrade(Resource r, CommCarePlatform platform) throws UnresolvedResourceException {
         //TODO: Hm... how to do this property setting for reverting?
 
         Profile p;
@@ -163,7 +163,7 @@ public class ProfileInstaller extends CacheInstaller<Profile> {
         } else {
             p = storage().read(cacheLocation);
         }
-        p.initializeProperties(instance, true);
+        p.initializeProperties(platform, true);
         storage().write(p);
         return true;
     }

--- a/src/main/java/org/commcare/resources/model/installers/XFormInstaller.java
+++ b/src/main/java/org/commcare/resources/model/installers/XFormInstaller.java
@@ -86,7 +86,7 @@ public class XFormInstaller extends CacheInstaller<FormDef> {
     }
 
     @Override
-    public boolean upgrade(Resource r) throws UnresolvedResourceException {
+    public boolean upgrade(Resource r, CommCarePlatform instance) throws UnresolvedResourceException {
         //Basically some content as revert. Merge;
         FormDef form = storage().read(cacheLocation);
         String tempString = form.getInstance().schema;

--- a/src/main/java/org/commcare/resources/model/installers/XFormInstaller.java
+++ b/src/main/java/org/commcare/resources/model/installers/XFormInstaller.java
@@ -86,7 +86,7 @@ public class XFormInstaller extends CacheInstaller<FormDef> {
     }
 
     @Override
-    public boolean upgrade(Resource r, CommCarePlatform instance) throws UnresolvedResourceException {
+    public boolean upgrade(Resource r, CommCarePlatform platform) throws UnresolvedResourceException {
         //Basically some content as revert. Merge;
         FormDef form = storage().read(cacheLocation);
         String tempString = form.getInstance().schema;

--- a/src/main/java/org/commcare/suite/model/Profile.java
+++ b/src/main/java/org/commcare/suite/model/Profile.java
@@ -1,5 +1,6 @@
 package org.commcare.suite.model;
 
+import org.commcare.util.CommCarePlatform;
 import org.javarosa.core.reference.RootTranslator;
 import org.javarosa.core.services.PropertyManager;
 import org.javarosa.core.services.storage.Persistable;
@@ -183,12 +184,13 @@ public class Profile implements Persistable {
      *
      * NOTE: Moving at earliest opportunity to j2me profile installer
      */
-    public void initializeProperties(boolean enableForce) {
+    public void initializeProperties(CommCarePlatform platform, boolean enableForce) {
+        PropertyManager propertyManager = platform.getPropertyManager();
         for (PropertySetter setter : properties) {
-            String property = PropertyManager.instance().getSingularProperty(setter.getKey());
+            String property = propertyManager.getSingularProperty(setter.getKey());
             //We only want to set properties which are undefined or are forced
             if (property == null || (enableForce && setter.force)) {
-                PropertyManager.instance().setProperty(setter.getKey(), setter.getValue());
+                propertyManager.setProperty(setter.getKey(), setter.getValue());
             }
         }
     }

--- a/src/main/java/org/commcare/util/CommCarePlatform.java
+++ b/src/main/java/org/commcare/util/CommCarePlatform.java
@@ -8,6 +8,7 @@ import org.commcare.suite.model.Menu;
 import org.commcare.suite.model.OfflineUserRestore;
 import org.commcare.suite.model.Profile;
 import org.commcare.suite.model.Suite;
+import org.javarosa.core.services.PropertyManager;
 import org.javarosa.core.services.storage.IStorageIterator;
 import org.javarosa.core.services.storage.IStorageUtilityIndexed;
 import org.javarosa.core.services.storage.StorageManager;
@@ -35,8 +36,15 @@ public class CommCarePlatform {
     private int profile;
     private OfflineUserRestore offlineUserRestore;
 
+    private PropertyManager propertyManager;
+
     private final int majorVersion;
     private final int minorVersion;
+
+    public CommCarePlatform(int majorVersion, int minorVersion, PropertyManager propertyManager) {
+        this(majorVersion, minorVersion);
+        this.propertyManager = propertyManager;
+    }
 
     public CommCarePlatform(int majorVersion, int minorVersion) {
         profile = -1;
@@ -170,5 +178,9 @@ public class CommCarePlatform {
 
     public void registerDemoUserRestore(OfflineUserRestore offlineUserRestore) {
         this.offlineUserRestore = offlineUserRestore;
+    }
+
+    public PropertyManager getPropertyManager() {
+        return propertyManager;
     }
 }

--- a/src/main/java/org/javarosa/core/services/Logger.java
+++ b/src/main/java/org/javarosa/core/services/Logger.java
@@ -60,21 +60,7 @@ public class Logger {
     }
 
     public static boolean isLoggingEnabled() {
-        boolean enabled;
-        boolean problemReadingFlag = false;
-        try {
-            String flag = PropertyManager.instance().getSingularProperty(LOGS_ENABLED);
-            enabled = (flag == null || flag.equals(LOGS_ENABLED_YES));
-        } catch (Exception e) {
-            enabled = true;    //default to true if problem
-            problemReadingFlag = true;
-        }
-
-        if (problemReadingFlag) {
-            logForce("log-error", "could not read 'logging enabled' flag");
-        }
-
-        return enabled;
+        return true;
     }
 
     public static void exception(Exception e) {

--- a/src/main/java/org/javarosa/core/services/Logger.java
+++ b/src/main/java/org/javarosa/core/services/Logger.java
@@ -9,9 +9,6 @@ import java.util.Date;
 public class Logger {
     private static final int MAX_MSG_LENGTH = 2048;
 
-    public final static String LOGS_ENABLED = "logenabled";
-    public final static String LOGS_ENABLED_YES = "Enabled";
-
     private static ILogger logger;
 
     public static void registerLogger(ILogger theLogger) {
@@ -33,12 +30,6 @@ public class Logger {
      * @param message A message describing the incident.
      */
     public static void log(String type, String message) {
-        if (isLoggingEnabled()) {
-            logForce(type, message);
-        }
-    }
-
-    private static void logForce(String type, String message) {
         System.err.println("logger> " + type + ": " + message);
         if (message == null) {
             message = "";
@@ -57,10 +48,6 @@ public class Logger {
                 logger.panic();
             }
         }
-    }
-
-    public static boolean isLoggingEnabled() {
-        return true;
     }
 
     public static void exception(Exception e) {

--- a/src/main/java/org/javarosa/core/services/PropertyManager.java
+++ b/src/main/java/org/javarosa/core/services/PropertyManager.java
@@ -22,28 +22,6 @@ import java.util.Vector;
  */
 public class PropertyManager implements IPropertyManager {
 
-    ///// manage global property manager /////
-
-    private static IPropertyManager instance; //a global instance of the property manager
-
-    public static void setPropertyManager(IPropertyManager pm) {
-        instance = pm;
-    }
-
-    public static void initDefaultPropertyManager() {
-        StorageManager.registerStorage(PropertyManager.STORAGE_KEY, Property.class);
-        setPropertyManager(new PropertyManager());
-    }
-
-    public static IPropertyManager instance() {
-        if (instance == null) {
-            initDefaultPropertyManager();
-        }
-        return instance;
-    }
-
-    //////////////////////////////////////////
-
     /**
      * The name for the Persistent storage utility name
      */
@@ -62,8 +40,8 @@ public class PropertyManager implements IPropertyManager {
     /**
      * Constructor for this PropertyManager
      */
-    public PropertyManager() {
-        this.properties = (IStorageUtilityIndexed)StorageManager.getStorage(STORAGE_KEY);
+    public PropertyManager(IStorageUtilityIndexed properties) {
+        this.properties = properties;
         rulesList = new Vector<>();
     }
 


### PR DESCRIPTION
cross-request: https://github.com/dimagi/commcare-android/pull/1928

Remove the static singleton PropertyManager in favor of using `CommCarePlatform` as the vector for passing this manager. Remove check for `logenabled` property at logger level, in favor of checking this at the `CommCareAppliation` level (where we have access to the `HiddenPreferences` for this value) 