### PR TITLE
Fixes callout when plain text assumption prefix is added

### DIFF
--- a/src/main/java/org/commcare/suite/model/Callout.java
+++ b/src/main/java/org/commcare/suite/model/Callout.java
@@ -72,8 +72,8 @@ public class Callout implements Externalizable, DetailTemplate {
         while (keys.hasMoreElements()) {
             String key = (String)keys.nextElement();
             boolean overridePlainTextAssumption = key.startsWith(OVERRIDE_PLAIN_TEXT_ASSUMPTION_PREFIX);
-            key = key.replace(OVERRIDE_PLAIN_TEXT_ASSUMPTION_PREFIX, "");
             String rawValue = extras.get(key);
+            key = key.replace(OVERRIDE_PLAIN_TEXT_ASSUMPTION_PREFIX, "");
 
             if (assumePlainTextValues && !overridePlainTextAssumption) {
                 evaluatedExtras.put(key, rawValue);


### PR DESCRIPTION
Earlier we were trying to get the extra value after removing the prefix `cc:xpath_key:` from key which will always give null value when `cc:xpath_key:` is added to the key. 