### PR TITLE
Only log exception with DetailFeild once

### DIFF
--- a/src/cli/java/org/commcare/util/screen/EntityListSubscreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityListSubscreen.java
@@ -83,6 +83,7 @@ public class EntityListSubscreen extends Subscreen<EntityScreen> {
         DetailField[] fields = detail.getFields();
 
         StringBuilder row = new StringBuilder();
+        XPathException detailFieldException = null;
         int i = 0;
         for (DetailField field : fields) {
             Object o;
@@ -90,7 +91,9 @@ public class EntityListSubscreen extends Subscreen<EntityScreen> {
                 o = field.getTemplate().evaluate(context);
             } catch (XPathException e) {
                 o = "error (see output)";
-                e.printStackTrace();
+                if (detailFieldException == null) {
+                    detailFieldException = e;
+                }
             }
             String s;
             if (!(o instanceof String)) {
@@ -98,8 +101,11 @@ public class EntityListSubscreen extends Subscreen<EntityScreen> {
             } else {
                 s = (String)o;
             }
-
             row.append(s);
+        }
+
+        if (detailFieldException != null) {
+            detailFieldException.printStackTrace();
         }
 
         if (collectDebug) {


### PR DESCRIPTION
If there was an issue with a case list field then this exception would get its entire stack printed for *every case in the screen*. In Formplayer this was resulting in multiple files being completely filled with stack traces. Only log it once. 