### PR TITLE
Improve cyclic error message

### DIFF
--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -724,7 +724,10 @@ public class FormDef implements IFormElement, IMetaData,
                                     // and child for clarity in the error message.
                                     edges.add(new TreeReference[]{outerReference, innerReference});
                                 }
-                                edges.add(new TreeReference[]{innerReference, trig.contextRef});
+                                // Add all the targets of the of the triggered
+                                for (TreeReference reference: trig.getTargets()) {
+                                    edges.add(new TreeReference[]{innerReference, reference});
+                                }
                             }
                         }
                     }

--- a/src/test/java/org/javarosa/core/model/test/CyclicReferenceTests.java
+++ b/src/test/java/org/javarosa/core/model/test/CyclicReferenceTests.java
@@ -22,7 +22,9 @@ public class CyclicReferenceTests {
             new FormParseInit("/xform_tests/group_cyclic_reference.xml");
         } catch (XFormParseException e) {
             String detailMessage = e.getMessage();
+            // Assert that we're using the shortest cycle algorithm
             assert detailMessage.contains("Shortest Cycle");
+            // There should only be three newlines since only the three core cyclic references were included
             int newlineCount = detailMessage.length() - detailMessage.replace("\n", "").length();
             assert newlineCount == 3;
             return;

--- a/src/test/java/org/javarosa/core/model/test/CyclicReferenceTests.java
+++ b/src/test/java/org/javarosa/core/model/test/CyclicReferenceTests.java
@@ -4,6 +4,7 @@ import org.javarosa.core.test.FormParseInit;
 import org.javarosa.xform.parse.XFormParseException;
 import org.junit.Test;
 
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -23,10 +24,10 @@ public class CyclicReferenceTests {
         } catch (XFormParseException e) {
             String detailMessage = e.getMessage();
             // Assert that we're using the shortest cycle algorithm
-            assert detailMessage.contains("Shortest Cycle");
+            assertTrue(detailMessage.contains("Shortest Cycle"));
             // There should only be three newlines since only the three core cyclic references were included
             int newlineCount = detailMessage.length() - detailMessage.replace("\n", "").length();
-            assert newlineCount == 3;
+            assertTrue(newlineCount == 3);
             return;
         }
         fail("Cyclical reference did not throw XFormParseException");

--- a/src/test/java/org/javarosa/core/model/test/CyclicReferenceTests.java
+++ b/src/test/java/org/javarosa/core/model/test/CyclicReferenceTests.java
@@ -1,0 +1,32 @@
+package org.javarosa.core.model.test;
+
+import org.javarosa.core.test.FormParseInit;
+import org.javarosa.xform.parse.XFormParseException;
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for cyclic references
+ *
+ * @author wpride
+ */
+
+public class CyclicReferenceTests {
+    /**
+     * Test that XPath cyclic reference that references parent throws usable error
+     */
+    @Test
+    public void testCyclicReferenceWithGroup() {
+        try {
+            new FormParseInit("/xform_tests/group_cyclic_reference.xml");
+        } catch (XFormParseException e) {
+            String detailMessage = e.getMessage();
+            assert detailMessage.contains("Shortest Cycle");
+            int newlineCount = detailMessage.length() - detailMessage.replace("\n", "").length();
+            assert newlineCount == 3;
+            return;
+        }
+        fail("Cyclical reference did not throw XFormParseException");
+    }
+}

--- a/src/test/resources/xform_tests/group_cyclic_reference.xml
+++ b/src/test/resources/xform_tests/group_cyclic_reference.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+    <h:head>
+        <h:title>Multimedia</h:title>
+        <model>
+            <instance>
+                <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/D663252A-C65E-41BD-A1E2-EEDFD6FB316F" uiVersion="1" version="1" name="Multimedia">
+                    <first />
+                    <question1>
+                        <question2 />
+                    </question1>
+                    <extra />
+                </data>
+            </instance>
+            <bind nodeset="/data/first" type="xsd:int" relevant="/data/question1/question2 = '2'" />
+            <bind nodeset="/data/question1" relevant="/data/first = '1'" />
+            <bind nodeset="/data/question1/question2" type="xsd:string" />
+            <bind nodeset="/data/extra" type="xsd:string" relevant="/data/first = '1'"/>
+            <itext>
+                <translation lang="en" default="">
+                    <text id="first-label">
+                        <value>First</value>
+                    </text>
+                </translation>
+            </itext>
+        </model>
+    </h:head>
+    <h:body>
+        <input ref="/data/first">
+            <label ref="jr:itext('first-label')" />
+        </input>
+        <group ref="/data/question1">
+            <input ref="/data/question1/question2" />
+        </group>
+        <input ref="/data/extra">
+            <label ref="jr:itext('first-label')" />
+        </input>
+    </h:body>
+</h:html>


### PR DESCRIPTION
Fixes https://manage.dimagi.com/default.asp?267666#

If you have a reference structure where:

**/data/outer_question**  depends on **/data/group/inner_question**

**and /data/group** depends on **/data/outer_question**

Then you have a cyclical reference error because **/data/group/inner_question** implicitly depends on **/data/group** - if the parent is not relevant, the child is not either.

Our vertices detection algorithm was missing this because when you looked for triggerables dependent on **/data/group** you would find nothing (because there were none directly referencing this node) causing an NPE. This remedies that by including all child references when looking for dependent triggerables of a `TreeReference`. 