### PR TITLE
Pull error handling from CommCareConfigEngine to Application Host

### DIFF
--- a/src/cli/java/org/commcare/util/cli/ApplicationHost.java
+++ b/src/cli/java/org/commcare/util/cli/ApplicationHost.java
@@ -8,6 +8,7 @@ import org.commcare.core.parse.ParseUtils;
 import org.commcare.core.sandbox.SandboxUtils;
 import org.commcare.data.xml.DataModelPullParser;
 import org.commcare.modern.session.SessionWrapper;
+import org.commcare.resources.model.UnresolvedResourceException;
 import org.commcare.session.SessionFrame;
 import org.commcare.suite.model.FormIdDatum;
 import org.commcare.suite.model.SessionDatum;
@@ -152,7 +153,18 @@ public class ApplicationHost {
         this.mUpdatePending = false;
         String updateTarget = mUpdateTarget;
         this.mUpdateTarget = null;
-        mEngine.attemptAppUpdate(updateTarget);
+        try {
+            mEngine.attemptAppUpdate(updateTarget);
+        } catch (UnresolvedResourceException e) {
+            printStream.println("Update Failed! Couldn't find or install one of the remote resources");
+            e.printStackTrace();
+        } catch (UnfullfilledRequirementsException e) {
+            printStream.println("Update Failed! This CLI host is incompatible with the app");
+            e.printStackTrace();
+        } catch (Exception e) {
+            printStream.println("Update Failed! There is a problem with one of the resources");
+            e.printStackTrace();
+        }
     }
 
     private boolean loopSession() throws IOException {

--- a/src/cli/java/org/commcare/util/cli/ApplicationHost.java
+++ b/src/cli/java/org/commcare/util/cli/ApplicationHost.java
@@ -163,7 +163,7 @@ public class ApplicationHost {
             printStream.println("Update Failed! This CLI host is incompatible with the app");
             e.printStackTrace();
         } catch (InstallCancelledException e) {
-            printStream.println("Update Failed! Update was cancelled";
+            printStream.println("Update Failed! Update was cancelled");
             e.printStackTrace();
         }
     }

--- a/src/cli/java/org/commcare/util/cli/ApplicationHost.java
+++ b/src/cli/java/org/commcare/util/cli/ApplicationHost.java
@@ -8,6 +8,7 @@ import org.commcare.core.parse.ParseUtils;
 import org.commcare.core.sandbox.SandboxUtils;
 import org.commcare.data.xml.DataModelPullParser;
 import org.commcare.modern.session.SessionWrapper;
+import org.commcare.resources.model.InstallCancelledException;
 import org.commcare.resources.model.UnresolvedResourceException;
 import org.commcare.session.SessionFrame;
 import org.commcare.suite.model.FormIdDatum;
@@ -161,8 +162,8 @@ public class ApplicationHost {
         } catch (UnfullfilledRequirementsException e) {
             printStream.println("Update Failed! This CLI host is incompatible with the app");
             e.printStackTrace();
-        } catch (Exception e) {
-            printStream.println("Update Failed! There is a problem with one of the resources");
+        } catch (InstallCancelledException e) {
+            printStream.println("Update Failed! Update was cancelled";
             e.printStackTrace();
         }
     }


### PR DESCRIPTION
remake of https://github.com/dimagi/commcare-core/pull/785 into `master`

This feels "correcter" to me anyways since the error handling and UI outputs should more rightly be handled in the `ApplicationHost` level