### PR TITLE
Removes deprecated classesdir when building with Android Gradle Plugin 3.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -193,8 +193,8 @@ task harnessJar(type: Jar, dependsOn: translateClasses) {
 // which might want to import classes
 task testsrcJar(type: Jar, dependsOn: testClasses) {
     classifier = 'tests'
-    from files(sourceSets.test.output.classesDir)
-    from files(sourceSets.cli.output.classesDir)
+    from files(sourceSets.test.output)
+    from files(sourceSets.cli.output)
 }
 
 


### PR DESCRIPTION
cross-request: https://github.com/dimagi/commcare-android/pull/1982