### PR TITLE
ReferenceManager refactor

### DIFF
--- a/src/cli/java/org/commcare/util/engine/CommCareConfigEngine.java
+++ b/src/cli/java/org/commcare/util/engine/CommCareConfigEngine.java
@@ -27,7 +27,7 @@ import org.javarosa.core.io.StreamsUtil;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.FormInstance;
-import org.javarosa.core.reference.ReferenceManagerHandler;
+import org.javarosa.core.reference.ReferenceHandler;
 import org.javarosa.core.reference.ResourceReferenceFactory;
 import org.javarosa.core.services.PropertyManager;
 import org.javarosa.core.services.locale.Localization;
@@ -107,12 +107,12 @@ public class CommCareConfigEngine {
     }
 
     protected void setRoots() {
-        ReferenceManagerHandler.instance().addReferenceFactory(new JavaHttpRoot());
+        ReferenceHandler.instance().addReferenceFactory(new JavaHttpRoot());
 
         this.mArchiveRoot = new ArchiveFileRoot();
 
-        ReferenceManagerHandler.instance().addReferenceFactory(mArchiveRoot);
-        ReferenceManagerHandler.instance().addReferenceFactory(new ResourceReferenceFactory());
+        ReferenceHandler.instance().addReferenceFactory(mArchiveRoot);
+        ReferenceHandler.instance().addReferenceFactory(new ResourceReferenceFactory());
     }
 
     public void initFromArchive(String archiveURL) throws InstallCancelledException,
@@ -194,7 +194,7 @@ public class CommCareConfigEngine {
         }
 
         //(That root now reads as jr://file/)
-        ReferenceManagerHandler.instance().addReferenceFactory(new JavaFileRoot(rootPath));
+        ReferenceHandler.instance().addReferenceFactory(new JavaFileRoot(rootPath));
 
         //Now build the testing reference we'll use
         return "jr://file/" + filePart;

--- a/src/cli/java/org/commcare/util/engine/CommCareConfigEngine.java
+++ b/src/cli/java/org/commcare/util/engine/CommCareConfigEngine.java
@@ -27,7 +27,7 @@ import org.javarosa.core.io.StreamsUtil;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.FormInstance;
-import org.javarosa.core.reference.ReferenceManager;
+import org.javarosa.core.reference.ReferenceManagerHandler;
 import org.javarosa.core.reference.ResourceReferenceFactory;
 import org.javarosa.core.services.PropertyManager;
 import org.javarosa.core.services.locale.Localization;
@@ -107,12 +107,12 @@ public class CommCareConfigEngine {
     }
 
     protected void setRoots() {
-        ReferenceManager.instance().addReferenceFactory(new JavaHttpRoot());
+        ReferenceManagerHandler.instance().addReferenceFactory(new JavaHttpRoot());
 
         this.mArchiveRoot = new ArchiveFileRoot();
 
-        ReferenceManager.instance().addReferenceFactory(mArchiveRoot);
-        ReferenceManager.instance().addReferenceFactory(new ResourceReferenceFactory());
+        ReferenceManagerHandler.instance().addReferenceFactory(mArchiveRoot);
+        ReferenceManagerHandler.instance().addReferenceFactory(new ResourceReferenceFactory());
     }
 
     public void initFromArchive(String archiveURL) throws InstallCancelledException,
@@ -194,7 +194,7 @@ public class CommCareConfigEngine {
         }
 
         //(That root now reads as jr://file/)
-        ReferenceManager.instance().addReferenceFactory(new JavaFileRoot(rootPath));
+        ReferenceManagerHandler.instance().addReferenceFactory(new JavaFileRoot(rootPath));
 
         //Now build the testing reference we'll use
         return "jr://file/" + filePart;

--- a/src/main/java/org/commcare/modern/reference/ArchiveFileRoot.java
+++ b/src/main/java/org/commcare/modern/reference/ArchiveFileRoot.java
@@ -3,7 +3,7 @@ package org.commcare.modern.reference;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.Reference;
 import org.javarosa.core.reference.ReferenceFactory;
-import org.javarosa.core.reference.ReferenceManagerHandler;
+import org.javarosa.core.reference.ReferenceHandler;
 import org.javarosa.core.util.PropertyUtils;
 
 import java.util.HashMap;
@@ -34,7 +34,7 @@ public class ArchiveFileRoot implements ReferenceFactory {
         if (context.lastIndexOf('/') != -1) {
             context = context.substring(0, context.lastIndexOf('/') + 1);
         }
-        return ReferenceManagerHandler.instance().DeriveReference(context + URI);
+        return ReferenceHandler.instance().DeriveReference(context + URI);
     }
 
     @Override

--- a/src/main/java/org/commcare/modern/reference/ArchiveFileRoot.java
+++ b/src/main/java/org/commcare/modern/reference/ArchiveFileRoot.java
@@ -3,7 +3,7 @@ package org.commcare.modern.reference;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.Reference;
 import org.javarosa.core.reference.ReferenceFactory;
-import org.javarosa.core.reference.ReferenceManager;
+import org.javarosa.core.reference.ReferenceManagerHandler;
 import org.javarosa.core.util.PropertyUtils;
 
 import java.util.HashMap;
@@ -34,7 +34,7 @@ public class ArchiveFileRoot implements ReferenceFactory {
         if (context.lastIndexOf('/') != -1) {
             context = context.substring(0, context.lastIndexOf('/') + 1);
         }
-        return ReferenceManager.instance().DeriveReference(context + URI);
+        return ReferenceManagerHandler.instance().DeriveReference(context + URI);
     }
 
     @Override

--- a/src/main/java/org/commcare/resources/model/ResourceTable.java
+++ b/src/main/java/org/commcare/resources/model/ResourceTable.java
@@ -4,7 +4,7 @@ import org.commcare.resources.model.installers.ProfileInstaller;
 import org.commcare.util.CommCarePlatform;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.Reference;
-import org.javarosa.core.reference.ReferenceManagerHandler;
+import org.javarosa.core.reference.ReferenceHandler;
 import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.storage.IStorageIterator;
 import org.javarosa.core.services.storage.IStorageUtilityIndexed;
@@ -387,7 +387,7 @@ public class ResourceTable {
             } else {
                 try {
                     handled = installResource(r, location,
-                            ReferenceManagerHandler.instance().DeriveReference(location.getLocation()),
+                            ReferenceHandler.instance().DeriveReference(location.getLocation()),
                             this, platform, upgrade);
                     if (handled) {
                         recordSuccess(r);
@@ -1038,12 +1038,12 @@ public class ResourceTable {
             final Reference derivedRef;
             if (context == null) {
                 derivedRef =
-                        ReferenceManagerHandler.instance().DeriveReference(location.getLocation());
+                        ReferenceHandler.instance().DeriveReference(location.getLocation());
             } else {
                 // contextualize the location ref in terms of the multiple refs
                 // pointing to different locations for the parent resource
                 derivedRef =
-                        ReferenceManagerHandler.instance().DeriveReference(location.getLocation(),
+                        ReferenceHandler.instance().DeriveReference(location.getLocation(),
                                 context);
             }
             ret.addElement(derivedRef);

--- a/src/main/java/org/commcare/resources/model/ResourceTable.java
+++ b/src/main/java/org/commcare/resources/model/ResourceTable.java
@@ -4,7 +4,7 @@ import org.commcare.resources.model.installers.ProfileInstaller;
 import org.commcare.util.CommCarePlatform;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.Reference;
-import org.javarosa.core.reference.ReferenceManager;
+import org.javarosa.core.reference.ReferenceManagerHandler;
 import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.storage.IStorageIterator;
 import org.javarosa.core.services.storage.IStorageUtilityIndexed;
@@ -387,7 +387,7 @@ public class ResourceTable {
             } else {
                 try {
                     handled = installResource(r, location,
-                            ReferenceManager.instance().DeriveReference(location.getLocation()),
+                            ReferenceManagerHandler.instance().DeriveReference(location.getLocation()),
                             this, platform, upgrade);
                     if (handled) {
                         recordSuccess(r);
@@ -1038,12 +1038,12 @@ public class ResourceTable {
             final Reference derivedRef;
             if (context == null) {
                 derivedRef =
-                        ReferenceManager.instance().DeriveReference(location.getLocation());
+                        ReferenceManagerHandler.instance().DeriveReference(location.getLocation());
             } else {
                 // contextualize the location ref in terms of the multiple refs
                 // pointing to different locations for the parent resource
                 derivedRef =
-                        ReferenceManager.instance().DeriveReference(location.getLocation(),
+                        ReferenceManagerHandler.instance().DeriveReference(location.getLocation(),
                                 context);
             }
             ret.addElement(derivedRef);

--- a/src/main/java/org/commcare/resources/model/installers/InstallerUtil.java
+++ b/src/main/java/org/commcare/resources/model/installers/InstallerUtil.java
@@ -4,7 +4,7 @@ import org.commcare.resources.model.MissingMediaException;
 import org.commcare.resources.model.Resource;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.Reference;
-import org.javarosa.core.reference.ReferenceManagerHandler;
+import org.javarosa.core.reference.ReferenceHandler;
 import org.javarosa.core.util.SizeBoundUniqueVector;
 
 import java.io.IOException;
@@ -17,7 +17,7 @@ public class InstallerUtil {
 
     public static void checkMedia(Resource r, String filePath, SizeBoundUniqueVector<MissingMediaException> problems, MediaType mt) {
         try {
-            Reference ref = ReferenceManagerHandler.instance().DeriveReference(filePath);
+            Reference ref = ReferenceHandler.instance().DeriveReference(filePath);
             String localName = ref.getLocalURI();
             boolean successfulAdd;
             try {

--- a/src/main/java/org/commcare/resources/model/installers/InstallerUtil.java
+++ b/src/main/java/org/commcare/resources/model/installers/InstallerUtil.java
@@ -4,7 +4,7 @@ import org.commcare.resources.model.MissingMediaException;
 import org.commcare.resources.model.Resource;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.Reference;
-import org.javarosa.core.reference.ReferenceManager;
+import org.javarosa.core.reference.ReferenceManagerHandler;
 import org.javarosa.core.util.SizeBoundUniqueVector;
 
 import java.io.IOException;
@@ -17,7 +17,7 @@ public class InstallerUtil {
 
     public static void checkMedia(Resource r, String filePath, SizeBoundUniqueVector<MissingMediaException> problems, MediaType mt) {
         try {
-            Reference ref = ReferenceManager.instance().DeriveReference(filePath);
+            Reference ref = ReferenceManagerHandler.instance().DeriveReference(filePath);
             String localName = ref.getLocalURI();
             boolean successfulAdd;
             try {

--- a/src/main/java/org/commcare/resources/model/installers/LocaleFileInstaller.java
+++ b/src/main/java/org/commcare/resources/model/installers/LocaleFileInstaller.java
@@ -12,7 +12,7 @@ import org.javarosa.core.io.StreamsUtil;
 import org.javarosa.core.io.StreamsUtil.InputIOException;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.Reference;
-import org.javarosa.core.reference.ReferenceManager;
+import org.javarosa.core.reference.ReferenceManagerHandler;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.services.locale.LocalizationUtils;
 import org.javarosa.core.services.locale.TableLocaleSource;
@@ -128,12 +128,12 @@ public class LocaleFileInstaller implements ResourceInstaller<CommCarePlatform> 
                 int copy = 0;
 
                 try {
-                    Reference destination = ReferenceManager.instance().DeriveReference("jr://file/" + uri);
+                    Reference destination = ReferenceManagerHandler.instance().DeriveReference("jr://file/" + uri);
                     while (destination.doesBinaryExist()) {
                         //Need a different location.
                         copy++;
                         String newUri = uri + "." + copy;
-                        destination = ReferenceManager.instance().DeriveReference("jr://file/" + newUri);
+                        destination = ReferenceManagerHandler.instance().DeriveReference("jr://file/" + newUri);
                     }
 
                     if (destination.isReadOnly()) {
@@ -237,7 +237,7 @@ public class LocaleFileInstaller implements ResourceInstaller<CommCarePlatform> 
         }
         Reference reference;
         try {
-            reference = ReferenceManager.instance().DeriveReference(localReference);
+            reference = ReferenceManagerHandler.instance().DeriveReference(localReference);
             if (!reference.isReadOnly()) {
                 reference.remove();
             }
@@ -284,7 +284,7 @@ public class LocaleFileInstaller implements ResourceInstaller<CommCarePlatform> 
                 //If we've gotten the cache into memory, we're fine
             } else {
                 try {
-                    if (!ReferenceManager.instance().DeriveReference(localReference).doesBinaryExist()) {
+                    if (!ReferenceManagerHandler.instance().DeriveReference(localReference).doesBinaryExist()) {
                         throw new MissingMediaException(r, "Locale data does note exist at: " + localReference);
                     }
                 } catch (IOException e) {

--- a/src/main/java/org/commcare/resources/model/installers/LocaleFileInstaller.java
+++ b/src/main/java/org/commcare/resources/model/installers/LocaleFileInstaller.java
@@ -12,7 +12,7 @@ import org.javarosa.core.io.StreamsUtil;
 import org.javarosa.core.io.StreamsUtil.InputIOException;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.Reference;
-import org.javarosa.core.reference.ReferenceManagerHandler;
+import org.javarosa.core.reference.ReferenceHandler;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.services.locale.LocalizationUtils;
 import org.javarosa.core.services.locale.TableLocaleSource;
@@ -128,12 +128,12 @@ public class LocaleFileInstaller implements ResourceInstaller<CommCarePlatform> 
                 int copy = 0;
 
                 try {
-                    Reference destination = ReferenceManagerHandler.instance().DeriveReference("jr://file/" + uri);
+                    Reference destination = ReferenceHandler.instance().DeriveReference("jr://file/" + uri);
                     while (destination.doesBinaryExist()) {
                         //Need a different location.
                         copy++;
                         String newUri = uri + "." + copy;
-                        destination = ReferenceManagerHandler.instance().DeriveReference("jr://file/" + newUri);
+                        destination = ReferenceHandler.instance().DeriveReference("jr://file/" + newUri);
                     }
 
                     if (destination.isReadOnly()) {
@@ -237,7 +237,7 @@ public class LocaleFileInstaller implements ResourceInstaller<CommCarePlatform> 
         }
         Reference reference;
         try {
-            reference = ReferenceManagerHandler.instance().DeriveReference(localReference);
+            reference = ReferenceHandler.instance().DeriveReference(localReference);
             if (!reference.isReadOnly()) {
                 reference.remove();
             }
@@ -284,7 +284,7 @@ public class LocaleFileInstaller implements ResourceInstaller<CommCarePlatform> 
                 //If we've gotten the cache into memory, we're fine
             } else {
                 try {
-                    if (!ReferenceManagerHandler.instance().DeriveReference(localReference).doesBinaryExist()) {
+                    if (!ReferenceHandler.instance().DeriveReference(localReference).doesBinaryExist()) {
                         throw new MissingMediaException(r, "Locale data does note exist at: " + localReference);
                     }
                 } catch (IOException e) {

--- a/src/main/java/org/commcare/suite/model/Detail.java
+++ b/src/main/java/org/commcare/suite/model/Detail.java
@@ -11,7 +11,7 @@ import org.commcare.util.GridStyle;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.reference.InvalidReferenceException;
-import org.javarosa.core.reference.ReferenceManagerHandler;
+import org.javarosa.core.reference.ReferenceHandler;
 import org.javarosa.core.util.ArrayUtilities;
 import org.javarosa.core.util.OrderedHashtable;
 import org.javarosa.core.util.externalizable.DeserializationException;
@@ -499,7 +499,7 @@ public class Detail implements Externalizable {
             return true;
         } else if (templatePathProvided != null) {
             try {
-                ReferenceManagerHandler.instance().DeriveReference(templatePathProvided).getLocalURI();
+                ReferenceHandler.instance().DeriveReference(templatePathProvided).getLocalURI();
                 this.printTemplatePath = templatePathProvided;
                 return true;
             } catch (InvalidReferenceException e) {

--- a/src/main/java/org/commcare/suite/model/Detail.java
+++ b/src/main/java/org/commcare/suite/model/Detail.java
@@ -11,7 +11,7 @@ import org.commcare.util.GridStyle;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.reference.InvalidReferenceException;
-import org.javarosa.core.reference.ReferenceManager;
+import org.javarosa.core.reference.ReferenceManagerHandler;
 import org.javarosa.core.util.ArrayUtilities;
 import org.javarosa.core.util.OrderedHashtable;
 import org.javarosa.core.util.externalizable.DeserializationException;
@@ -499,7 +499,7 @@ public class Detail implements Externalizable {
             return true;
         } else if (templatePathProvided != null) {
             try {
-                ReferenceManager.instance().DeriveReference(templatePathProvided).getLocalURI();
+                ReferenceManagerHandler.instance().DeriveReference(templatePathProvided).getLocalURI();
                 this.printTemplatePath = templatePathProvided;
                 return true;
             } catch (InvalidReferenceException e) {

--- a/src/main/java/org/commcare/suite/model/OfflineUserRestore.java
+++ b/src/main/java/org/commcare/suite/model/OfflineUserRestore.java
@@ -8,7 +8,7 @@ import org.javarosa.core.io.StreamsUtil;
 import org.javarosa.core.model.User;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.Reference;
-import org.javarosa.core.reference.ReferenceManager;
+import org.javarosa.core.reference.ReferenceManagerHandler;
 import org.javarosa.core.services.storage.Persistable;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
@@ -82,7 +82,7 @@ public class OfflineUserRestore implements Persistable {
 
     private InputStream getStreamFromReference() {
         try {
-            Reference local = ReferenceManager.instance().DeriveReference(reference);
+            Reference local = ReferenceManagerHandler.instance().DeriveReference(reference);
             return local.getStream();
         } catch (IOException | InvalidReferenceException e) {
             throw new RuntimeException(e);

--- a/src/main/java/org/commcare/suite/model/OfflineUserRestore.java
+++ b/src/main/java/org/commcare/suite/model/OfflineUserRestore.java
@@ -8,7 +8,7 @@ import org.javarosa.core.io.StreamsUtil;
 import org.javarosa.core.model.User;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.Reference;
-import org.javarosa.core.reference.ReferenceManagerHandler;
+import org.javarosa.core.reference.ReferenceHandler;
 import org.javarosa.core.services.storage.Persistable;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
@@ -82,7 +82,7 @@ public class OfflineUserRestore implements Persistable {
 
     private InputStream getStreamFromReference() {
         try {
-            Reference local = ReferenceManagerHandler.instance().DeriveReference(reference);
+            Reference local = ReferenceHandler.instance().DeriveReference(reference);
             return local.getStream();
         } catch (IOException | InvalidReferenceException e) {
             throw new RuntimeException(e);

--- a/src/main/java/org/javarosa/core/reference/PrefixedRootFactory.java
+++ b/src/main/java/org/javarosa/core/reference/PrefixedRootFactory.java
@@ -73,7 +73,7 @@ public abstract class PrefixedRootFactory implements ReferenceFactory {
     @Override
     public Reference derive(String URI, String context) throws InvalidReferenceException {
         String referenceURI = context.substring(0, context.lastIndexOf('/') + 1) + URI;
-        return ReferenceManager.instance().DeriveReference(referenceURI);
+        return ReferenceManagerHandler.instance().DeriveReference(referenceURI);
     }
 
     @Override

--- a/src/main/java/org/javarosa/core/reference/PrefixedRootFactory.java
+++ b/src/main/java/org/javarosa/core/reference/PrefixedRootFactory.java
@@ -73,7 +73,7 @@ public abstract class PrefixedRootFactory implements ReferenceFactory {
     @Override
     public Reference derive(String URI, String context) throws InvalidReferenceException {
         String referenceURI = context.substring(0, context.lastIndexOf('/') + 1) + URI;
-        return ReferenceManagerHandler.instance().DeriveReference(referenceURI);
+        return ReferenceHandler.instance().DeriveReference(referenceURI);
     }
 
     @Override

--- a/src/main/java/org/javarosa/core/reference/ReferenceDataSource.java
+++ b/src/main/java/org/javarosa/core/reference/ReferenceDataSource.java
@@ -42,7 +42,7 @@ public class ReferenceDataSource implements LocaleDataSource {
     public Hashtable<String, String> getLocalizedText() {
         InputStream is = null;
         try {
-            is = ReferenceManagerHandler.instance().DeriveReference(referenceURI).getStream();
+            is = ReferenceHandler.instance().DeriveReference(referenceURI).getStream();
             if (is == null) {
                 throw new IOException("There is no resource at " + referenceURI);
             }

--- a/src/main/java/org/javarosa/core/reference/ReferenceDataSource.java
+++ b/src/main/java/org/javarosa/core/reference/ReferenceDataSource.java
@@ -42,7 +42,7 @@ public class ReferenceDataSource implements LocaleDataSource {
     public Hashtable<String, String> getLocalizedText() {
         InputStream is = null;
         try {
-            is = ReferenceManager.instance().DeriveReference(referenceURI).getStream();
+            is = ReferenceManagerHandler.instance().DeriveReference(referenceURI).getStream();
             if (is == null) {
                 throw new IOException("There is no resource at " + referenceURI);
             }

--- a/src/main/java/org/javarosa/core/reference/ReferenceHandler.java
+++ b/src/main/java/org/javarosa/core/reference/ReferenceHandler.java
@@ -4,7 +4,7 @@ package org.javarosa.core.reference;
 /**
  * Created by willpride on 2/20/18.
  */
-public class ReferenceManagerHandler {
+public class ReferenceHandler {
 
     private static ReferenceManager staticManager;
 
@@ -31,7 +31,7 @@ public class ReferenceManagerHandler {
     }
 
     public static void setUseThreadLocalStrategy(boolean useThreadLocal) {
-        ReferenceManagerHandler.useThreadLocal = useThreadLocal;
+        ReferenceHandler.useThreadLocal = useThreadLocal;
     }
 
     /**

--- a/src/main/java/org/javarosa/core/reference/ReferenceHandler.java
+++ b/src/main/java/org/javarosa/core/reference/ReferenceHandler.java
@@ -18,18 +18,6 @@ public class ReferenceHandler {
 
     private static boolean useThreadLocal = false;
 
-    public static void init(boolean force) {
-        if (useThreadLocal) {
-            if (threadLocalManager.get() == null || force) {
-                threadLocalManager.set(new ReferenceManager());
-            }
-        } else {
-            if (staticManager == null || force) {
-                staticManager = new ReferenceManager();
-            }
-        }
-    }
-
     public static void setUseThreadLocalStrategy(boolean useThreadLocal) {
         ReferenceHandler.useThreadLocal = useThreadLocal;
     }
@@ -40,8 +28,14 @@ public class ReferenceHandler {
      */
     public static ReferenceManager instance() {
         if (useThreadLocal) {
+            if (threadLocalManager.get() == null) {
+                threadLocalManager.set(new ReferenceManager());
+            }
             return threadLocalManager.get();
         } else {
+            if (staticManager == null) {
+                staticManager = new ReferenceManager();
+            }
             return staticManager;
         }
     }

--- a/src/main/java/org/javarosa/core/reference/ReferenceManager.java
+++ b/src/main/java/org/javarosa/core/reference/ReferenceManager.java
@@ -39,14 +39,6 @@ public class ReferenceManager {
     }
 
     /**
-     * @return Singleton accessor to the global
-     * ReferenceManager.
-     */
-    public static ReferenceManager instance() {
-        return ReferenceManagerHandler.getGlobalReferenceManager();
-    }
-
-    /**
      * @return The available reference factories
      */
     public ReferenceFactory[] getFactories() {

--- a/src/main/java/org/javarosa/core/reference/ReferenceManager.java
+++ b/src/main/java/org/javarosa/core/reference/ReferenceManager.java
@@ -28,19 +28,11 @@ import java.util.Vector;
  */
 public class ReferenceManager {
 
-    private static ThreadLocal<ReferenceManager> instance = new ThreadLocal<ReferenceManager>() {
-        @Override
-        protected ReferenceManager initialValue()
-        {
-            return new ReferenceManager();
-        }
-    };
-
     private final Vector<RootTranslator> translators;
     private final Vector<ReferenceFactory> factories;
     private final Vector<RootTranslator> sessionTranslators;
 
-    private ReferenceManager() {
+    public ReferenceManager() {
         translators = new Vector<>();
         factories = new Vector<>();
         sessionTranslators = new Vector<>();
@@ -51,7 +43,7 @@ public class ReferenceManager {
      * ReferenceManager.
      */
     public static ReferenceManager instance() {
-        return instance.get();
+        return ReferenceManagerHandler.getGlobalReferenceManager();
     }
 
     /**

--- a/src/main/java/org/javarosa/core/reference/ReferenceManagerHandler.java
+++ b/src/main/java/org/javarosa/core/reference/ReferenceManagerHandler.java
@@ -18,14 +18,6 @@ public class ReferenceManagerHandler {
 
     private static boolean useThreadLocal = false;
 
-    public static ReferenceManager getGlobalReferenceManager() {
-        if (useThreadLocal) {
-            return threadLocalManager.get();
-        } else {
-            return staticManager;
-        }
-    }
-
     public static void init(boolean force) {
         if (useThreadLocal) {
             if (threadLocalManager.get() == null || force) {
@@ -40,5 +32,17 @@ public class ReferenceManagerHandler {
 
     public static void setUseThreadLocalStrategy(boolean useThreadLocal) {
         ReferenceManagerHandler.useThreadLocal = useThreadLocal;
+    }
+
+    /**
+     * @return Singleton accessor to the global
+     * ReferenceManager.
+     */
+    public static ReferenceManager instance() {
+        if (useThreadLocal) {
+            return threadLocalManager.get();
+        } else {
+            return staticManager;
+        }
     }
 }

--- a/src/main/java/org/javarosa/core/reference/ReferenceManagerHandler.java
+++ b/src/main/java/org/javarosa/core/reference/ReferenceManagerHandler.java
@@ -1,0 +1,44 @@
+package org.javarosa.core.reference;
+
+
+/**
+ * Created by willpride on 2/20/18.
+ */
+public class ReferenceManagerHandler {
+
+    private static ReferenceManager staticManager;
+
+    private static final ThreadLocal<ReferenceManager> threadLocalManager = new ThreadLocal<ReferenceManager>(){
+        @Override
+        protected ReferenceManager initialValue()
+        {
+            return new ReferenceManager();
+        }
+    };
+
+    private static boolean useThreadLocal = false;
+
+    public static ReferenceManager getGlobalReferenceManager() {
+        if (useThreadLocal) {
+            return threadLocalManager.get();
+        } else {
+            return staticManager;
+        }
+    }
+
+    public static void init(boolean force) {
+        if (useThreadLocal) {
+            if (threadLocalManager.get() == null || force) {
+                threadLocalManager.set(new ReferenceManager());
+            }
+        } else {
+            if (staticManager == null || force) {
+                staticManager = new ReferenceManager();
+            }
+        }
+    }
+
+    public static void setUseThreadLocalStrategy(boolean useThreadLocal) {
+        ReferenceManagerHandler.useThreadLocal = useThreadLocal;
+    }
+}

--- a/src/main/java/org/javarosa/core/reference/RootTranslator.java
+++ b/src/main/java/org/javarosa/core/reference/RootTranslator.java
@@ -47,12 +47,12 @@ public class RootTranslator implements ReferenceFactory, Externalizable {
 
     @Override
     public Reference derive(String URI) throws InvalidReferenceException {
-        return ReferenceManager.instance().DeriveReference(translatedPrefix + URI.substring(prefix.length()));
+        return ReferenceManagerHandler.instance().DeriveReference(translatedPrefix + URI.substring(prefix.length()));
     }
 
     @Override
     public Reference derive(String URI, String context) throws InvalidReferenceException {
-        return ReferenceManager.instance().DeriveReference(URI, translatedPrefix + context.substring(prefix.length()));
+        return ReferenceManagerHandler.instance().DeriveReference(URI, translatedPrefix + context.substring(prefix.length()));
     }
 
     @Override

--- a/src/main/java/org/javarosa/core/reference/RootTranslator.java
+++ b/src/main/java/org/javarosa/core/reference/RootTranslator.java
@@ -47,12 +47,12 @@ public class RootTranslator implements ReferenceFactory, Externalizable {
 
     @Override
     public Reference derive(String URI) throws InvalidReferenceException {
-        return ReferenceManagerHandler.instance().DeriveReference(translatedPrefix + URI.substring(prefix.length()));
+        return ReferenceHandler.instance().DeriveReference(translatedPrefix + URI.substring(prefix.length()));
     }
 
     @Override
     public Reference derive(String URI, String context) throws InvalidReferenceException {
-        return ReferenceManagerHandler.instance().DeriveReference(URI, translatedPrefix + context.substring(prefix.length()));
+        return ReferenceHandler.instance().DeriveReference(URI, translatedPrefix + context.substring(prefix.length()));
     }
 
     @Override

--- a/src/test/java/org/commcare/util/reference/test/JavaResourceReferenceTest.java
+++ b/src/test/java/org/commcare/util/reference/test/JavaResourceReferenceTest.java
@@ -1,7 +1,7 @@
 package org.commcare.util.reference.test;
 
 import org.commcare.test.utilities.TestHelpers;
-import org.javarosa.core.reference.ReferenceManagerHandler;
+import org.javarosa.core.reference.ReferenceHandler;
 import org.javarosa.core.reference.ResourceReference;
 import org.javarosa.core.reference.ResourceReferenceFactory;
 import org.junit.Assert;
@@ -17,11 +17,11 @@ import java.io.InputStream;
 public class JavaResourceReferenceTest {
     @Test
     public void testReferences() throws Exception {
-        ReferenceManagerHandler.instance().addReferenceFactory(new ResourceReferenceFactory());
+        ReferenceHandler.instance().addReferenceFactory(new ResourceReferenceFactory());
 
         String referenceName = "jr://resource/reference/resource_reference_test.txt";
 
-        Reference r = ReferenceManagerHandler.instance().DeriveReference(referenceName);
+        Reference r = ReferenceHandler.instance().DeriveReference(referenceName);
 
         if (!(r instanceof ResourceReference)) {
             Assert.fail("Incorrect reference type: " + r);

--- a/src/test/java/org/commcare/util/reference/test/JavaResourceReferenceTest.java
+++ b/src/test/java/org/commcare/util/reference/test/JavaResourceReferenceTest.java
@@ -1,12 +1,12 @@
 package org.commcare.util.reference.test;
 
 import org.commcare.test.utilities.TestHelpers;
+import org.javarosa.core.reference.ReferenceManagerHandler;
 import org.javarosa.core.reference.ResourceReference;
 import org.javarosa.core.reference.ResourceReferenceFactory;
 import org.junit.Assert;
 
 import org.javarosa.core.reference.Reference;
-import org.javarosa.core.reference.ReferenceManager;
 import org.junit.Test;
 
 import java.io.InputStream;
@@ -17,11 +17,11 @@ import java.io.InputStream;
 public class JavaResourceReferenceTest {
     @Test
     public void testReferences() throws Exception {
-        ReferenceManager.instance().addReferenceFactory(new ResourceReferenceFactory());
+        ReferenceManagerHandler.instance().addReferenceFactory(new ResourceReferenceFactory());
 
         String referenceName = "jr://resource/reference/resource_reference_test.txt";
 
-        Reference r = ReferenceManager.instance().DeriveReference(referenceName);
+        Reference r = ReferenceManagerHandler.instance().DeriveReference(referenceName);
 
         if (!(r instanceof ResourceReference)) {
             Assert.fail("Incorrect reference type: " + r);

--- a/src/test/java/org/javarosa/core/model/test/QuestionDefTest.java
+++ b/src/test/java/org/javarosa/core/model/test/QuestionDefTest.java
@@ -4,7 +4,7 @@ import org.javarosa.core.model.Constants;
 import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.Reference;
-import org.javarosa.core.reference.ReferenceManagerHandler;
+import org.javarosa.core.reference.ReferenceHandler;
 import org.javarosa.core.reference.ResourceReferenceFactory;
 import org.javarosa.core.reference.RootTranslator;
 import org.javarosa.core.services.PrototypeManager;
@@ -131,10 +131,10 @@ public class QuestionDefTest {
         String audioURI = fep.getAudioText();
         String ref;
 
-        ReferenceManagerHandler.instance().addReferenceFactory(new ResourceReferenceFactory());
-        ReferenceManagerHandler.instance().addRootTranslator(new RootTranslator("jr://audio/", "jr://resource/"));
+        ReferenceHandler.instance().addReferenceFactory(new ResourceReferenceFactory());
+        ReferenceHandler.instance().addRootTranslator(new RootTranslator("jr://audio/", "jr://resource/"));
         try {
-            Reference r = ReferenceManagerHandler.instance().DeriveReference(audioURI);
+            Reference r = ReferenceHandler.instance().DeriveReference(audioURI);
             ref = r.getURI();
             if (!ref.equals("jr://resource/hah.mp3")) {
                 fail("Root translation failed.");
@@ -145,12 +145,12 @@ public class QuestionDefTest {
         }
 
 
-        ReferenceManagerHandler.instance().addRootTranslator(new RootTranslator("jr://images/", "jr://resource/"));
+        ReferenceHandler.instance().addRootTranslator(new RootTranslator("jr://images/", "jr://resource/"));
         q = fpi.getNextQuestion();
         fep = fpi.getFormEntryModel().getQuestionPrompt();
         String imURI = fep.getImageText();
         try {
-            Reference r = ReferenceManagerHandler.instance().DeriveReference(imURI);
+            Reference r = ReferenceHandler.instance().DeriveReference(imURI);
             ref = r.getURI();
             if (!ref.equals("jr://resource/four.gif")) {
                 fail("Root translation failed.");

--- a/src/test/java/org/javarosa/core/model/test/QuestionDefTest.java
+++ b/src/test/java/org/javarosa/core/model/test/QuestionDefTest.java
@@ -4,7 +4,7 @@ import org.javarosa.core.model.Constants;
 import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.Reference;
-import org.javarosa.core.reference.ReferenceManager;
+import org.javarosa.core.reference.ReferenceManagerHandler;
 import org.javarosa.core.reference.ResourceReferenceFactory;
 import org.javarosa.core.reference.RootTranslator;
 import org.javarosa.core.services.PrototypeManager;
@@ -131,10 +131,10 @@ public class QuestionDefTest {
         String audioURI = fep.getAudioText();
         String ref;
 
-        ReferenceManager.instance().addReferenceFactory(new ResourceReferenceFactory());
-        ReferenceManager.instance().addRootTranslator(new RootTranslator("jr://audio/", "jr://resource/"));
+        ReferenceManagerHandler.instance().addReferenceFactory(new ResourceReferenceFactory());
+        ReferenceManagerHandler.instance().addRootTranslator(new RootTranslator("jr://audio/", "jr://resource/"));
         try {
-            Reference r = ReferenceManager.instance().DeriveReference(audioURI);
+            Reference r = ReferenceManagerHandler.instance().DeriveReference(audioURI);
             ref = r.getURI();
             if (!ref.equals("jr://resource/hah.mp3")) {
                 fail("Root translation failed.");
@@ -145,12 +145,12 @@ public class QuestionDefTest {
         }
 
 
-        ReferenceManager.instance().addRootTranslator(new RootTranslator("jr://images/", "jr://resource/"));
+        ReferenceManagerHandler.instance().addRootTranslator(new RootTranslator("jr://images/", "jr://resource/"));
         q = fpi.getNextQuestion();
         fep = fpi.getFormEntryModel().getQuestionPrompt();
         String imURI = fep.getImageText();
         try {
-            Reference r = ReferenceManager.instance().DeriveReference(imURI);
+            Reference r = ReferenceManagerHandler.instance().DeriveReference(imURI);
             ref = r.getURI();
             if (!ref.equals("jr://resource/four.gif")) {
                 fail("Root translation failed.");


### PR DESCRIPTION
Implements a similar pattern to in https://github.com/dimagi/commcare-core/pull/757 but for `ReferenceManager`. Unfortunately had to duplicate much of the code in that PR because generic objects cannot be static

The managed class was already named `Manager` so I had to choose between calling this new class `ReferenceManagerManager` or some other synonym, so I settled on `Handler`... lol. Considered renaming `ReferenceManager` to `ReferenceResolver` or `ReferenceDeriver` and then naming the new class `ReferenceManager` but decided to keep this lower touch... open to suggestions!

Most of the diff is just moving the `instance()` method from `ReferenceManger` into the new class