### PR TITLE
2.43 - Fix regression by changing strategy

### DIFF
--- a/src/main/java/org/commcare/session/CommCareSession.java
+++ b/src/main/java/org/commcare/session/CommCareSession.java
@@ -118,24 +118,12 @@ public class CommCareSession {
         }
     }
 
-    public Vector<Entry> getEntriesForCommand(String commandId) {
-        return getEntriesForCommand(commandId, false);
-    }
-
-    public Vector<Entry> getEntriesForCommand(String commandId, boolean includeNested) {
-        return getEntriesForCommand(commandId, new OrderedHashtable<String, String>(), includeNested);
-    }
-
     /**
      * @param commandId          the current command id
-     * @param currentSessionData all of the datums already on the stack
-     * @param includeNested     whether to include entries from child modules
      * @return A list of all of the form entry actions that are possible with the given commandId
      * and the given list of already-collected datums
      */
-    private Vector<Entry> getEntriesForCommand(String commandId,
-                                               OrderedHashtable<String, String> currentSessionData,
-                                               boolean includeNested) {
+    private Vector<Entry> getEntriesForCommand(String commandId) {
         Vector<Entry> entries = new Vector<>();
         if (commandId == null) {
             return entries;
@@ -143,14 +131,8 @@ public class CommCareSession {
         for (Suite s : platform.getInstalledSuites()) {
             List<Menu> menusWithId = s.getMenusWithId(commandId);
             if (menusWithId != null) {
-                // make a copy so that we can use this as a queue
-                Queue<Menu> menusToExamine = new LinkedList<>(menusWithId);
-                while (!menusToExamine.isEmpty()) {
-                    Menu menu = menusToExamine.poll();
-                    entries.addAll(getStillValidEntriesFromMenu(menu, currentSessionData));
-                    if (includeNested) {
-                        menusToExamine.addAll(s.getMenusWithRoot(menu.getId()));
-                    }
+                for (Menu menu : menusWithId) {
+                    entries.addAll(getStillValidEntriesFromMenu(menu));
                 }
             }
 
@@ -161,8 +143,7 @@ public class CommCareSession {
         return entries;
     }
 
-    private Vector<Entry> getStillValidEntriesFromMenu(Menu menu,
-                                                       OrderedHashtable<String, String> currentSessionData) {
+    private Vector<Entry> getStillValidEntriesFromMenu(Menu menu) {
         Hashtable<String, Entry> globalEntryMap = platform.getCommandToEntryMap();
         Vector<Entry> stillValid = new Vector<>();
         for (String cmd : menu.getCommandIds()) {
@@ -195,19 +176,19 @@ public class CommCareSession {
             return SessionFrame.STATE_COMMAND_ID;
         }
 
-        Vector<Entry> remainingValidEntries =
-                getEntriesForCommand(currentCmd, collectedDatums, true);
-        String needDatum = getDataNeededByAllEntries(remainingValidEntries);
+        Vector<Entry> entriesForCurrentCommand = getEntriesForCommand(currentCmd);
+        String needDatum = getDataNeededByAllEntries(entriesForCurrentCommand);
 
         if (needDatum != null) {
             return needDatum;
-        } else if (remainingValidEntries.isEmpty()) {
-            throw new RuntimeException("Collected datums don't match required datums for entries at command " + currentCmd);
-        } else if (remainingValidEntries.size() == 1
-                && remainingValidEntries.elementAt(0) instanceof RemoteRequestEntry
-                && ((RemoteRequestEntry)remainingValidEntries.elementAt(0)).getPostRequest().isRelevant(evalContext)) {
+        } else if (entriesForCurrentCommand.isEmpty()) {
+            // No entries available directly within the current command, so we must need to select another menu
+            return SessionFrame.STATE_COMMAND_ID;
+        } else if (entriesForCurrentCommand.size() == 1
+                && entriesForCurrentCommand.elementAt(0) instanceof RemoteRequestEntry
+                && ((RemoteRequestEntry)entriesForCurrentCommand.elementAt(0)).getPostRequest().isRelevant(evalContext)) {
             return SessionFrame.STATE_SYNC_REQUEST;
-        } else if (remainingValidEntries.size() > 1 || !remainingValidEntries.elementAt(0).getCommandId().equals(currentCmd)) {
+        } else if (entriesForCurrentCommand.size() > 1 || !entriesForCurrentCommand.elementAt(0).getCommandId().equals(currentCmd)) {
             //the only other thing we can need is a form command. If there's
             //still more than one applicable entry, we need to keep going
             return SessionFrame.STATE_COMMAND_ID;
@@ -297,7 +278,7 @@ public class CommCareSession {
      * an entry on the stack
      */
     public SessionDatum getNeededDatum() {
-        Vector<Entry> entries = getEntriesForCommand(getCommand(), true);
+        Vector<Entry> entries = getEntriesForCommand(getCommand());
         if (entries.isEmpty()) {
             throw new IllegalStateException("The current session has no valid entry");
         }

--- a/src/test/java/org/commcare/backend/session/test/ChildModuleNavigationTests.java
+++ b/src/test/java/org/commcare/backend/session/test/ChildModuleNavigationTests.java
@@ -2,11 +2,8 @@ package org.commcare.backend.session.test;
 
 import org.commcare.modern.session.SessionWrapper;
 import org.commcare.session.SessionFrame;
-import org.commcare.suite.model.Entry;
 import org.commcare.test.utilities.MockApp;
 import org.junit.Test;
-
-import java.util.Vector;
 
 import static org.junit.Assert.assertEquals;
 
@@ -36,11 +33,4 @@ public class ChildModuleNavigationTests {
         session.setDatum("adolescent_case_id", "Al");
     }
 
-    @Test
-    public void testNestedGetEntriesBehavior() throws Exception {
-        MockApp app = new MockApp("/app_with_child_modules/");
-        SessionWrapper session = app.getSession();
-        Vector<Entry> entries = session.getEntriesForCommand("m1", true);
-        assertEquals(2, entries.size());
-    }
 }


### PR DESCRIPTION
Going to be sort of hard to explain this so bear with me.. 

This PR reverts the primary change made in https://github.com/dimagi/commcare-core/pull/778, which was to make `getEntriesForCommand()` take in a boolean `includeNested` argument, in order to allow for the inclusion of entries belonging child modules in the list of entries. However, this change has previously unforeseen consequences on the behavior of existing apps that are too extreme to be acceptable. The best way to explain the problem is with an example: I discovered this while working with [this app](https://www.commcarehq.org/a/inddex-test/apps/view/5ee0251a637c4ff2ad21ddd17e140d8b/), which contains one menu (`m1`) that contains a lot of entries, as well as one child menu (`m9`). Prior to the change made in https://github.com/dimagi/commcare-core/pull/778, `getEntriesForCommand()` when called after the user selects `m1` would only return the entries that are direct children of `m1`, all of which require the same datum `case_id`. This resulted in the case list for selecting that datum always showing up before `m1` was displayed, which enabled the app builder to add display conditions to some of the entries within m1 that _reference_ the `case_id` datum within the session. However, once the entries within `m9` started getting included in the results of `getEntriesForCommand()`, the datum `case_id` was no longer needed by all entries in the result set, and so we were then trying to show the menu `m1` _before_ collecting `case_id`, at which point the display conditions on those entries throw an xpath error.

Given the potential for any number of apps out in the wild to have been relying on this behavior in the same way, I don't see how we can release this change, even though it is technically correct in terms of the CommCare session model.

So, what I've done here is to revert that change and instead make a different change that addresses the problem I had been trying to solve. I don't like it as much from a completeness standpoint, but it is much safer and gets the job done. I've highlighted and explained the new change inline in the PR.