### PR TITLE
Use ReferenceManager.instance() instead of ReferenceHandler

### DIFF
--- a/src/cli/java/org/commcare/util/engine/CommCareConfigEngine.java
+++ b/src/cli/java/org/commcare/util/engine/CommCareConfigEngine.java
@@ -27,7 +27,7 @@ import org.javarosa.core.io.StreamsUtil;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.FormInstance;
-import org.javarosa.core.reference.ReferenceHandler;
+import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.reference.ResourceReferenceFactory;
 import org.javarosa.core.services.PropertyManager;
 import org.javarosa.core.services.locale.Localization;
@@ -107,12 +107,12 @@ public class CommCareConfigEngine {
     }
 
     protected void setRoots() {
-        ReferenceHandler.instance().addReferenceFactory(new JavaHttpRoot());
+        ReferenceManager.instance().addReferenceFactory(new JavaHttpRoot());
 
         this.mArchiveRoot = new ArchiveFileRoot();
 
-        ReferenceHandler.instance().addReferenceFactory(mArchiveRoot);
-        ReferenceHandler.instance().addReferenceFactory(new ResourceReferenceFactory());
+        ReferenceManager.instance().addReferenceFactory(mArchiveRoot);
+        ReferenceManager.instance().addReferenceFactory(new ResourceReferenceFactory());
     }
 
     public void initFromArchive(String archiveURL) throws InstallCancelledException,
@@ -194,7 +194,7 @@ public class CommCareConfigEngine {
         }
 
         //(That root now reads as jr://file/)
-        ReferenceHandler.instance().addReferenceFactory(new JavaFileRoot(rootPath));
+        ReferenceManager.instance().addReferenceFactory(new JavaFileRoot(rootPath));
 
         //Now build the testing reference we'll use
         return "jr://file/" + filePart;

--- a/src/main/java/org/commcare/modern/reference/ArchiveFileRoot.java
+++ b/src/main/java/org/commcare/modern/reference/ArchiveFileRoot.java
@@ -3,7 +3,6 @@ package org.commcare.modern.reference;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.Reference;
 import org.javarosa.core.reference.ReferenceFactory;
-import org.javarosa.core.reference.ReferenceHandler;
 import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.util.PropertyUtils;
 

--- a/src/main/java/org/commcare/modern/reference/ArchiveFileRoot.java
+++ b/src/main/java/org/commcare/modern/reference/ArchiveFileRoot.java
@@ -4,6 +4,7 @@ import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.Reference;
 import org.javarosa.core.reference.ReferenceFactory;
 import org.javarosa.core.reference.ReferenceHandler;
+import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.util.PropertyUtils;
 
 import java.util.HashMap;
@@ -34,7 +35,7 @@ public class ArchiveFileRoot implements ReferenceFactory {
         if (context.lastIndexOf('/') != -1) {
             context = context.substring(0, context.lastIndexOf('/') + 1);
         }
-        return ReferenceHandler.instance().DeriveReference(context + URI);
+        return ReferenceManager.instance().DeriveReference(context + URI);
     }
 
     @Override

--- a/src/main/java/org/commcare/resources/model/ResourceTable.java
+++ b/src/main/java/org/commcare/resources/model/ResourceTable.java
@@ -4,7 +4,6 @@ import org.commcare.resources.model.installers.ProfileInstaller;
 import org.commcare.util.CommCarePlatform;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.Reference;
-import org.javarosa.core.reference.ReferenceHandler;
 import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.storage.IStorageIterator;

--- a/src/main/java/org/commcare/resources/model/ResourceTable.java
+++ b/src/main/java/org/commcare/resources/model/ResourceTable.java
@@ -5,6 +5,7 @@ import org.commcare.util.CommCarePlatform;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.Reference;
 import org.javarosa.core.reference.ReferenceHandler;
+import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.storage.IStorageIterator;
 import org.javarosa.core.services.storage.IStorageUtilityIndexed;
@@ -387,7 +388,7 @@ public class ResourceTable {
             } else {
                 try {
                     handled = installResource(r, location,
-                            ReferenceHandler.instance().DeriveReference(location.getLocation()),
+                            ReferenceManager.instance().DeriveReference(location.getLocation()),
                             this, platform, upgrade);
                     if (handled) {
                         recordSuccess(r);
@@ -1038,12 +1039,12 @@ public class ResourceTable {
             final Reference derivedRef;
             if (context == null) {
                 derivedRef =
-                        ReferenceHandler.instance().DeriveReference(location.getLocation());
+                        ReferenceManager.instance().DeriveReference(location.getLocation());
             } else {
                 // contextualize the location ref in terms of the multiple refs
                 // pointing to different locations for the parent resource
                 derivedRef =
-                        ReferenceHandler.instance().DeriveReference(location.getLocation(),
+                        ReferenceManager.instance().DeriveReference(location.getLocation(),
                                 context);
             }
             ret.addElement(derivedRef);

--- a/src/main/java/org/commcare/resources/model/installers/InstallerUtil.java
+++ b/src/main/java/org/commcare/resources/model/installers/InstallerUtil.java
@@ -4,7 +4,7 @@ import org.commcare.resources.model.MissingMediaException;
 import org.commcare.resources.model.Resource;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.Reference;
-import org.javarosa.core.reference.ReferenceHandler;
+import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.util.SizeBoundUniqueVector;
 
 import java.io.IOException;
@@ -17,7 +17,7 @@ public class InstallerUtil {
 
     public static void checkMedia(Resource r, String filePath, SizeBoundUniqueVector<MissingMediaException> problems, MediaType mt) {
         try {
-            Reference ref = ReferenceHandler.instance().DeriveReference(filePath);
+            Reference ref = ReferenceManager.instance().DeriveReference(filePath);
             String localName = ref.getLocalURI();
             boolean successfulAdd;
             try {

--- a/src/main/java/org/commcare/resources/model/installers/LocaleFileInstaller.java
+++ b/src/main/java/org/commcare/resources/model/installers/LocaleFileInstaller.java
@@ -12,7 +12,7 @@ import org.javarosa.core.io.StreamsUtil;
 import org.javarosa.core.io.StreamsUtil.InputIOException;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.Reference;
-import org.javarosa.core.reference.ReferenceHandler;
+import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.services.locale.LocalizationUtils;
 import org.javarosa.core.services.locale.TableLocaleSource;
@@ -128,12 +128,12 @@ public class LocaleFileInstaller implements ResourceInstaller<CommCarePlatform> 
                 int copy = 0;
 
                 try {
-                    Reference destination = ReferenceHandler.instance().DeriveReference("jr://file/" + uri);
+                    Reference destination = ReferenceManager.instance().DeriveReference("jr://file/" + uri);
                     while (destination.doesBinaryExist()) {
                         //Need a different location.
                         copy++;
                         String newUri = uri + "." + copy;
-                        destination = ReferenceHandler.instance().DeriveReference("jr://file/" + newUri);
+                        destination = ReferenceManager.instance().DeriveReference("jr://file/" + newUri);
                     }
 
                     if (destination.isReadOnly()) {
@@ -237,7 +237,7 @@ public class LocaleFileInstaller implements ResourceInstaller<CommCarePlatform> 
         }
         Reference reference;
         try {
-            reference = ReferenceHandler.instance().DeriveReference(localReference);
+            reference = ReferenceManager.instance().DeriveReference(localReference);
             if (!reference.isReadOnly()) {
                 reference.remove();
             }
@@ -284,7 +284,7 @@ public class LocaleFileInstaller implements ResourceInstaller<CommCarePlatform> 
                 //If we've gotten the cache into memory, we're fine
             } else {
                 try {
-                    if (!ReferenceHandler.instance().DeriveReference(localReference).doesBinaryExist()) {
+                    if (!ReferenceManager.instance().DeriveReference(localReference).doesBinaryExist()) {
                         throw new MissingMediaException(r, "Locale data does note exist at: " + localReference);
                     }
                 } catch (IOException e) {

--- a/src/main/java/org/commcare/suite/model/Detail.java
+++ b/src/main/java/org/commcare/suite/model/Detail.java
@@ -1,17 +1,17 @@
 package org.commcare.suite.model;
 
-import org.commcare.modern.util.Pair;
 import org.commcare.cases.entity.Entity;
+import org.commcare.cases.entity.EntityUtil;
 import org.commcare.cases.entity.NodeEntityFactory;
+import org.commcare.modern.util.Pair;
 import org.commcare.util.CollectionUtils;
 import org.commcare.util.DetailFieldPrintInfo;
-import org.commcare.cases.entity.EntityUtil;
 import org.commcare.util.GridCoordinate;
 import org.commcare.util.GridStyle;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.reference.InvalidReferenceException;
-import org.javarosa.core.reference.ReferenceHandler;
+import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.util.ArrayUtilities;
 import org.javarosa.core.util.OrderedHashtable;
 import org.javarosa.core.util.externalizable.DeserializationException;
@@ -499,7 +499,7 @@ public class Detail implements Externalizable {
             return true;
         } else if (templatePathProvided != null) {
             try {
-                ReferenceHandler.instance().DeriveReference(templatePathProvided).getLocalURI();
+                ReferenceManager.instance().DeriveReference(templatePathProvided).getLocalURI();
                 this.printTemplatePath = templatePathProvided;
                 return true;
             } catch (InvalidReferenceException e) {

--- a/src/main/java/org/commcare/suite/model/OfflineUserRestore.java
+++ b/src/main/java/org/commcare/suite/model/OfflineUserRestore.java
@@ -8,7 +8,7 @@ import org.javarosa.core.io.StreamsUtil;
 import org.javarosa.core.model.User;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.Reference;
-import org.javarosa.core.reference.ReferenceHandler;
+import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.services.storage.Persistable;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
@@ -82,7 +82,7 @@ public class OfflineUserRestore implements Persistable {
 
     private InputStream getStreamFromReference() {
         try {
-            Reference local = ReferenceHandler.instance().DeriveReference(reference);
+            Reference local = ReferenceManager.instance().DeriveReference(reference);
             return local.getStream();
         } catch (IOException | InvalidReferenceException e) {
             throw new RuntimeException(e);

--- a/src/main/java/org/javarosa/core/reference/PrefixedRootFactory.java
+++ b/src/main/java/org/javarosa/core/reference/PrefixedRootFactory.java
@@ -73,7 +73,7 @@ public abstract class PrefixedRootFactory implements ReferenceFactory {
     @Override
     public Reference derive(String URI, String context) throws InvalidReferenceException {
         String referenceURI = context.substring(0, context.lastIndexOf('/') + 1) + URI;
-        return ReferenceHandler.instance().DeriveReference(referenceURI);
+        return ReferenceManager.instance().DeriveReference(referenceURI);
     }
 
     @Override

--- a/src/main/java/org/javarosa/core/reference/ReferenceDataSource.java
+++ b/src/main/java/org/javarosa/core/reference/ReferenceDataSource.java
@@ -42,7 +42,7 @@ public class ReferenceDataSource implements LocaleDataSource {
     public Hashtable<String, String> getLocalizedText() {
         InputStream is = null;
         try {
-            is = ReferenceHandler.instance().DeriveReference(referenceURI).getStream();
+            is = ReferenceManager.instance().DeriveReference(referenceURI).getStream();
             if (is == null) {
                 throw new IOException("There is no resource at " + referenceURI);
             }

--- a/src/main/java/org/javarosa/core/reference/ReferenceManager.java
+++ b/src/main/java/org/javarosa/core/reference/ReferenceManager.java
@@ -38,6 +38,10 @@ public class ReferenceManager {
         sessionTranslators = new Vector<>();
     }
 
+    public static ReferenceManager instance() {
+        return ReferenceHandler.instance();
+    }
+
     /**
      * @return The available reference factories
      */

--- a/src/main/java/org/javarosa/core/reference/RootTranslator.java
+++ b/src/main/java/org/javarosa/core/reference/RootTranslator.java
@@ -47,12 +47,12 @@ public class RootTranslator implements ReferenceFactory, Externalizable {
 
     @Override
     public Reference derive(String URI) throws InvalidReferenceException {
-        return ReferenceHandler.instance().DeriveReference(translatedPrefix + URI.substring(prefix.length()));
+        return ReferenceManager.instance().DeriveReference(translatedPrefix + URI.substring(prefix.length()));
     }
 
     @Override
     public Reference derive(String URI, String context) throws InvalidReferenceException {
-        return ReferenceHandler.instance().DeriveReference(URI, translatedPrefix + context.substring(prefix.length()));
+        return ReferenceManager.instance().DeriveReference(URI, translatedPrefix + context.substring(prefix.length()));
     }
 
     @Override

--- a/src/test/java/org/commcare/util/reference/test/JavaResourceReferenceTest.java
+++ b/src/test/java/org/commcare/util/reference/test/JavaResourceReferenceTest.java
@@ -2,7 +2,6 @@ package org.commcare.util.reference.test;
 
 import org.commcare.test.utilities.TestHelpers;
 import org.javarosa.core.reference.Reference;
-import org.javarosa.core.reference.ReferenceHandler;
 import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.reference.ResourceReference;
 import org.javarosa.core.reference.ResourceReferenceFactory;

--- a/src/test/java/org/commcare/util/reference/test/JavaResourceReferenceTest.java
+++ b/src/test/java/org/commcare/util/reference/test/JavaResourceReferenceTest.java
@@ -1,12 +1,12 @@
 package org.commcare.util.reference.test;
 
 import org.commcare.test.utilities.TestHelpers;
+import org.javarosa.core.reference.Reference;
 import org.javarosa.core.reference.ReferenceHandler;
+import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.reference.ResourceReference;
 import org.javarosa.core.reference.ResourceReferenceFactory;
 import org.junit.Assert;
-
-import org.javarosa.core.reference.Reference;
 import org.junit.Test;
 
 import java.io.InputStream;
@@ -17,11 +17,11 @@ import java.io.InputStream;
 public class JavaResourceReferenceTest {
     @Test
     public void testReferences() throws Exception {
-        ReferenceHandler.instance().addReferenceFactory(new ResourceReferenceFactory());
+        ReferenceManager.instance().addReferenceFactory(new ResourceReferenceFactory());
 
         String referenceName = "jr://resource/reference/resource_reference_test.txt";
 
-        Reference r = ReferenceHandler.instance().DeriveReference(referenceName);
+        Reference r = ReferenceManager.instance().DeriveReference(referenceName);
 
         if (!(r instanceof ResourceReference)) {
             Assert.fail("Incorrect reference type: " + r);

--- a/src/test/java/org/javarosa/core/model/test/QuestionDefTest.java
+++ b/src/test/java/org/javarosa/core/model/test/QuestionDefTest.java
@@ -4,7 +4,6 @@ import org.javarosa.core.model.Constants;
 import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.Reference;
-import org.javarosa.core.reference.ReferenceHandler;
 import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.reference.ResourceReferenceFactory;
 import org.javarosa.core.reference.RootTranslator;

--- a/src/test/java/org/javarosa/core/model/test/QuestionDefTest.java
+++ b/src/test/java/org/javarosa/core/model/test/QuestionDefTest.java
@@ -5,6 +5,7 @@ import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.Reference;
 import org.javarosa.core.reference.ReferenceHandler;
+import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.reference.ResourceReferenceFactory;
 import org.javarosa.core.reference.RootTranslator;
 import org.javarosa.core.services.PrototypeManager;
@@ -131,10 +132,10 @@ public class QuestionDefTest {
         String audioURI = fep.getAudioText();
         String ref;
 
-        ReferenceHandler.instance().addReferenceFactory(new ResourceReferenceFactory());
-        ReferenceHandler.instance().addRootTranslator(new RootTranslator("jr://audio/", "jr://resource/"));
+        ReferenceManager.instance().addReferenceFactory(new ResourceReferenceFactory());
+        ReferenceManager.instance().addRootTranslator(new RootTranslator("jr://audio/", "jr://resource/"));
         try {
-            Reference r = ReferenceHandler.instance().DeriveReference(audioURI);
+            Reference r = ReferenceManager.instance().DeriveReference(audioURI);
             ref = r.getURI();
             if (!ref.equals("jr://resource/hah.mp3")) {
                 fail("Root translation failed.");
@@ -145,12 +146,12 @@ public class QuestionDefTest {
         }
 
 
-        ReferenceHandler.instance().addRootTranslator(new RootTranslator("jr://images/", "jr://resource/"));
+        ReferenceManager.instance().addRootTranslator(new RootTranslator("jr://images/", "jr://resource/"));
         q = fpi.getNextQuestion();
         fep = fpi.getFormEntryModel().getQuestionPrompt();
         String imURI = fep.getImageText();
         try {
-            Reference r = ReferenceHandler.instance().DeriveReference(imURI);
+            Reference r = ReferenceManager.instance().DeriveReference(imURI);
             ref = r.getURI();
             if (!ref.equals("jr://resource/four.gif")) {
                 fail("Root translation failed.");


### PR DESCRIPTION
For consistency reasons, switch to using ReferenceManager.instance() (as in `commcare-android`) rather than ReferenceHandler

cross-request: https://github.com/dimagi/formplayer/pull/627