### PR TITLE
CommCareSessionException back to typed

### DIFF
--- a/src/cli/java/org/commcare/util/screen/CommCareSessionException.java
+++ b/src/cli/java/org/commcare/util/screen/CommCareSessionException.java
@@ -5,7 +5,7 @@ package org.commcare.util.screen;
  *
  * Created by ctsims on 8/5/2015.
  */
-public class CommCareSessionException extends RuntimeException {
+public class CommCareSessionException extends Exception {
     public CommCareSessionException(String message) {
         super(message);
     }


### PR DESCRIPTION
Made this a `RuntimeException` for reasons I can't now remember, think it makes more sense typed