### PR TITLE
Temporary Fix for Improper Case Sync Algorithm

### DIFF
--- a/src/main/java/org/commcare/cases/util/CasePurgeFilter.java
+++ b/src/main/java/org/commcare/cases/util/CasePurgeFilter.java
@@ -214,6 +214,11 @@ public class CasePurgeFilter extends EntityFilter<Case> {
             }
         }
 
+        //NOTE: There is no currently 'safe' number of times to execute these two propagations that
+        //will properly cover the graph, this is a short-term fix for covering the most common
+        //cases.
+        propagateMarkToDAG(g, true, STATUS_ALIVE, STATUS_ALIVE);
+        propagateMarkToDAG(g, false, STATUS_ALIVE, STATUS_ALIVE, CaseIndex.RELATIONSHIP_EXTENSION, true);
         propagateMarkToDAG(g, true, STATUS_ALIVE, STATUS_ALIVE);
         propagateMarkToDAG(g, false, STATUS_ALIVE, STATUS_ALIVE, CaseIndex.RELATIONSHIP_EXTENSION, true);
     }

--- a/src/test/resources/case_relationship_tests.json
+++ b/src/test/resources/case_relationship_tests.json
@@ -851,7 +851,7 @@
         ]
     },
     {
-        "name": "reach_tests",
+        "name": "reach_tests_subcase",
         "owned": [
             "claim"
         ],
@@ -859,7 +859,6 @@
             "p_mother"
         ],
         "subcases": [
-
             ["p_child", "p_mother"]
         ],
         "extensions": [
@@ -873,5 +872,98 @@
         "outcome": [
             "claim", "house", "p_mother", "p_child", "child_health", "measurement"
         ]
+    },
+    {
+        "name": "reach_tests_extension",
+        "owned": [
+            "claim"
+        ],
+        "closed": [
+            "p_mother"
+        ],
+        "subcases": [
+
+        ],
+        "extensions": [
+            ["claim", "house"],
+            ["p_mother", "house"],
+            ["p_child", "house"],
+            ["p_child", "p_mother"],
+            ["child_health", "p_child"],
+            ["measurement", "child_health"]
+        ],
+        "outcome": [
+            "claim", "house", "p_mother", "p_child", "child_health", "measurement"
+        ]
+    },
+    {
+        "name": "reach_tests_subcase_both_closed",
+        "owned": [
+            "claim"
+        ],
+        "closed": [
+            "p_mother",
+            "p_child"
+        ],
+        "subcases": [
+            ["p_child", "p_mother"]
+        ],
+        "extensions": [
+            ["claim", "house"],
+            ["p_mother", "house"],
+            ["p_child", "house"],
+
+            ["child_health", "p_child"],
+            ["measurement", "child_health"]
+        ],
+        "outcome": [
+            "claim", "house"
+        ]
+    },
+    {
+        "name": "reach_tests_extension_both_closed",
+        "owned": [
+            "claim"
+        ],
+        "closed": [
+            "p_mother",
+            "p_child"
+        ],
+        "subcases": [
+
+        ],
+        "extensions": [
+            ["claim", "house"],
+            ["p_mother", "house"],
+            ["p_child", "house"],
+            ["p_child", "p_mother"],
+            ["child_health", "p_child"],
+            ["measurement", "child_health"]
+        ],
+        "outcome": [
+            "claim", "house"
+        ]
+    },
+    {
+        "name": "alternating_propogation",
+        "owned": [
+            "L"
+        ],
+        "closed": [
+
+        ],
+        "subcases": [
+
+        ],
+        "extensions": [
+            ["L", "B"],
+            ["C", "B"],
+            ["C", "D"],
+            ["E", "D"]
+        ],
+        "outcome": [
+            "L", "B", "C", "D", "E"
+        ]
     }
+
 ]

--- a/src/test/resources/case_relationship_tests.json
+++ b/src/test/resources/case_relationship_tests.json
@@ -849,5 +849,29 @@
         "outcome": [
             "a", "b"
         ]
+    },
+    {
+        "name": "reach_tests",
+        "owned": [
+            "claim"
+        ],
+        "closed": [
+            "p_mother"
+        ],
+        "subcases": [
+
+            ["p_child", "p_mother"]
+        ],
+        "extensions": [
+            ["claim", "house"],
+            ["p_mother", "house"],
+            ["p_child", "house"],
+
+            ["child_health", "p_child"],
+            ["measurement", "child_health"]
+        ],
+        "outcome": [
+            "claim", "house", "p_mother", "p_child", "child_health", "measurement"
+        ]
     }
 ]


### PR DESCRIPTION
The case sync algorithm currently fails to propagate tags across alternating applications of the rules, meaning that some topologies that are in occasional use don't match up with HQ's implementation (see the "alternating_propogation" example in the new tests).

This doesn't fix that directly, but is a quick / temporary fix for the most common layouts until we can apply a real fix.