### PR TITLE
Only create index if not exists

### DIFF
--- a/src/main/java/org/commcare/modern/database/DatabaseIndexingUtils.java
+++ b/src/main/java/org/commcare/modern/database/DatabaseIndexingUtils.java
@@ -19,7 +19,7 @@ public class DatabaseIndexingUtils {
     public static String indexOnTableCommand(String indexName,
                                              String tableName,
                                              String columnListString) {
-        return "CREATE INDEX " + indexName + " ON " +
+        return "CREATE INDEX IF NOT EXISTS " + indexName + " ON " +
                 tableName + "( " + columnListString + " )";
     }
 


### PR DESCRIPTION
Formplayer needed this change to not crash due to the index already existing. Not clear if Android doesn't crash because its version of SQLite handles this implicitly or if Android is checking if the index exists already elsewhere but I think this change is positive as-is regardless. 