### PR TITLE
Fail with SessionUnavailableException instead of NPE

### DIFF
--- a/src/cli/java/org/commcare/util/mocks/MockUserDataSandbox.java
+++ b/src/cli/java/org/commcare/util/mocks/MockUserDataSandbox.java
@@ -123,6 +123,11 @@ public class MockUserDataSandbox extends UserSandbox {
         return mUser;
     }
 
+    @Override
+    public User getLoggedInUserUnsafe() {
+        return mUser;
+    }
+
     public void setAppFixtureStorageLocation(IStorageUtilityIndexed<FormInstance>
                                                      appFixtureStorageLocation) {
         this.appFixtureStorage = appFixtureStorageLocation;

--- a/src/main/java/org/commcare/core/interfaces/UserSandbox.java
+++ b/src/main/java/org/commcare/core/interfaces/UserSandbox.java
@@ -60,6 +60,8 @@ public abstract class UserSandbox {
 
     public abstract User getLoggedInUser();
 
+    public abstract User getLoggedInUserUnsafe() throws RuntimeException;
+
     public abstract void setLoggedInUser(User user);
 
     public void setSyncToken(String syncToken){

--- a/src/main/java/org/commcare/core/process/CommCareInstanceInitializer.java
+++ b/src/main/java/org/commcare/core/process/CommCareInstanceInitializer.java
@@ -168,7 +168,7 @@ public class CommCareInstanceInitializer extends InstanceInitializationFactory {
         if (this.mPlatform == null) {
             throw new RuntimeException("Cannot generate session instance with undeclared platform!");
         }
-        User u = mSandbox.getLoggedInUser();
+        User u = mSandbox.getLoggedInUserUnsafe();
         TreeElement root =
                 SessionInstanceBuilder.getSessionInstance(session.getFrame(), getDeviceId(),
                         getVersionString(), u.getUsername(), u.getUniqueId(),


### PR DESCRIPTION
Since L174 in `CommCareInstanceInitializer` calls `u.getUsername()` and `u.getUniqueId()` anyway, it's better in this instance for us to throw a `SessionUnavailableException` if/when there is no currently-logged in user, rather than returning null and waiting for that to cause a NPE 2 lines later.

Will fix the remaining occurrences of https://fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/59cfab3ebe077a4dcc85c3a7?time=last-thirty-days (which have gone down significantly since https://github.com/dimagi/commcare-android/pull/1875 was merged, but not entirely. I assume this is because there are times when the session expires sometime between the call to `CommCareApplication.instance().getSession()` that was added in that PR and this point of code execution).