### PR TITLE
Update XPathExpression isLeafNode

### DIFF
--- a/src/main/java/org/javarosa/xpath/expr/XPathExpression.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathExpression.java
@@ -74,10 +74,6 @@ public abstract class XPathExpression implements Externalizable, XPathAnalyzable
         DataInstance instance = nodeset.getInstance();
         Vector<TreeReference> refs = nodeset.getReferences();
 
-        if (refs == null) {
-            return;
-        }
-
         for (TreeReference ref : refs) {
             AbstractTreeElement treeElement = instance.resolveReference(ref);
             s.serialize(treeElement);

--- a/src/main/java/org/javarosa/xpath/expr/XPathExpression.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathExpression.java
@@ -41,18 +41,15 @@ public abstract class XPathExpression implements Externalizable, XPathAnalyzable
     }
 
     public static void serializeResult(Object value, OutputStream output) throws IOException {
-        if (!isLeafNode(value)) {
+        if (value instanceof XPathNodeset && !isLeafNode((XPathNodeset) value)) {
             serializeElements((XPathNodeset) value, output);
         } else {
             output.write(FunctionUtils.toString(value).getBytes(StandardCharsets.UTF_8));
         }
     }
 
-    private static boolean isLeafNode(Object value) {
-        if (!(value instanceof XPathNodeset)) {
-            return false;
-        }
-        XPathNodeset nodeset = (XPathNodeset) value;
+    private static boolean isLeafNode(XPathNodeset value) {
+        XPathNodeset nodeset = value;
         Vector<TreeReference> refs = nodeset.getReferences();
         if (refs == null || refs.size() != 1) {
             return false;
@@ -76,6 +73,11 @@ public abstract class XPathExpression implements Externalizable, XPathAnalyzable
 
         DataInstance instance = nodeset.getInstance();
         Vector<TreeReference> refs = nodeset.getReferences();
+
+        if (refs == null) {
+            return;
+        }
+
         for (TreeReference ref : refs) {
             AbstractTreeElement treeElement = instance.resolveReference(ref);
             s.serialize(treeElement);


### PR DESCRIPTION
Some changes made by @benrudolph way back when he was working on debugger serialization (I think):
https://github.com/dimagi/commcare-core/pull/591
https://github.com/dimagi/commcare-core/commit/96169d4a07109d3ef459a72c5f77bd95f306b70e

The `XPathNodeset` check is just moved up and the `refs == null` check would prevent an NPE so I think this is pretty harmless