### PR TITLE
Check if select() arg is valid quesiton

### DIFF
--- a/src/main/java/org/javarosa/xpath/expr/XPathSelectedFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathSelectedFunc.java
@@ -36,11 +36,18 @@ public class XPathSelectedFunc extends XPathFuncExpr {
      * @param o2 choice to look for
      */
     private static Boolean multiSelected(Object o1, Object o2) {
+
+        o1 = FunctionUtils.unpack(o1);
+        if (!(o1 instanceof String)) {
+            throw generateBadArgumentMessage("selected", 1, "multi-select question", o1);
+        }
+
         o2 = FunctionUtils.unpack(o2);
         if (!(o2 instanceof String)) {
             throw generateBadArgumentMessage("selected", 2, "single potential value from the list of select options", o2);
         }
-        String s1 = (String)FunctionUtils.unpack(o1);
+
+        String s1 = (String)o1;
         String s2 = ((String)o2).trim();
 
         return (" " + s1 + " ").contains(" " + s2 + " ");


### PR DESCRIPTION
Addresses bug here https://sentry.io/dimagi/formplayer/issues/577997262/?query=domain:one-community-test

In this case the first argument to the function was a hidden value taking the values `0` or `1` (instead of a select question) and when we attempted to cast this to a String list of values we got the `ClassCastException`. This gives a better error message.

An alternative fix would coerce `0` or `1` to a String an treat this like a list of values with a single value in it; however, this seems contrary to the expected behavior of this function. 