### PR TITLE
CLI - Fix error handling

### DIFF
--- a/src/translate/java/org/javarosa/engine/XFormPlayer.java
+++ b/src/translate/java/org/javarosa/engine/XFormPlayer.java
@@ -478,6 +478,10 @@ public class XFormPlayer {
                         badInput(input, fep.getConstraintText());
                         return false;
                     }
+                } catch(InvalidInputException e) {
+                    //This is handled by the outer loop processor, so make sure we don't
+                    //absorb it below
+                    throw e;
                 } catch (Exception e) {
                     e.printStackTrace();
                     badInput(input, e.getMessage());


### PR DESCRIPTION
At some point we added a generic Exception handler to the CLI eval loop, which prevented it from erroring out when certain exceptions were thrown.

This unfortunately also started catching one of our semantic exceptions and outputting the stack as if it was an unknown / unexpected error.

This makes  it so that when you violate a constraint or use an invalid input you only see the appropriate XForms constraint message, and not a stack trace.