### PR TITLE
CLI Fix - Entity Select

### DIFF
--- a/src/cli/java/org/commcare/util/screen/EntityListSubscreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityListSubscreen.java
@@ -233,7 +233,9 @@ public class EntityListSubscreen extends Subscreen<EntityScreen> {
 
 
         try {
-            host.setHighlightedEntity(input);
+            int chosenIndex = Integer.valueOf(input);
+
+            host.setHighlightedEntity(mChoices[chosenIndex]);
             return true;
         } catch (NumberFormatException e) {
             //This will result in things just executing again, which is fine.


### PR DESCRIPTION
Entity select was attempting to match the numeric input [IE: '3'] to the new reference map, causing a crash when anything was selected