### PR TITLE
Remove readonly ODK attribute

### DIFF
--- a/src/main/java/org/commcare/xml/RootParser.java
+++ b/src/main/java/org/commcare/xml/RootParser.java
@@ -22,7 +22,6 @@ public class RootParser extends ElementParser<RootTranslator> {
         this.checkNode("root");
 
         String id = parser.getAttributeValue(null, "prefix");
-        String readonly = parser.getAttributeValue(null, "readonly");
 
         //Get the child or error out if none exists
         getNextTagInBlock("root");

--- a/src/main/java/org/javarosa/core/model/DataBinding.java
+++ b/src/main/java/org/javarosa/core/model/DataBinding.java
@@ -28,8 +28,6 @@ public class DataBinding {
     public boolean relevantAbsolute;
     public Condition requiredCondition;
     public boolean requiredAbsolute;
-    public Condition readonlyCondition;
-    public boolean readonlyAbsolute;
     public IConditionExpr constraint;
     public Recalculate calculate;
 
@@ -40,7 +38,6 @@ public class DataBinding {
     public DataBinding() {
         relevantAbsolute = true;
         requiredAbsolute = false;
-        readonlyAbsolute = false;
     }
 
     public XPathReference getReference() {

--- a/src/main/java/org/javarosa/xform/parse/XFormParser.java
+++ b/src/main/java/org/javarosa/xform/parse/XFormParser.java
@@ -1873,7 +1873,6 @@ public class XFormParser {
         usedAtts.addElement("type");
         usedAtts.addElement("relevant");
         usedAtts.addElement("required");
-        usedAtts.addElement("readonly");
         usedAtts.addElement("constraint");
         usedAtts.addElement("constraintMsg");
         usedAtts.addElement("calculate");
@@ -1930,23 +1929,6 @@ public class XFormParser {
                     binding.requiredCondition = c;
                 } catch (XPathUnsupportedException xue) {
                     throw buildParseException(nodeset, xue.getMessage(), xpathReq, "required condition");
-                }
-            }
-        }
-
-        String xpathRO = e.getAttributeValue(null, "readonly");
-        if (xpathRO != null) {
-            if ("true()".equals(xpathRO)) {
-                binding.readonlyAbsolute = true;
-            } else if ("false()".equals(xpathRO)) {
-                binding.readonlyAbsolute = false;
-            } else {
-                try {
-                    Condition c = buildCondition(xpathRO, "readonly", ref);
-                    c = (Condition)_f.addTriggerable(c);
-                    binding.readonlyCondition = c;
-                } catch (XPathUnsupportedException xue) {
-                    throw buildParseException(nodeset, xue.getMessage(), xpathRO, "read-only condition");
                 }
             }
         }
@@ -2014,10 +1996,6 @@ public class XFormParser {
             prettyType = "require condition";
             trueAction = Condition.ACTION_REQUIRE;
             falseAction = Condition.ACTION_DONT_REQUIRE;
-        } else if ("readonly".equals(type)) {
-            prettyType = "readonly condition";
-            trueAction = Condition.ACTION_DISABLE;
-            falseAction = Condition.ACTION_ENABLE;
         } else {
             prettyType = "unknown condition";
         }
@@ -2720,9 +2698,6 @@ public class XFormParser {
         if (bind.requiredCondition != null) {
             bind.requiredCondition.addTarget(ref);
         }
-        if (bind.readonlyCondition != null) {
-            bind.readonlyCondition.addTarget(ref);
-        }
         if (bind.calculate != null) {
             bind.calculate.addTarget(ref);
         }
@@ -2736,9 +2711,6 @@ public class XFormParser {
         }
         if (bind.requiredCondition == null) {
             node.setRequired(bind.requiredAbsolute);
-        }
-        if (bind.readonlyCondition == null) {
-            node.setEnabled(!bind.readonlyAbsolute);
         }
         if (bind.constraint != null) {
             node.setConstraint(new Constraint(bind.constraint, bind.constraintMessage));

--- a/src/translate/java/org/javarosa/xform/schema/FormOverview.java
+++ b/src/translate/java/org/javarosa/xform/schema/FormOverview.java
@@ -139,8 +139,6 @@ public class FormOverview {
 
         printProperty("required", f, instanceNode, indent + 1, sb);
 
-        printProperty("readonly", f, instanceNode, indent + 1, sb);
-
         String defaultValue = printDefault(instanceNode);
         if (defaultValue != null) {
             println(sb, indent + 1, "Default: " + defaultValue);
@@ -189,12 +187,6 @@ public class FormOverview {
             absolute = instanceNode.isRequired();
             absoluteReportable = true;
             absoluteHeader = "Required";
-        } else if (property.equals("readonly")) {
-            action = Condition.ACTION_DISABLE;
-            conditionHeader = "Conditionally Read-only";
-            absolute = instanceNode.isEnabled();
-            absoluteReportable = false;
-            absoluteHeader = "Read-only";
         }
 
         IConditionExpr expr = null;
@@ -292,17 +284,12 @@ public class FormOverview {
         TreeElement instanceNode = getInstanceNode(f.getInstance(), g.getBind());
 
         String relevant = printConditionalProperty("relevant", f, instanceNode);
-        String readonly = printConditionalProperty("readonly", f, instanceNode);
 
-        if (repeat || caption != null || (relevant != null || readonly != null)) {
+        if (repeat || caption != null || (relevant != null)) {
             println(sb, indent, (repeat ? "Repeat" : "Group") + ":" + (caption != null ? " \"" + caption + "\"" : ""));
 
             if (relevant != null) {
                 println(sb, indent + 1, relevant);
-            }
-
-            if (readonly != null) {
-                println(sb, indent + 1, readonly);
             }
 
             println(sb);


### PR DESCRIPTION
#kill unused/annoying `readonly` attribute inherited from ODK