### PR TITLE
Increment CommCareConfigEngine version to 2.42

### DIFF
--- a/src/cli/java/org/commcare/util/engine/CommCareConfigEngine.java
+++ b/src/cli/java/org/commcare/util/engine/CommCareConfigEngine.java
@@ -65,7 +65,7 @@ public class CommCareConfigEngine {
     protected ArchiveFileRoot mArchiveRoot;
 
     public static final int MAJOR_VERSION = 2;
-    public static final int MINOR_VERSION = 41;
+    public static final int MINOR_VERSION = 42;
 
 
     public CommCareConfigEngine() {


### PR DESCRIPTION
I should add this to the `mobile-deply` scripts