### PR TITLE
Add LocalizerManager class

### DIFF
--- a/src/main/java/org/javarosa/core/services/locale/Localization.java
+++ b/src/main/java/org/javarosa/core/services/locale/Localization.java
@@ -7,31 +7,23 @@ import java.util.Hashtable;
 
 public class Localization {
 
-    private static final ThreadLocal<Localizer> globalLocalizer = new ThreadLocal<Localizer>(){
-        @Override
-        protected Localizer initialValue()
-        {
-            return new Localizer(true, false);
-        }
-    };
-
     public static String get(String key) {
         return get(key, new String[]{});
     }
 
     public static String get(String key, String arg) {
         checkRep();
-        return globalLocalizer.get().getText(key, new String[]{arg});
+        return LocalizerManager.getGlobalLocalizer().getText(key, new String[]{arg});
     }
 
     public static String get(String key, String[] args) {
         checkRep();
-        return globalLocalizer.get().getText(key, args);
+        return LocalizerManager.getGlobalLocalizer().getText(key, args);
     }
 
     public static String get(String key, Hashtable args) {
         checkRep();
-        return globalLocalizer.get().getText(key, args);
+        return LocalizerManager.getGlobalLocalizer().getText(key, args);
     }
 
     public static String getWithDefault(String key, String valueIfKeyMissing) {
@@ -48,44 +40,42 @@ public class Localization {
 
     public static void registerLanguageReference(String localeName, String referenceUri) {
         init(false);
-        if (!globalLocalizer.get().hasLocale(localeName)) {
-            globalLocalizer.get().addAvailableLocale(localeName);
+        if (!LocalizerManager.getGlobalLocalizer().hasLocale(localeName)) {
+            LocalizerManager.getGlobalLocalizer().addAvailableLocale(localeName);
         }
-        globalLocalizer.get().registerLocaleResource(localeName, new ReferenceDataSource(referenceUri));
-        if (globalLocalizer.get().getDefaultLocale() == null) {
-            globalLocalizer.get().setDefaultLocale(localeName);
+        LocalizerManager.getGlobalLocalizer().registerLocaleResource(localeName, new ReferenceDataSource(referenceUri));
+        if (LocalizerManager.getGlobalLocalizer().getDefaultLocale() == null) {
+            LocalizerManager.getGlobalLocalizer().setDefaultLocale(localeName);
         }
     }
 
     public static Localizer getGlobalLocalizerAdvanced() {
         init(false);
-        return globalLocalizer.get();
+        return LocalizerManager.getGlobalLocalizer();
     }
 
     public static void setLocale(String locale) {
         checkRep();
-        globalLocalizer.get().setLocale(locale);
+        LocalizerManager.getGlobalLocalizer().setLocale(locale);
     }
 
     public static String getCurrentLocale() {
         checkRep();
-        return globalLocalizer.get().getLocale();
+        return LocalizerManager.getGlobalLocalizer().getLocale();
     }
 
     public static void setDefaultLocale(String defaultLocale) {
         checkRep();
-        globalLocalizer.get().setDefaultLocale(defaultLocale);
+        LocalizerManager.getGlobalLocalizer().setDefaultLocale(defaultLocale);
     }
 
     public static void init(boolean force) {
-        if (globalLocalizer.get() == null || force) {
-            globalLocalizer.set(new Localizer(true, false));
-        }
+        LocalizerManager.init(force);
     }
 
     private static void checkRep() {
         init(false);
-        if (globalLocalizer.get().getAvailableLocales().length == 0) {
+        if (LocalizerManager.getGlobalLocalizer().getAvailableLocales().length == 0) {
             throw new LocaleTextException("There are no locales defined for the application. Please make sure to register locale text using the Locale.register() method");
         }
     }

--- a/src/main/java/org/javarosa/core/services/locale/LocalizerManager.java
+++ b/src/main/java/org/javarosa/core/services/locale/LocalizerManager.java
@@ -1,0 +1,54 @@
+package org.javarosa.core.services.locale;
+
+/**
+ * (Yet another) Manager class, this one for determining which localization strategy to use.
+ * The options are:
+ *
+ *  1. staticLocalizer: Static variable for platforms where the same Localizer can be safely shared across
+ *     all threads on the JVM (Android)
+ *  2. threadLocalLocalizer: ThreadLocal variable for platforms where different threads are potentially
+ *     running separate applications (Web Apps)
+ *
+ *  Defaults to the static Localizer. Web Apps should set the strategy to useThreadLocal = true immediately
+ *  on startup.
+ *
+ *  @author wpride
+ */
+public class LocalizerManager {
+
+    private static Localizer staticLocalizer;
+
+    private static final ThreadLocal<Localizer> threadLocalLocalizer = new ThreadLocal<Localizer>(){
+        @Override
+        protected Localizer initialValue()
+        {
+            return new Localizer(true, false);
+        }
+    };
+
+    private static boolean useThreadLocal = false;
+
+    public static Localizer getGlobalLocalizer() {
+        if (useThreadLocal) {
+            return threadLocalLocalizer.get();
+        } else {
+            return staticLocalizer;
+        }
+    }
+
+    public static void init(boolean force) {
+        if (useThreadLocal) {
+            if (threadLocalLocalizer.get() == null || force) {
+                threadLocalLocalizer.set(new Localizer(true, false));
+            }
+        } else {
+            if (staticLocalizer == null || force) {
+                staticLocalizer = new Localizer(true, false);
+            }
+        }
+    }
+
+    public static void setUseThreadLocalStrategy(boolean useThreadLocal) {
+        LocalizerManager.useThreadLocal = useThreadLocal;
+    }
+}


### PR DESCRIPTION
This class allows Android and Web Apps to share the static `Localizer` code by introducing a manager to mediate between strategies. Taken from class comment:

(Yet another) Manager class, this one for determining which localization strategy to use.
The options are:

1. staticLocalizer: Static variable for platforms where the same Localizer can be safely shared across all threads on the JVM (Android)
2. threadLocalLocalizer: ThreadLocal variable for platforms where different threads are potentially running separate applications (Web Apps)

Defaults to the static Localizer. Web Apps should sets the strategy to useThreadLocal = `true` immediately on startup.