### PR TITLE
Enable Formplayer to skip user-restore parsing

### DIFF
--- a/src/main/java/org/commcare/resources/model/installers/SuiteInstaller.java
+++ b/src/main/java/org/commcare/resources/model/installers/SuiteInstaller.java
@@ -13,6 +13,7 @@ import org.commcare.xml.SuiteParser;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.reference.Reference;
 import org.javarosa.core.services.locale.Localization;
+import org.javarosa.core.services.storage.IStorageUtilityIndexed;
 import org.javarosa.core.util.SizeBoundUniqueVector;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
@@ -43,6 +44,10 @@ public class SuiteInstaller extends CacheInstaller<Suite> {
         return Suite.STORAGE_KEY;
     }
 
+    protected SuiteParser getSuiteParser(InputStream incoming, ResourceTable table, String guid, IStorageUtilityIndexed formInstanceStorage) throws IOException {
+        return new SuiteParser(incoming, table, guid, formInstanceStorage);
+    }
+
     @Override
     public boolean install(Resource r, ResourceLocation location, Reference ref,
                            ResourceTable table, CommCarePlatform platform,
@@ -54,7 +59,7 @@ public class SuiteInstaller extends CacheInstaller<Suite> {
             InputStream incoming = null;
             try {
                 incoming = ref.getStream();
-                SuiteParser parser = new SuiteParser(incoming, table, r.getRecordGuid(), platform.getStorageManager().getStorage(FormInstance.STORAGE_KEY));
+                SuiteParser parser = getSuiteParser(incoming, table, r.getRecordGuid(), platform.getStorageManager().getStorage(FormInstance.STORAGE_KEY));
                 if (location.getAuthority() == Resource.RESOURCE_AUTHORITY_REMOTE) {
                     parser.setMaximumAuthority(Resource.RESOURCE_AUTHORITY_REMOTE);
                 }

--- a/src/test/java/org/commcare/backend/suite/model/test/AppStructureTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/AppStructureTests.java
@@ -98,7 +98,7 @@ public class AppStructureTests {
         Assert.assertTrue(focusFunction == null);
     }
 
-    //@Test
+    @Test
     public void testDemoUserRestoreParsing() throws Exception {
         // Test parsing an app with a properly-formed demo user restore file
         MockApp appWithGoodUserRestore = new MockApp("/app_with_good_demo_restore/");


### PR DESCRIPTION
Enable Formplayer to skip `user-restore` parsing during app install

- pull out `getSuiteParser` method in `SuiteInstaller`
- pull out `handleTag` method in `SuiteParser` 
- uncomment previously skipped test around user-restore parsing

cross-request: https://github.com/dimagi/formplayer/pull/623