### PR TITLE
Mimicks parent for all up to date resources during update

### DIFF
--- a/src/main/java/org/commcare/resources/model/Resource.java
+++ b/src/main/java/org/commcare/resources/model/Resource.java
@@ -265,6 +265,7 @@ public class Resource implements Persistable, IMetaData {
         this.id = source.id;
         this.recordId = source.recordId;
         this.descriptor = source.descriptor;
+        this.parent = source.parent;
     }
 
     public String getDescriptor() {


### PR DESCRIPTION
Fixes a bug where after an update, already up to date resources in that update loose right parent guilds. 

@ctsims  This turned out to be pretty easy. I didnt realise earlier that we already are mimicking up to date resources in update table. 