### PR TITLE
Wsp/ethiopian date fix

### DIFF
--- a/src/main/java/org/commcare/util/LocaleArrayDataSource.java
+++ b/src/main/java/org/commcare/util/LocaleArrayDataSource.java
@@ -2,6 +2,7 @@ package org.commcare.util;
 
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.util.NoLocalizedTextException;
+import org.javarosa.core.util.UnregisteredLocaleException;
 
 /**
  * Get localized arrays from the Localization file system (stored as comma separated lists)
@@ -23,7 +24,7 @@ public class LocaleArrayDataSource implements ArrayDataSource{
     public String[] getArray(String key) {
         try {
             return Localization.getArray(key);
-        } catch (NoLocalizedTextException e) {
+        } catch (NoLocalizedTextException | UnregisteredLocaleException e) {
             if (fallback != null) {
                 return fallback.getArray(key);
             } else {

--- a/src/main/java/org/javarosa/core/model/utils/DateUtils.java
+++ b/src/main/java/org/javarosa/core/model/utils/DateUtils.java
@@ -221,6 +221,10 @@ public class DateUtils {
         cd.set(Calendar.SECOND, df.second);
         cd.set(Calendar.MILLISECOND, df.secTicks);
 
+        if (df.hour == 0 && df.minute == 0 && df.second == 0 && df.secTicks == 0) {
+            cd.set(Calendar.HOUR_OF_DAY, 11);
+        }
+
         cd.add(Calendar.MILLISECOND, -1 * timezoneOffset);
 
         return cd.getTime();


### PR DESCRIPTION
Naive but I think possibly correct fix for [this](https://manage.dimagi.com/default.asp?276244) bug

Currently when you create a new date without time such as in a date picker, the input to this function is IE `05-11-2018`. This then gets set to midnight of this day, which if there is a negative timezone adjustment will get shifted to the previous day. By setting the default time to be midday instead of midnight we can easily avoid this.

Whenever messing with dates/times/timezones I feel like every step forward is also a step backwards but every test is passing and this makes sense to me so