### PR TITLE
Add common hashtags to ignore-set

### DIFF
--- a/src/main/java/org/javarosa/xform/parse/XFormParser.java
+++ b/src/main/java/org/javarosa/xform/parse/XFormParser.java
@@ -639,7 +639,9 @@ public class XFormParser {
                 "doneEmptyCaption",
                 "mainHeader",
                 "entryHeader",
-                "delHeader"
+                "delHeader",
+                "hashtags",
+                "hashtagTransforms"
         };
         Vector<String> suppressWarning = new Vector<>();
         for (String aSuppressWarningArr : suppressWarningArr) {


### PR DESCRIPTION
Vellum adds this XML consistently so should suppress warning