### PR TITLE
Revert removing EntityDatum instanceof check from guessUnknown

### DIFF
--- a/src/main/java/org/commcare/session/CommCareSession.java
+++ b/src/main/java/org/commcare/session/CommCareSession.java
@@ -366,7 +366,8 @@ public class CommCareSession {
                 }
                 Vector<SessionDatum> data = entry.getSessionDataReqs();
                 for (SessionDatum datum : data) {
-                    if (datum.getDataId().equals(poppedId)) {
+                    if (datum instanceof EntityDatum &&
+                            datum.getDataId().equals(poppedId)) {
                         return SessionFrame.STATE_DATUM_VAL;
                     }
                 }


### PR DESCRIPTION
In commit https://github.com/dimagi/commcare-core/commit/6dacb1848a8a5edbc5bb0c16448e68c1ba009d2e I removed the check `datum instanceof EntityDatum`. Unfortunately I can't remember what this change was attempting to address (September 2016...) and can't find the PR containing this change (likely because this was snuck in with a submodule update rather than a proper PR into `formplayer` branch). This change seems illogical to me now and the tests are passing, so I'm reverting the change. 