### PR TITLE
Fix multiplicity of children in session instance

### DIFF
--- a/src/main/java/org/commcare/session/SessionInstanceBuilder.java
+++ b/src/main/java/org/commcare/session/SessionInstanceBuilder.java
@@ -114,7 +114,7 @@ public class SessionInstanceBuilder {
     }
 
     private static void addData(TreeElement root, String name, String data) {
-        TreeElement datum = new TreeElement(name);
+        TreeElement datum = new TreeElement(name, root.getChildMultiplicity(name));
         datum.setValue(new UncastData(data));
         root.addChild(datum);
     }

--- a/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
+++ b/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
@@ -422,7 +422,7 @@ public class EvaluationContext {
                     if (child != null) {
                         childSet.addElement(child.getRef());
                     } else {
-                        throw new IllegalStateException("Missing or non-sequential nodes expanding a reference");
+                        throw new IllegalStateException("Missing or non-sequential nodes expanding a reference: " + node.getRef());
                     }
                 }
                 if (includeTemplates) {

--- a/src/translate/java/org/javarosa/engine/xml/TreeElementParser.java
+++ b/src/translate/java/org/javarosa/engine/xml/TreeElementParser.java
@@ -41,12 +41,11 @@ public class TreeElementParser extends ElementParser<TreeElement> {
                     String name = parser.getName();
                     int val;
                     if (multiplicities.containsKey(name)) {
-                        val = multiplicities.get(name) +1;
+                        val = multiplicities.get(name) + 1;
                     } else {
                         val = 0;
                     }
                     multiplicities.put(name,  val);
-
                     TreeElement kid = new TreeElementParser(parser, val, instanceId).parse();
                     element.addChild(kid);
                     break;

--- a/src/translate/java/org/javarosa/engine/xml/TreeElementParser.java
+++ b/src/translate/java/org/javarosa/engine/xml/TreeElementParser.java
@@ -29,34 +29,34 @@ public class TreeElementParser extends ElementParser<TreeElement> {
         int depth = parser.getDepth();
         TreeElement element = new TreeElement(parser.getName(), multiplicity);
         element.setInstanceName(instanceId);
-        for(int i = 0 ; i < parser.getAttributeCount(); ++i) {
+        for (int i = 0 ; i < parser.getAttributeCount(); ++i) {
             element.setAttribute(parser.getAttributeNamespace(i), parser.getAttributeName(i), parser.getAttributeValue(i));
         }
 
         Hashtable<String, Integer> multiplicities = new Hashtable<>();
         //NOTE: We never expect this to be the exit condition
-        while(parser.getDepth() >= depth) {
-        switch(this.nextNonWhitespace()) {
-            case KXmlParser.START_TAG:
-                String name = parser.getName();
-                int val;
-                if(multiplicities.containsKey(name)) {
-                    val = multiplicities.get(name) +1;
-                } else {
-                    val = 0;
-                }
-                multiplicities.put(name,  val);
+        while (parser.getDepth() >= depth) {
+            switch (this.nextNonWhitespace()) {
+                case KXmlParser.START_TAG:
+                    String name = parser.getName();
+                    int val;
+                    if (multiplicities.containsKey(name)) {
+                        val = multiplicities.get(name) +1;
+                    } else {
+                        val = 0;
+                    }
+                    multiplicities.put(name,  val);
 
-                TreeElement kid = new TreeElementParser(parser, val, instanceId).parse();
-                element.addChild(kid);
-                break;
-            case KXmlParser.END_TAG:
-                return element;
-            case KXmlParser.TEXT:
-                element.setValue(new UncastData(parser.getText().trim()));
-                break;
-            default:
-                throw new InvalidStructureException("Exception while trying to parse an XML Tree, got something other than tags and text", parser);
+                    TreeElement kid = new TreeElementParser(parser, val, instanceId).parse();
+                    element.addChild(kid);
+                    break;
+                case KXmlParser.END_TAG:
+                    return element;
+                case KXmlParser.TEXT:
+                    element.setValue(new UncastData(parser.getText().trim()));
+                    break;
+                default:
+                    throw new InvalidStructureException("Exception while trying to parse an XML Tree, got something other than tags and text", parser);
             }
         }
 


### PR DESCRIPTION
Discovered this while investigating https://manage.dimagi.com/default.asp?273828, though I'm pretty sure this is actually incidental to the issue they were reporting, which I still can't reproduce. 

This only comes up when using the case list search functionality to choose a case prior to entering [this form](https://www.commcarehq.org/a/possible-communityhealth/apps/view/23278308f7205809610d6b9c2603dc50/form/c6a559066280668aa4ab229102da88579e444888/source/). The issue was that we were not accounting for the possibility of children of the `session/data` node having a multiplicity other than 0. This isn't surprising because I imagine such a situation comes up very very rarely, but the `addUserQueryData()` construct allows for it, because it's possible for more than one `"stringquery"` or `"fingerprintquery"` node to be added.