### PR TITLE
Fixes bug with Callout key force_xpath_parsing

### DIFF
--- a/src/main/java/org/commcare/suite/model/Callout.java
+++ b/src/main/java/org/commcare/suite/model/Callout.java
@@ -73,16 +73,18 @@ public class Callout implements Externalizable, DetailTemplate {
         Enumeration keys = extras.keys();
         while (keys.hasMoreElements()) {
             String key = (String)keys.nextElement();
-            String rawValue = extras.get(key);
-            if (assumePlainTextValues && !forceXpathParsing) {
-                evaluatedExtras.put(key, rawValue);
-            } else {
-                try {
-                    String evaluatedValue =
-                            FunctionUtils.toString(XPathParseTool.parseXPath(rawValue).eval(context));
-                    evaluatedExtras.put(key, evaluatedValue);
-                } catch (XPathSyntaxException e) {
-                    // do nothing
+            if (!key.contentEquals(KEY_FORCE_XPATH_PARSING)) {
+                String rawValue = extras.get(key);
+                if (assumePlainTextValues && !forceXpathParsing) {
+                    evaluatedExtras.put(key, rawValue);
+                } else {
+                    try {
+                        String evaluatedValue =
+                                FunctionUtils.toString(XPathParseTool.parseXPath(rawValue).eval(context));
+                        evaluatedExtras.put(key, evaluatedValue);
+                    } catch (XPathSyntaxException e) {
+                        // do nothing
+                    }
                 }
             }
         }
@@ -98,7 +100,6 @@ public class Callout implements Externalizable, DetailTemplate {
             String key = (String)keys.nextElement();
             if (key.contentEquals(KEY_FORCE_XPATH_PARSING)) {
                 String forceXpathVal = extras.get(key);
-                extras.remove(key);
                 return forceXpathVal.contentEquals(KEY_FORCE_XPATH_PARSING_VALUE_TRUE);
             }
         }


### PR DESCRIPTION
Another silly mistake :( Since function `forceXpathParsing ` removed the key 'force_xpath_parsing' as soon as it found it, if user goes out of the case list and come back in  `forceXpathParsing ` doesn't encounter they key `force_xpath_parsing` this time and hence the scan fails. 