### PR TITLE
Pass UnResolvedResourceExceptions during install to calling function

### DIFF
--- a/src/main/java/org/commcare/resources/model/ResourceTable.java
+++ b/src/main/java/org/commcare/resources/model/ResourceTable.java
@@ -391,6 +391,8 @@ public class ResourceTable {
                             invalidResourceException = e;
                         } catch (UnreliableSourceException use) {
                             unreliableSourceException = use;
+                        } catch (UnresolvedResourceException ure) {
+                            unresolvedResourceException = ure;
                         }
                         if (handled) {
                             recordSuccess(r);
@@ -428,8 +430,8 @@ public class ResourceTable {
             } else if (unreliableSourceException == null) {
                 // no particular failure to point our finger at.
                 throw new UnresolvedResourceException(r,
-                        "No external or local definition could be found for resource " +
-                                r.getResourceId());
+                        "No external or local definition could be found for resource " + r.getDescriptor()
+                                + " with id " + r.getResourceId());
             } else {
                 // Expose the lossy failure rather than the generic one
                 throw unreliableSourceException;

--- a/src/main/java/org/commcare/resources/model/ResourceTable.java
+++ b/src/main/java/org/commcare/resources/model/ResourceTable.java
@@ -367,6 +367,7 @@ public class ResourceTable {
 
         UnreliableSourceException unreliableSourceException = null;
         InvalidResourceException invalidResourceException = null;
+        UnresolvedResourceException unresolvedResourceException = null;
 
         boolean handled = false;
 
@@ -413,6 +414,8 @@ public class ResourceTable {
                     // Continue until no resources can be found.
                 } catch (UnreliableSourceException use) {
                     unreliableSourceException = use;
+                } catch (UnresolvedResourceException ure) {
+                    unresolvedResourceException = ure;
                 }
             }
         }
@@ -420,6 +423,8 @@ public class ResourceTable {
         if (!handled) {
             if (invalidResourceException != null) {
                 throw invalidResourceException;
+            } else if (unresolvedResourceException != null) {
+                throw unresolvedResourceException;
             } else if (unreliableSourceException == null) {
                 // no particular failure to point our finger at.
                 throw new UnresolvedResourceException(r,


### PR DESCRIPTION
Not sure if it was intentional though the original UnResolvedResourceException thrown from the individual installers `install` was never making up to the calling Activity and hence was not getting shown in error message. 

cross-request: https://github.com/dimagi/commcare-android/pull/2060