### PR TITLE
Replaced ex type from IllegalArgumentEx to XPathEx

### DIFF
--- a/src/main/java/org/javarosa/core/model/data/helper/Selection.java
+++ b/src/main/java/org/javarosa/core/model/data/helper/Selection.java
@@ -22,6 +22,7 @@ import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.Externalizable;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.javarosa.xpath.XPathException;
 import org.javarosa.xpath.XPathTypeMismatchException;
 
 import java.io.DataInputStream;
@@ -121,7 +122,7 @@ public class Selection implements Externalizable {
         if (xmlValue != null && xmlValue.length() > 0) {
             return xmlValue;
         } else {
-            throw new IllegalArgumentException("Invalid XML Value for Select Option");
+            throw new XPathException("Invalid XML Value for Select Option");
         }
     }
 


### PR DESCRIPTION
Replaced exception type to XPath so it could be handled in FormEntityActivity  
This is fix for app crashing when repeat group reads empty node.
Jira ticket: https://dimagi-dev.atlassian.net/browse/MOB-55