### PR TITLE
Fix for Broken optimization path on indexed fixtures

### DIFF
--- a/src/main/java/org/commcare/cases/util/StorageBackedTreeRoot.java
+++ b/src/main/java/org/commcare/cases/util/StorageBackedTreeRoot.java
@@ -286,7 +286,7 @@ public abstract class StorageBackedTreeRoot<T extends AbstractTreeElement> imple
                                                     QueryContext currentQueryContext) throws IllegalArgumentException {
         int numKeysToProcess = this.getNumberOfBatchableKeysInProfileSet(profiles);
 
-        if(numKeysToProcess == -1) {
+        if(numKeysToProcess  < 1) {
             throw new IllegalArgumentException("No optimization path found for optimization type");
         }
 

--- a/src/main/java/org/javarosa/core/model/instance/utils/FormLoadingUtils.java
+++ b/src/main/java/org/javarosa/core/model/instance/utils/FormLoadingUtils.java
@@ -1,5 +1,6 @@
 package org.javarosa.core.model.instance.utils;
 
+import org.javarosa.core.io.StreamsUtil;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.xml.ElementParser;
@@ -38,9 +39,7 @@ public class FormLoadingUtils {
                 throw new IOException(e.getMessage());
             }
         } finally {
-            if (is != null) {
-                is.close();
-            }
+            StreamsUtil.closeStream(is);
         }
     }
 }

--- a/src/main/java/org/javarosa/core/model/instance/utils/FormLoadingUtils.java
+++ b/src/main/java/org/javarosa/core/model/instance/utils/FormLoadingUtils.java
@@ -27,13 +27,20 @@ public class FormLoadingUtils {
 
     public static TreeElement xmlToTreeElement(String xmlFilepath)
             throws InvalidStructureException, IOException {
-        InputStream is = FormLoadingUtils.class.getResourceAsStream(xmlFilepath);
-        TreeElementParser parser = new TreeElementParser(ElementParser.instantiateParser(is), 0, "instance");
-
+        InputStream is = null;
         try {
-            return parser.parse();
-        } catch (UnfullfilledRequirementsException | XmlPullParserException e) {
-            throw new IOException(e.getMessage());
+            is = FormLoadingUtils.class.getResourceAsStream(xmlFilepath);
+            TreeElementParser parser = new TreeElementParser(ElementParser.instantiateParser(is), 0, "instance");
+
+            try {
+                return parser.parse();
+            } catch (UnfullfilledRequirementsException | XmlPullParserException e) {
+                throw new IOException(e.getMessage());
+            }
+        } finally {
+            if (is != null) {
+                is.close();
+            }
         }
     }
 }

--- a/src/test/java/org/commcare/fixtures/test/IndexedFixtureTests.java
+++ b/src/test/java/org/commcare/fixtures/test/IndexedFixtureTests.java
@@ -109,5 +109,13 @@ public class IndexedFixtureTests {
 
     }
 
+    @Test
+    public void queryInSetLookup() throws XPathSyntaxException, UnfullfilledRequirementsException,
+            XmlPullParserException, IOException, InvalidStructureException {
+        ParseUtils.parseIntoSandbox(getClass().getResourceAsStream("/indexed-fixture-with-keys.xml"), sandbox);
 
+        EvaluationContext ec =
+                MockDataUtils.buildContextWithInstance(sandbox, "products", CaseTestUtils.FIXTURE_INSTANCE_PRODUCT);
+        CaseTestUtils.xpathEvalAndAssert(ec, "sort(join(' ', instance('products')/products/product[selected('a6d16035b98f6f962a6538bd927cefb3 31ab899368d38c2d0207fe80c00fb8c1', @id)]/name))", "CU DIU");
+    }
 }

--- a/src/test/resources/indexed-fixture-with-keys.xml
+++ b/src/test/resources/indexed-fixture-with-keys.xml
@@ -1,0 +1,40 @@
+<OpenRosaResponse>
+    <message nature="ota_restore_success">Successfully restored account test!</message>
+    <schema id="commtrack:products">
+        <indices>
+            <index>@id</index>
+        </indices>
+    </schema>
+    <fixture id="commtrack:products" indexed="true">
+        <products>
+            <product id="f895be4959f9a8a66f57c340aac461b4">
+                <name>Collier</name>
+                <code>col</code>
+                <description>Collier du cycle mensuel</description>
+                <program_id>31ab899368d38c2d0207fe80c00fc3f3</program_id>
+                <cost>152</cost>
+            </product>
+            <product id="a6d16035b98f6f962a6538bd927cefb3">
+                <name>CU</name>
+                <code>pd</code>
+                <description>La contraception d'urgence</description>
+                <program_id>31ab899368d38c2d0207fe80c00fc3f3</program_id>
+                <cost>57</cost>
+            </product>
+            <product id="31ab899368d38c2d0207fe80c00fa96c">
+                <name>Depo-Provera</name>
+                <code>dp</code>
+                <description>Injectable</description>
+                <program_id>31ab899368d38c2d0207fe80c00fc3f3</program_id>
+                <cost>152</cost>
+            </product>
+            <product id="31ab899368d38c2d0207fe80c00fb8c1">
+                <name>DIU</name>
+                <code>diu</code>
+                <description>TCU 380A</description>
+                <program_id>31ab899368d38c2d0207fe80c00fc3f3</program_id>
+                <cost>380</cost>
+            </product>
+        </products>
+    </fixture>
+</OpenRosaResponse>


### PR DESCRIPTION
The `[selected(list, indexed_reference)]` predicate is coded to be optimizable for case index lookups. That predicate's existence is breaking the optimization route when it doesn't get used due to a bug in processing.

The attached test replicates the bug.

Useful to fix in 2.45, because REACH likely will be using this reference pattern.