### PR TITLE
Refactor ExtWrapList to be usable for any implementing class of List

### DIFF
--- a/src/main/java/org/javarosa/core/util/externalizable/ExtWrapList.java
+++ b/src/main/java/org/javarosa/core/util/externalizable/ExtWrapList.java
@@ -3,27 +3,30 @@ package org.javarosa.core.util.externalizable;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.List;
 import java.util.Vector;
 
 
-//list of objects of single (non-polymorphic) type
+// List of objects of single (non-polymorphic) type
 public class ExtWrapList extends ExternalizableWrapper {
     public ExternalizableWrapper type;
     private boolean sealed;
+    private Class<? extends List> listImplementation;
 
     /* serialization */
 
-    public ExtWrapList(Vector val) {
+    public ExtWrapList(List val) {
         this(val, null);
     }
 
-    public ExtWrapList(Vector val, ExternalizableWrapper type) {
+    public ExtWrapList(List val, ExternalizableWrapper type) {
         if (val == null) {
             throw new NullPointerException();
         }
 
         this.val = val;
         this.type = type;
+        this.listImplementation = val.getClass();
     }
 
     /* deserialization */
@@ -32,13 +35,14 @@ public class ExtWrapList extends ExternalizableWrapper {
 
     }
 
-    public ExtWrapList(Class type) {
-        this(type, false);
+    public ExtWrapList(Class listElementType) {
+        this(listElementType, Vector.class);
     }
 
-    public ExtWrapList(Class type, boolean sealed) {
-        this.type = new ExtWrapBase(type);
-        this.sealed = sealed;
+    public ExtWrapList(Class listElementType, Class listImplementation) {
+        this.type = new ExtWrapBase(listElementType);
+        this.listImplementation = listImplementation;
+        this.sealed = false;
     }
 
     public ExtWrapList(ExternalizableWrapper type) {
@@ -46,23 +50,30 @@ public class ExtWrapList extends ExternalizableWrapper {
             throw new NullPointerException();
         }
 
+        this.listImplementation = Vector.class;
         this.type = type;
     }
 
     @Override
     public ExternalizableWrapper clone(Object val) {
-        return new ExtWrapList((Vector)val, type);
+        return new ExtWrapList((List)val, type);
     }
 
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         if (!sealed) {
             int size = (int)ExtUtil.readNumeric(in);
-            Vector<Object> v = new Vector<>(size);
-            for (int i = 0; i < size; i++) {
-                v.addElement(ExtUtil.read(in, type, pf));
+            try {
+                List<Object> l = listImplementation.newInstance();
+                for (int i = 0; i < size; i++) {
+                    l.add(ExtUtil.read(in, type, pf));
+                }
+                val = l;
+            } catch (InstantiationException e) {
+                throw new DeserializationException("caused by: " + e.getClass().getCanonicalName());
+            } catch (IllegalAccessException e) {
+                throw new DeserializationException("caused by: " + e.getClass().getCanonicalName());
             }
-            val = v;
         } else {
             int size = (int)ExtUtil.readNumeric(in);
             Object[] theval = new Object[size];
@@ -75,34 +86,39 @@ public class ExtWrapList extends ExternalizableWrapper {
 
     @Override
     public void writeExternal(DataOutputStream out) throws IOException {
-        Vector v = (Vector)val;
-
-        ExtUtil.writeNumeric(out, v.size());
-        for (int i = 0; i < v.size(); i++) {
-            ExtUtil.write(out, type == null ? v.elementAt(i) : type.clone(v.elementAt(i)));
+        List l = (List)val;
+        ExtUtil.writeNumeric(out, l.size());
+        for (int i = 0; i < l.size(); i++) {
+            ExtUtil.write(out, type == null ? l.get(i) : type.clone(l.get(i)));
         }
     }
 
     @Override
     public void metaReadExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         type = ExtWrapTagged.readTag(in, pf);
+        try {
+            listImplementation = (Class<? extends List>)Class.forName(ExtUtil.readString(in));
+        } catch (ClassNotFoundException e) {
+            throw new DeserializationException("caused by: " + e);
+        }
     }
 
     @Override
     public void metaWriteExternal(DataOutputStream out) throws IOException {
-        Vector v = (Vector)val;
+        List l = (List)val;
         Object tagObj;
 
         if (type == null) {
-            if (v.size() == 0) {
+            if (l.size() == 0) {
                 tagObj = new Object();
             } else {
-                tagObj = v.elementAt(0);
+                tagObj = l.get(0);
             }
         } else {
             tagObj = type;
         }
 
         ExtWrapTagged.writeTag(out, tagObj);
+        ExtUtil.writeString(out, listImplementation.getName());
     }
 }

--- a/src/main/java/org/javarosa/core/util/externalizable/ExtWrapList.java
+++ b/src/main/java/org/javarosa/core/util/externalizable/ExtWrapList.java
@@ -13,7 +13,7 @@ public class ExtWrapList extends ExternalizableWrapper {
     private boolean sealed;
     private Class<? extends List> listImplementation;
 
-    /* serialization */
+    /* Constructors for serialization */
 
     public ExtWrapList(List val) {
         this(val, null);
@@ -29,12 +29,13 @@ public class ExtWrapList extends ExternalizableWrapper {
         this.listImplementation = val.getClass();
     }
 
-    /* deserialization */
+    /* Constructors for deserialization */
 
     public ExtWrapList() {
 
     }
 
+    // Assumes that the list implementation is a Vector, since that is most common
     public ExtWrapList(Class listElementType) {
         this(listElementType, Vector.class);
     }
@@ -45,12 +46,17 @@ public class ExtWrapList extends ExternalizableWrapper {
         this.sealed = false;
     }
 
+    // Assumes that the list implementation is a Vector, since that is most common
     public ExtWrapList(ExternalizableWrapper type) {
+        this(type, Vector.class);
+    }
+
+    public ExtWrapList(ExternalizableWrapper type, Class listImplementation) {
         if (type == null) {
             throw new NullPointerException();
         }
 
-        this.listImplementation = Vector.class;
+        this.listImplementation = listImplementation;
         this.type = type;
     }
 
@@ -70,9 +76,9 @@ public class ExtWrapList extends ExternalizableWrapper {
                 }
                 val = l;
             } catch (InstantiationException e) {
-                throw new DeserializationException("caused by: " + e.getClass().getCanonicalName());
+                throw new DeserializationException(e.getMessage());
             } catch (IllegalAccessException e) {
-                throw new DeserializationException("caused by: " + e.getClass().getCanonicalName());
+                throw new DeserializationException(e.getMessage());
             }
         } else {
             int size = (int)ExtUtil.readNumeric(in);
@@ -99,7 +105,7 @@ public class ExtWrapList extends ExternalizableWrapper {
         try {
             listImplementation = (Class<? extends List>)Class.forName(ExtUtil.readString(in));
         } catch (ClassNotFoundException e) {
-            throw new DeserializationException("caused by: " + e);
+            throw new DeserializationException(e.getMessage());
         }
     }
 

--- a/src/main/java/org/javarosa/core/util/externalizable/ExtWrapList.java
+++ b/src/main/java/org/javarosa/core/util/externalizable/ExtWrapList.java
@@ -70,7 +70,13 @@ public class ExtWrapList extends ExternalizableWrapper {
         if (!sealed) {
             int size = (int)ExtUtil.readNumeric(in);
             try {
-                List<Object> l = listImplementation.newInstance();
+                List<Object> l;
+                if (listImplementation.equals(Vector.class)) {
+                    // to preserve performance gains of instantiating a Vector with its size
+                    l = new Vector<>(size);
+                } else {
+                    l = listImplementation.newInstance();
+                }
                 for (int i = 0; i < size; i++) {
                     l.add(ExtUtil.read(in, type, pf));
                 }


### PR DESCRIPTION
Previously `ExtWrapList` could only be used to serialize/deserialize `Vector` objects. The tweaks in this PR allow it to be used for any class that implements the `List` interface (which is both more useful and more consistent with what the class name implies).

cross-request: https://github.com/dimagi/commcare-android/pull/1945