### PR TITLE
Fixes crash in checksum caused by negative index value

### DIFF
--- a/src/main/java/org/javarosa/xpath/expr/XPathChecksumFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathChecksumFunc.java
@@ -4,12 +4,10 @@ package org.javarosa.xpath.expr;
 import org.commcare.cases.util.StringUtils;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.DataInstance;
-import org.javarosa.core.util.ArrayUtilities;
 import org.javarosa.xpath.XPathUnsupportedException;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 
 public class XPathChecksumFunc extends XPathFuncExpr {
@@ -92,7 +90,13 @@ public class XPathChecksumFunc extends XPathFuncExpr {
 
         int check = 0;
         for (int i = 0; i < inputList.size(); i++) {
-            check = op[check][p[((i + 1) % 8)][Character.getNumericValue(inputList.get(i))]];
+            int charAsNum;
+            try {
+                charAsNum = Integer.parseInt(String.valueOf(inputList.get(i)));
+            } catch (NumberFormatException e) {
+                throw new XPathUnsupportedException("Illegal character '" + inputList.get(i) + "' in input for Xpath function checksum()");
+            }
+            check = op[check][p[((i + 1) % 8)][charAsNum]];
         }
 
         return Integer.toString(inv[check]);

--- a/src/test/java/org/javarosa/xpath/test/XPathEvalTest.java
+++ b/src/test/java/org/javarosa/xpath/test/XPathEvalTest.java
@@ -274,7 +274,6 @@ public class XPathEvalTest {
         testEval("format-date-for-calendar('2017-07-15', 'nepali', '%Y-%m-%d')", null, null, "2074-03-31");
 
 
-
         //note: there are lots of time and timezone-like issues with dates that should be tested (particularly DST changes),
         //    but it's just too hard and client-dependent, so not doing it now
         //  basically:
@@ -566,6 +565,7 @@ public class XPathEvalTest {
 
         testEval("checksum('verhoeff','41310785898')", null, null, "4");
         testEval("checksum('verhoeff','66671496237')", null, null, "3");
+        testEval("checksum('verhoeff','*1310785898')", null, null, new XPathUnsupportedException());
         testEval("checksum('verhoefffff','41310785898')", null, null, new XPathUnsupportedException());
 
         //Variables


### PR DESCRIPTION
CL: https://www.fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/59d9bc6cbe077a4dccef38ea?time=last-ninety-days

`Character.getNumericValue` returns -ve values for unsupported characters which causes this crash. Replaced it with `Integer.parseInt` and shows an error in case input of checksum is not a valid integer string. 

Product Note: Fixes a crash on CommCare that occurs when `checksum()` function gets a non integer value in input.
