### PR TITLE
Fix for Short Cycle Detection Algorithm

### DIFF
--- a/src/main/java/org/javarosa/core/util/ShortestCycleAlgorithm.java
+++ b/src/main/java/org/javarosa/core/util/ShortestCycleAlgorithm.java
@@ -30,8 +30,10 @@ public class ShortestCycleAlgorithm {
     public ShortestCycleAlgorithm(Vector<TreeReference[]> edges) {
         this.edges = edges;
         for (TreeReference[] references: edges) {
-            String parentKey = references[0].toString();
-            String childKey = references[1].toString();
+
+            String parentKey = references[1].toString();
+            String childKey = references[0].toString();
+
             addChild(parentKey, childKey);
             if (!nodes.contains(parentKey)) {
                 nodes.add(parentKey);
@@ -115,15 +117,33 @@ public class ShortestCycleAlgorithm {
         for (int i = 0; i < shortestCycle.size(); i++) {
             stringBuilder.append(shortestCycle.get(i));
             if (i == shortestCycle.size() - 1) {
-                stringBuilder.append(" is referenced by ");
+                stringBuilder.append(" references ");
                 stringBuilder.append(shortestCycle.get(0));
                 stringBuilder.append(".");
             } else {
-                stringBuilder.append( " is referenced by " );
+                stringBuilder.append( " references " );
                 stringBuilder.append(shortestCycle.get(i + 1));
                 stringBuilder.append( ", \n" );
             }
         }
         return stringBuilder.toString();
+    }
+
+    private String toDOTDigraph() {
+        String graph ="";
+        for(TreeReference[] edge : edges){
+            //graph += clean(edge[0].toString(false)) + " -> " + clean(edge[1].toString(false)) + ";\n";
+            graph += clean(edge[1].toString(false)) + " -> " + clean(edge[0].toString(false)) + ";\n";
+        }
+
+        return "digraph G{\n" + graph + "\n}";
+    }
+
+    private String clean(String input) {
+        return input.replaceAll("/", "").
+                replaceAll("-", "_").
+                replaceAll("\\(", "").
+                replaceAll("\\)", "").
+                replaceAll("@", "");
     }
 }

--- a/src/main/java/org/javarosa/core/util/ShortestCycleAlgorithm.java
+++ b/src/main/java/org/javarosa/core/util/ShortestCycleAlgorithm.java
@@ -129,11 +129,14 @@ public class ShortestCycleAlgorithm {
         return stringBuilder.toString();
     }
 
+    /**
+     * @return a GraphViz Digraph (DOT engine) which will visualize the dependencies between the
+     * edges. Helpful for debugging
+     */
     private String toDOTDigraph() {
         String graph ="";
         for(TreeReference[] edge : edges){
-            //graph += clean(edge[0].toString(false)) + " -> " + clean(edge[1].toString(false)) + ";\n";
-            graph += clean(edge[1].toString(false)) + " -> " + clean(edge[0].toString(false)) + ";\n";
+            graph += clean(edge[0].toString(false)) + " -> " + clean(edge[1].toString(false)) + ";\n";
         }
 
         return "digraph G{\n" + graph + "\n}";

--- a/src/main/java/org/javarosa/xform/parse/XFormParser.java
+++ b/src/main/java/org/javarosa/xform/parse/XFormParser.java
@@ -2839,7 +2839,7 @@ public class XFormParser {
         if (!acyclic) {
             String errorMessage = new ShortestCycleAlgorithm(edges).getCycleErrorMessage();
             reporter.error(errorMessage);
-            throw new RuntimeException(errorMessage);
+            throw new XFormParseException(errorMessage);
         }
     }
 

--- a/src/test/java/org/javarosa/core/model/test/CyclicReferenceTests.java
+++ b/src/test/java/org/javarosa/core/model/test/CyclicReferenceTests.java
@@ -32,4 +32,23 @@ public class CyclicReferenceTests {
         }
         fail("Cyclical reference did not throw XFormParseException");
     }
+
+    /**
+     * Test that XPath cyclic reference that references parent throws usable error
+     */
+    @Test
+    public void testCyclicalReferenceRegression() {
+        try {
+            new FormParseInit("/xform_tests/real_form_with_cycle_errors.xml");
+        } catch (XFormParseException e) {
+            String detailMessage = e.getMessage();
+            // Assert that we're using the shortest cycle algorithm
+            assertTrue(detailMessage.contains("Shortest Cycle"));
+            // There should only be three newlines since only the three core cyclic references were included
+            int newlineCount = detailMessage.length() - detailMessage.replace("\n", "").length();
+            assertTrue(newlineCount == 4);
+            return;
+        }
+        fail("Cyclical reference did not throw XFormParseException");
+    }
 }

--- a/src/test/resources/xform_tests/real_form_with_cycle_errors.xml
+++ b/src/test/resources/xform_tests/real_form_with_cycle_errors.xml
@@ -1,0 +1,7060 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Registo e Testagem da Família</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/60b3230473d96a8b00ad0e11144b52a6e31b6cf6" uiVersion="1" version="1" name="Registo e Testagem da Família">
+					<consentimento_registo />
+					<referecencia_gps />
+					<consentimento_sim>
+						<registro_de_conviventes>
+							<patient_information>
+								<lbl_confirmar_informacao />
+								<paciente_index />
+								<apelido />
+								<nome_primero />
+								<genero />
+								<data_de_nacimento_conhecido />
+								<data_do_nacimento />
+								<idade_perguntar />
+								<question1>
+									<display_idade_meses />
+									<display_idade_anos />
+									<lbl_breasfeeding_child />
+								</question1>
+								<confirmacao_da_gravidez>
+									<nova_gravidez />
+									<tem_edd />
+									<edd />
+								</confirmacao_da_gravidez>
+								<confirmacao_da_lactancia>
+									<nova_lactancia />
+								</confirmacao_da_lactancia>
+								<gravida />
+								<lactante />
+								<estado_civil />
+								<escolaridade />
+								<ocupacao />
+								<ocupacao_outro />
+								<nome_empresa />
+								<grau_de_parentesco />
+								<parceiro_fora_da_casa_perguntar  />
+								<sexual_partner_info>
+									<num_parceiros_fora_casa />
+									<register_info_sexual_lbl />
+								</sexual_partner_info>
+								<parceiro_fora_da_casa_endereco />
+								<parceiro_fora_da_casa />
+								<partner_of_hiv_index />
+								<outro_grau_de_parentesco />
+								<tem_numero_de_telefone />
+								<telefone />
+								<consentimento_menor_15_anos />
+								<numero_conviventes />
+								<num_parceiros />
+								<numero_conviventes_under5 />
+								<numero_conviventes_5_to_14 />
+								<numero_de_filhos />
+							</patient_information>
+							<address />
+							<sexual_partner_or_community_member>
+								<numero_conviventes />
+								<num_parceiros />
+								<numero_conviventes_under5 />
+								<numero_conviventes_5_to_14 />
+								<filhos_fora_hh>
+									<children_living_outside_the_hh />
+									<number_of_children_living_outside_the_house />
+									<lbl_counsel />
+								</filhos_fora_hh>
+							</sexual_partner_or_community_member>
+							<o_paciente__sexualmente_activo />
+							<tipo_de_sexo />
+							<relacoes_mesmo_sexo />
+							<o_paciente_tem_mais_de_um_parceiro_sexual />
+							<alguma_vez_foi_solicitado_a_ter_relaes_sexuais_com_algum_em_troca_de_dinhei />
+							<consome_bebidas_alcolicas />
+							<que_tipo_costuma_consumir />
+							<consome_outras_drogas />
+							<frequencia_drogas />
+							<testagem_para_adultos>
+								<indique_os_factores_de_risco_que_o_paciente_apresenta />
+								<sintomas />
+								<outro />
+								<adult_at_risk />
+								<este__um_adulto_em_risco_e_deve_ser_testado />
+							</testagem_para_adultos>
+							<testagem_hiv_para_key_population>
+								<homens_que_fazem_sexo_com_homens>
+									<produto_lubrificacao />
+									<tipo_lubricador />
+									<sabe_sobre_HIV />
+									<sabe_prevenir />
+									<acredita_HIV />
+									<disieases />
+									<procurou_tratamento />
+									<homens_que_tem_sexo_homens />
+									<este_peciente_est_em_risco_e_deve_ser_testado_pois_apresenta_factores_de_ho />
+								</homens_que_fazem_sexo_com_homens>
+								<question46>
+									<txt_reaction />
+									<ja_ouviu_falar_de_its_hiv />
+									<sabe_como_se_prevenir_para_no_contrair />
+									<usa_o_preservativo_com_os_clientes_e_tambm_com_seu_parceiro />
+									<usa_em_todas_as_practicas_sexuais />
+									<produto_lubrificacao />
+									<tipo_lubricador />
+									<onde_tem_praticado_sua_actividade_como_trabalhadora />
+									<trabalhadora_de_sexo />
+									<esta_paciente__trabalhadora_de_sexo_e_deve_ser_testada />
+								</question46>
+								<testagem_para_pessoas_que_usam_e_injetam_drogas>
+									<relation_after_drugs />
+									<usa_preservativo_durante_as_suas_relacoes_sxuais />
+									<usa_drogas_injectaveis />
+									<com_que_frequencia_usa_estas_drogas />
+									<j_partilhou_agulhas_ou_seringas />
+									<acha_que_alguem_que_usa_drogas_injectaveis_corre_risco_de_contrair_o_hiv />
+									<usa_injecta_drogas />
+									<este_paciente_faz_o_uso_de_drogas_e_deve />
+								</testagem_para_pessoas_que_usam_e_injetam_drogas>
+							</testagem_hiv_para_key_population>
+							<teste_consentido>
+								<pre-test_assessment>
+									<testagem_crianca_maior_de_18>
+										<mae_viva_presente />
+										<documentation />
+										<pedir_cartao />
+										<seroestado_conhecido />
+										<seroestado_da_mae />
+										<crianca_em_seguimento />
+										<child_of_seropositivo_mother  />
+										<child_at_risk />
+										<internada_ultimos_6meses />
+										<lesao_ultimos_6meses />
+										<severe_health_issues />
+									</testagem_crianca_maior_de_18>
+									<testagem_para_hiv_de_adolescente_10-18_anos>
+										<mae_viva_presente />
+										<hospitalised_6months />
+										<o_paciente_teve_uma_leso_extensa_que_no_melhora_com_o_tratamento />
+										<nos_ultimos_3_meses_teve_algum_problema_de_saude_persistente_como_perda_de_ />
+										<o_paciente_tem_corrimento />
+										<o_paciente_tem_um_dos_seguintes_problemas />
+										<adolescente_risco />
+										<este_adolescente_est_em_risco_e_deve_ser_testado />
+									</testagem_para_hiv_de_adolescente_10-18_anos>
+									<patient_questions>
+										<testado_hiv_vez />
+										<testar_na_us />
+										<fez_pcr />
+										<resultado_previo_hiv />
+										<child_still_breastfeeding />
+										<mai_parou_amamentar />
+										<child_risk_evaluated />
+										<tem_nid />
+										<nid />
+										<testado_por_hiv_recente />
+										<data_ultimo_teste_hiv />
+										<restagem_3_meses />
+										<em_tratamento_hiv />
+										<em_seguimento_ccr />
+										<should_be_tested />
+										<lbl_no_test />
+										<contact_doesnt_require_test />
+										<test_patient_anyway />
+										<reason_to_test_hiv />
+										<querer_testar />
+										<si_nao />
+										<activista_capacitado_testagem />
+										<referir_para_teste />
+									</patient_questions>
+									<outcomes>
+										<referir_e_aconselhar />
+										<referir_crianca_ccr />
+										<aconselhado_adesao />
+										<aconselhado_saude_infantil />
+										<aconselhado_negativo />
+									</outcomes>
+								</pre-test_assessment>
+								<testagem_HIV>
+									<testagem_hiv_pasos>
+										<ver_os_pasos_test1 />
+										<teste_1>
+											<preparacao>
+												<reunir_itens />
+												<tira_teste />
+												<rotule_cartao />
+												<remover_cobertura />
+											</preparacao>
+											<colhendo_amostra>
+												<colhar_amostra />
+											</colhendo_amostra>
+											<aplicando_amostra>
+												<aplicar_amostra />
+												<sangue_total />
+											</aplicando_amostra>
+											<obtener_resultados>
+												<tempo_resultados />
+												<registrar_resultados />
+											</obtener_resultados>
+											<interpretacao_teste />
+										</teste_1>
+										<resultado_teste_rapido_determine />
+										<Quer_ver_os_pasos />
+										<teste_2>
+											<unigold_preparacao>
+												<unigold_reunir_itens />
+											</unigold_preparacao>
+											<unigold_dispositivo_embalagem />
+											<unigold_colhendo_amostra>
+												<unigold_colhar_amostra />
+											</unigold_colhendo_amostra>
+											<unigold_aplicando_amostra>
+												<unigold_aplicar_amostra />
+												<unigold_sangue_total />
+											</unigold_aplicando_amostra>
+											<obtener_resultados>
+												<tempo_resultados />
+												<registrar_resultados />
+											</obtener_resultados>
+											<interpretacao_teste />
+										</teste_2>
+										<resultado_teste_rapido_unigold />
+										<resultado_final>
+											<display_resultado_do_teste_rapido />
+											<resultado_indeterminado_repetir />
+										</resultado_final>
+										<resultado_do_teste_rapido />
+									</testagem_hiv_pasos>
+									<testagem_hiv_pasos2>
+										<ver_os_pasos_test1 />
+										<teste_1>
+											<preparacao>
+												<reunir_itens />
+												<tira_teste />
+												<rotule_cartao />
+												<remover_cobertura />
+											</preparacao>
+											<colhendo_amostra>
+												<colhar_amostra />
+											</colhendo_amostra>
+											<aplicando_amostra>
+												<aplicar_amostra />
+												<sangue_total />
+											</aplicando_amostra>
+											<obtener_resultados>
+												<tempo_resultados />
+												<registrar_resultados />
+											</obtener_resultados>
+											<interpretacao_teste />
+										</teste_1>
+										<resultado_teste_rapido_determine />
+										<Quer_ver_os_pasos />
+										<teste_2>
+											<unigold_preparacao>
+												<unigold_reunir_itens />
+											</unigold_preparacao>
+											<unigold_dispositivo_embalagem />
+											<unigold_colhendo_amostra>
+												<unigold_colhar_amostra />
+											</unigold_colhendo_amostra>
+											<unigold_aplicando_amostra>
+												<unigold_aplicar_amostra />
+												<unigold_sangue_total />
+											</unigold_aplicando_amostra>
+											<obtener_resultados>
+												<tempo_resultados />
+												<registrar_resultados />
+											</obtener_resultados>
+											<interpretacao_teste />
+										</teste_2>
+										<resultado_teste_rapido_unigold />
+										<resultado_final>
+											<display_resultado_do_teste_rapido />
+											<indeterminado_segunda />
+										</resultado_final>
+										<resultado_do_teste_rapido_2 />
+									</testagem_hiv_pasos2>
+									<couseling>
+										<aconselhamento_pos />
+									</couseling>
+									<tests_used>
+										<numero_testes_determine />
+										<numero_testes_determine_coregir />
+										<numero_testes_unigold />
+										<numero_testes_unigold_coregir />
+									</tests_used>
+									<referencia>
+										<resultado_negativo_referral />
+										<referir_adulto />
+										<referir_crianca />
+										<referir_mae_crianca />
+										<pos_seguimento />
+										<neg_crianca_testado />
+									</referencia>
+									<test_ownership>
+										<chw_testagem />
+										<activista_fez_testagem_hiv />
+										<tem_numero_de_telefone />
+										<telefone />
+									</test_ownership>
+								</testagem_HIV>
+								<rastreio_tb>
+									<rastreio_tb_display />
+									<antes_de_comenar_o_rastreio_lembre-se_d_en />
+									<ja_em_tratamento />
+									<verificar_adesao />
+									<nit />
+									<contacto_ultimo_ano />
+									<sintomas_menos_15 />
+									<sintomas_mas_15 />
+									<symptoms_details>
+										<cough />
+										<cough_with_blood />
+										<fever />
+										<lost_weight />
+										<fatigue />
+										<night_sweating />
+										<diarrhea />
+									</symptoms_details>
+									<tb_screening_result>
+										<referido_rastreio_tb />
+										<lbl_refer_exposed_child_tb />
+										<hiv_exposed />
+										<lbl_tb_symptoms />
+									</tb_screening_result>
+									<referido_rastreio_tb>
+										<instruccoes_frascos />
+										<instruccoes />
+									</referido_rastreio_tb>
+									<escarro>
+										<question9 />
+									</escarro>
+									<patient_received_container />
+									<not_received_container />
+									<tb_properties>
+										<tb_patient_in_household />
+										<tb_positivo />
+										<coinfectado />
+										<crianca_exposta_tb  />
+										<hiv_exposto_tb />
+										<sintomas_clinicos_tb />
+										<patient_for_tpi />
+										<patient_needs_tpi  />
+										<rastreio_positivo_tb  />
+										<first_observation_date />
+										<second_observation_date />
+										<third_observation_date />
+										<resultado_tb />
+										<patient_on_tpi />
+										<data_rastreio_tb />
+									</tb_properties>
+								</rastreio_tb>
+							</teste_consentido>
+						</registro_de_conviventes>
+					</consentimento_sim>
+					<referrals>
+						<required_referrals>
+							<list_required_referrals>
+								<referir_paciente />
+								<lbl_hiv_indeterminate />
+								<lbl_new_pregnancy />
+								<lbl_new_breastfeeding />
+								<lbl_tb_hiv_positive />
+								<lbl_refer_for_ccr />
+								<lbl_refer_child_pos_tb_screening  />
+								<pacinete_para_testar_na_unidade_sanitria />
+								<lbl_iniciar_tarv  />
+								<resultado_negativo_referral />
+								<pos_seguimento  />
+								<neg_crianca_testado />
+								<lbl_tb_positive />
+								<lbl_refer_hiv_for_tpi />
+								<lbl_refer_exposed_child_tb />
+								<hiv_exposed />
+								<lbl_tb_symptoms />
+							</list_required_referrals>
+							<fez_referencia />
+							<does_patients_name_accepts_to_receive_care_at_chw_hf_name />
+							<preferred_health_facility_grp>
+								<hf_to_refer_province  />
+								<hf_health_facility  />
+								<hf_selected_partner_ids />
+								<chw_current_province />
+								<current_chw_partner_id />
+								<selected_hf_has_current_partner />
+								<lbl_transfer_to_current_chw_partner />
+								<select_partner />
+								<selected_hf_partner />
+								<lbl_no_partner_in_hf />
+								<close_case_no_partner_hf  />
+								<current_chw_province_code />
+								<patiient_chose_other_hf />
+							</preferred_health_facility_grp>
+							<consentimento_busca_activa />
+							<intentar_convencer />
+							<test>
+								<test_data_de_referencia />
+								<test_data_proxima_visita />
+							</test>
+						</required_referrals>
+						<no_referrals>
+							<outras_referencias />
+							<outra_doenca />
+						</no_referrals>
+					</referrals>
+					<contacts_registration_concent />
+					<register_conviventes_during_visit />
+					<hh_reg>
+						<mais_conviventes />
+						<confirmar_registo_conviventes_completo />
+					</hh_reg>
+					<display_new_convivente />
+					<data>
+						<referencia>
+							<referido />
+							<data_de_referencia />
+							<referido_por />
+							<nome_da_referencia />
+							<referencia_aberto />
+							<refer_to_us />
+							<numero_de_referencias />
+							<owner_id  />
+							<health_facility_referral_crianza_menos_18_meses  />
+							<ba_referido_filtro />
+							<referido_tb />
+							<household_name />
+							<create_ref />
+							<transfer_status />
+							<transferral />
+							<cases_transfer />
+						</referencia>
+						<geral>
+							<next_form />
+							<nome />
+							<apelido />
+							<chegado_a_us />
+							<estado_tarv />
+							<idade_calc />
+							<idade_meses />
+							<data_do_nacimento />
+							<close_case  />
+							<indeterminado_hiv_testado />
+							<retestagem />
+							<determine_used_calc />
+							<determine_used_final />
+							<unigold_used_calc />
+							<unigold_used_final />
+							<us />
+							<data_registro_cc />
+							<data_ultimo_teste_hiv />
+							<data_ultimo_rastreio_tb  />
+							<paciente_index />
+							<tipo_de_paciente />
+							<nome_concat />
+							<activista_responsavel_paciente />
+							<contact_phone_number />
+							<contact_phone_number_is_verified />
+							<testado_por_hiv_uma_vez  />
+							<testado_durante_visita  />
+							<positivo_hiv_testado  />
+							<hiv_nova_lactancia  />
+							<hiv_nova_gravidez  />
+							<crianca_para_testar  />
+							<iniciar_tarv />
+							<patient_registered />
+							<hiv_positivo  />
+							<localizado />
+							<testado_por_hiv  />
+							<provincia />
+							<distrito />
+							<unidade_sanitaria />
+							<location_id />
+							<motivos_de_nao_testar />
+							<perfil_de_paciente />
+							<index_perfil />
+							<priority />
+							<nego />
+							<age_range1 />
+							<age_range2 />
+							<parceiro_do_index />
+							<import_validated />
+							<familia_directa />
+							<transfer_status />
+						</geral>
+						<busca_activa>
+							<nao_busca_activa />
+							<busca_activa />
+							<a_faltar />
+							<numero_de_faltas />
+						</busca_activa>
+					</data>
+					<casa>
+						<conviventes>
+							<convivente1 />
+							<convivente2 />
+							<convivente3 />
+							<convivente4 />
+							<convivente5 />
+							<convivente6 />
+							<convivente7 />
+							<convivente8 />
+							<convivente9 />
+							<convivente10 />
+							<convivente11 />
+							<convivente12 />
+							<convivente13 />
+							<convivente14 />
+							<convivente15 />
+							<convivente16 />
+							<convivente17 />
+							<convivente18 />
+							<convivente19 />
+							<convivente20 />
+							<close_casa />
+						</conviventes>
+						<testagem>
+							<numero_de_filhos_positivos />
+							<numero_de_filhos_testados />
+							<parceiro_serologia />
+							<parceiro_testado />
+							<num_conviventes_positivos />
+							<num_conviventes_referido />
+							<num_conviventes_testado_positivo />
+							<num_conviventes_testado_hiv />
+							<num_conviventes_registrado />
+							<num_conviventes_rastreado_tb  />
+							<num_conviventes_referido_tb  />
+						</testagem>
+						<index>
+							<registo_de_conviventes_completo />
+							<primera_visita_completo />
+							<registou_convivente />
+							<testou_convivente />
+							<rastreiou_convivente_tb />
+						</index>
+						<nome />
+						<apelido />
+					</casa>
+					<indicators_v4>
+						<rastreado_tb />
+						<ind_rastreio_positivo_tb />
+						<hiv_testado />
+						<testado_hiv_ultimos_3_meses />
+						<ind_positivo_hiv_testado />
+						<resultado_discordante />
+						<ind_patient_for_tpi />
+						<ind_patient_needs_tpi />
+					</indicators_v4>
+					<calendario >
+						<data_proxima_consulta />
+						<visita_numero  />
+						<em_acompanhamento />
+						<data_ultima_visita />
+						<mes />
+					</calendario>
+					<convivente_cascade>
+						<registado />
+						<to_test />
+						<tested />
+						<tested_positive />
+						<should_refer />
+						<referred />
+						<has_nid />
+						<age_range />
+						<prev_positivo_or_pcr />
+					</convivente_cascade>
+					<organizacao />
+					<fgh_needs_visit />
+					<household_name />
+				</data>
+			</instance>
+			<instance src="jr://instance/casedb" id="casedb" />
+			<instance src="jr://instance/session" id="commcaresession" />
+			<instance src="jr://fixture/locations" id="locations" />
+			<instance src="jr://fixture/item-list:health_facility" id="health_facility" />
+			<bind  nodeset="/data/consentimento_registo" required="true()" />
+			<bind  nodeset="/data/referecencia_gps" type="geopoint" />
+			<bind  nodeset="/data/consentimento_sim"  relevant="/data/consentimento_registo = 'sim' or instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/agrees_to_registration = &quot;yes&quot;" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/lbl_confirmar_informacao"  relevant="instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/tipo_de_paciente = &quot;sexual_partner&quot;" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/paciente_index"  calculate="cond(instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/nome != '' or instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/apelido != '', 1, 0)" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/apelido" type="xsd:string" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/nome_primero" type="xsd:string" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/genero" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/data_de_nacimento_conhecido" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/data_do_nacimento" type="xsd:date" constraint=". &lt;= today()" jr:constraintMsg="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/data_do_nacimento-constraintMsg')"  relevant="/data/consentimento_sim/registro_de_conviventes/patient_information/data_de_nacimento_conhecido = 'sim'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/idade_perguntar" type="xsd:int" constraint=". &lt; 99" jr:constraintMsg="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/idade_perguntar-constraintMsg')"  relevant="/data/consentimento_sim/registro_de_conviventes/patient_information/data_de_nacimento_conhecido = 'nao'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/question1" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/question1/display_idade_meses"  relevant="/data/data/geral/idade_meses &lt; 24" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/question1/display_idade_anos"  relevant="/data/data/geral/idade_meses &gt;= 24" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/question1/lbl_breasfeeding_child"  relevant="/data/data/geral/idade_calc &lt;= 3" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez"  relevant="/data/data/geral/idade_calc &gt; 11" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez/nova_gravidez"  relevant="/data/consentimento_sim/registro_de_conviventes/patient_information/genero = 'F'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez/tem_edd"  relevant="/data/consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez/nova_gravidez = 'sim'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez/edd" type="xsd:date" constraint=". &gt; today()"  relevant="/data/consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez/tem_edd = 'sim'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_lactancia"  relevant="/data/consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez/nova_gravidez = 'nao' and /data/data/geral/idade_calc &gt; 11" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_lactancia/nova_lactancia"  relevant="/data/consentimento_sim/registro_de_conviventes/patient_information/genero = 'F'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/gravida"  calculate="if(/data/consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez/nova_gravidez = 'sim', 1, 0)" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/lactante"  calculate="if(/data/consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_lactancia/nova_lactancia = 'sim', 1, 0)" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/estado_civil"  relevant="/data/data/geral/idade_calc &gt; 11" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/escolaridade"  relevant="/data/data/geral/idade_calc &gt; 4" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/ocupacao"  relevant="/data/data/geral/idade_calc &gt; 12" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/ocupacao_outro" type="xsd:string"  relevant="/data/consentimento_sim/registro_de_conviventes/patient_information/ocupacao = 'outro'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/nome_empresa" type="xsd:string"  relevant="/data/consentimento_sim/registro_de_conviventes/patient_information/ocupacao = 'mineiro' or /data/consentimento_sim/registro_de_conviventes/patient_information/ocupacao = 'trab_saude' or /data/consentimento_sim/registro_de_conviventes/patient_information/ocupacao = 'educacao' or /data/consentimento_sim/registro_de_conviventes/patient_information/ocupacao = 'camionista'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/grau_de_parentesco"  constraint="not((. = 'esposo' or . = 'namorado') and /data/data/geral/idade_calc &lt; 12)" jr:constraintMsg="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/grau_de_parentesco-constraintMsg')"  relevant="instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/tipo_de_paciente != 'sexual_partner' and instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/tipo_de_paciente != 'community_member'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/parceiro_fora_da_casa_perguntar" relevant="0" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/sexual_partner_info"  relevant="/data/data/geral/idade_calc &gt; 14" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/sexual_partner_info/num_parceiros_fora_casa" type="xsd:int" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/sexual_partner_info/register_info_sexual_lbl"  relevant="/data/consentimento_sim/registro_de_conviventes/patient_information/sexual_partner_info/num_parceiros_fora_casa &gt; 0" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/parceiro_fora_da_casa_endereco" type="xsd:string"  relevant="/data/consentimento_sim/registro_de_conviventes/patient_information/parceiro_fora_da_casa_perguntar = 'sim'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/parceiro_fora_da_casa"  calculate="if(/data/consentimento_sim/registro_de_conviventes/patient_information/parceiro_fora_da_casa_perguntar = 'sim', 1, 0)" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/partner_of_hiv_index"  calculate="cond(/data/data/geral/index_perfil != 'tb' and (/data/consentimento_sim/registro_de_conviventes/patient_information/grau_de_parentesco = 'namorado' or /data/consentimento_sim/registro_de_conviventes/patient_information/grau_de_parentesco = 'esposo' or instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/registration_reason = &quot;sexual_partner&quot;), 1, 0)" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/outro_grau_de_parentesco" type="xsd:string"  relevant="/data/consentimento_sim/registro_de_conviventes/patient_information/grau_de_parentesco = 'outro'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/tem_numero_de_telefone" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/telefone" type="xsd:string" constraint="regex(., '^[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]$')" jr:constraintMsg="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/telefone-constraintMsg')"  relevant="/data/consentimento_sim/registro_de_conviventes/patient_information/tem_numero_de_telefone = 'sim' or instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/tem_numero_de_telefone = 'sim'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/consentimento_menor_15_anos"  relevant="/data/data/geral/idade_calc &lt; 15" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/numero_conviventes"  relevant="/data/consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes"  calculate="/data/consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/num_parceiros"  calculate="/data/consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/num_parceiros" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/numero_conviventes_under5"  calculate="/data/consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes_under5" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/numero_conviventes_5_to_14"  calculate="/data/consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes_5_to_14" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/patient_information/numero_de_filhos" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/address" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member"  relevant="/data/data/geral/tipo_de_paciente = &quot;convivente&quot;" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/num_parceiros" type="xsd:int"  relevant="/data/data/geral/idade_calc &gt; 12 and /data/consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes &gt; 0" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes_under5" type="xsd:int"  relevant="/data/consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes &gt; 0" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes_5_to_14" type="xsd:int"  relevant="/data/consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes &gt; 0" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/filhos_fora_hh" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/filhos_fora_hh/children_living_outside_the_hh" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/filhos_fora_hh/number_of_children_living_outside_the_house" type="xsd:int"  relevant="/data/consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/filhos_fora_hh/children_living_outside_the_hh = 'yes'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/filhos_fora_hh/lbl_counsel"  relevant="/data/consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/filhos_fora_hh/children_living_outside_the_hh = 'yes'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/o_paciente__sexualmente_activo"  relevant="/data/data/geral/idade_calc &gt;= 18" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/tipo_de_sexo"  relevant="/data/consentimento_sim/registro_de_conviventes/o_paciente__sexualmente_activo = 'sim'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/relacoes_mesmo_sexo" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/o_paciente_tem_mais_de_um_parceiro_sexual"  relevant="/data/consentimento_sim/registro_de_conviventes/o_paciente__sexualmente_activo = 'sim' and /data/data/geral/idade_calc &gt;= 18" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/alguma_vez_foi_solicitado_a_ter_relaes_sexuais_com_algum_em_troca_de_dinhei"  relevant="/data/consentimento_sim/registro_de_conviventes/o_paciente__sexualmente_activo = 'sim'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/consome_bebidas_alcolicas"  relevant="/data/data/geral/idade_calc &gt;= 18" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/que_tipo_costuma_consumir" type="xsd:string"  relevant="/data/consentimento_sim/registro_de_conviventes/consome_bebidas_alcolicas = 'sim'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/consome_outras_drogas"  relevant="/data/data/geral/idade_calc &gt;= 18" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/frequencia_drogas" type="xsd:string"  relevant="/data/consentimento_sim/registro_de_conviventes/consome_outras_drogas = 'sim'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_para_adultos"  relevant="/data/data/geral/idade_calc &gt;= 18 and /data/consentimento_sim/registro_de_conviventes/o_paciente__sexualmente_activo = 'sim'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_para_adultos/indique_os_factores_de_risco_que_o_paciente_apresenta" constraint="if(selected(., 'nenhum'), count-selected(.) = 1, count-selected(.) &gt; 0)" jr:constraintMsg="jr:itext('consentimento_sim/registro_de_conviventes/testagem_para_adultos/indique_os_factores_de_risco_que_o_paciente_apresenta-constraintMsg')" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas" constraint="if(selected(., 'nenhum'), count-selected(.) = 1, count-selected(.) &gt; 0)" jr:constraintMsg="jr:itext('consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-constraintMsg')" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_para_adultos/outro" type="xsd:string"  relevant="/data/consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas = 'outro'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_para_adultos/adult_at_risk"  calculate="if(count-selected(/data/consentimento_sim/registro_de_conviventes/testagem_para_adultos/indique_os_factores_de_risco_que_o_paciente_apresenta) &gt;= 1 or ((/data/consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas &gt;= 1) and not(selected(/data/consentimento_sim/registro_de_conviventes/testagem_para_adultos/indique_os_factores_de_risco_que_o_paciente_apresenta, 'nenhum')) and count-selected(/data/consentimento_sim/registro_de_conviventes/testagem_para_adultos/indique_os_factores_de_risco_que_o_paciente_apresenta) &gt; 0) or (not(selected(/data/consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas, 'nenhum')) and count-selected(/data/consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas) &gt; 0), 1, 0)" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_para_adultos/este__um_adulto_em_risco_e_deve_ser_testado"  relevant="/data/consentimento_sim/registro_de_conviventes/testagem_para_adultos/adult_at_risk = 1" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population"  relevant="/data/consentimento_sim/registro_de_conviventes/o_paciente__sexualmente_activo = 'sim' and /data/data/geral/idade_calc &gt;= 18" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens"  relevant="/data/consentimento_sim/registro_de_conviventes/patient_information/genero = 'M' and /data/consentimento_sim/registro_de_conviventes/tipo_de_sexo = 'anal' and /data/consentimento_sim/registro_de_conviventes/o_paciente__sexualmente_activo = 'sim' and /data/consentimento_sim/registro_de_conviventes/relacoes_mesmo_sexo = 'sim'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/produto_lubrificacao" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/tipo_lubricador" type="xsd:string"  relevant="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/produto_lubrificacao = 'sim'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/sabe_sobre_HIV" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/sabe_prevenir"  relevant="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/sabe_sobre_HIV = 'sim'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/acredita_HIV" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/disieases" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/procurou_tratamento"  relevant="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/disieases = 'sim_en'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/homens_que_tem_sexo_homens"  calculate="if(/data/consentimento_sim/registro_de_conviventes/o_paciente__sexualmente_activo = 'sim' and /data/consentimento_sim/registro_de_conviventes/relacoes_mesmo_sexo = 'sim', 1, 0)" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/este_peciente_est_em_risco_e_deve_ser_testado_pois_apresenta_factores_de_ho"  relevant="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/homens_que_tem_sexo_homens = 1" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46"  relevant="/data/consentimento_sim/registro_de_conviventes/alguma_vez_foi_solicitado_a_ter_relaes_sexuais_com_algum_em_troca_de_dinhei = 'sim'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/txt_reaction" type="xsd:string"  relevant="/data/consentimento_sim/registro_de_conviventes/alguma_vez_foi_solicitado_a_ter_relaes_sexuais_com_algum_em_troca_de_dinhei = 'sim'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/ja_ouviu_falar_de_its_hiv" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/sabe_como_se_prevenir_para_no_contrair" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/usa_o_preservativo_com_os_clientes_e_tambm_com_seu_parceiro" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/usa_em_todas_as_practicas_sexuais" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/produto_lubrificacao" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/tipo_lubricador" type="xsd:string"  relevant="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/produto_lubrificacao = 'sim'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/onde_tem_praticado_sua_actividade_como_trabalhadora"  relevant="/data/consentimento_sim/registro_de_conviventes/alguma_vez_foi_solicitado_a_ter_relaes_sexuais_com_algum_em_troca_de_dinhei = 'sim'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/trabalhadora_de_sexo"  calculate="if(/data/consentimento_sim/registro_de_conviventes/alguma_vez_foi_solicitado_a_ter_relaes_sexuais_com_algum_em_troca_de_dinhei = 'sim', 1, 0)" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/esta_paciente__trabalhadora_de_sexo_e_deve_ser_testada"  relevant="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/trabalhadora_de_sexo = 1" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas"  relevant="/data/consentimento_sim/registro_de_conviventes/consome_bebidas_alcolicas = 'sim' and /data/consentimento_sim/registro_de_conviventes/consome_outras_drogas = 'sim'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/relation_after_drugs" type="xsd:string"  relevant="/data/consentimento_sim/registro_de_conviventes/consome_outras_drogas = 'sim'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/usa_preservativo_durante_as_suas_relacoes_sxuais" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/usa_drogas_injectaveis" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/com_que_frequencia_usa_estas_drogas" type="xsd:string"  relevant="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/usa_drogas_injectaveis = 'sim'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/j_partilhou_agulhas_ou_seringas" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/acha_que_alguem_que_usa_drogas_injectaveis_corre_risco_de_contrair_o_hiv" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/usa_injecta_drogas"  calculate="if(/data/consentimento_sim/registro_de_conviventes/consome_bebidas_alcolicas = 'sim' and /data/consentimento_sim/registro_de_conviventes/consome_outras_drogas = 'sim', 1, 0)" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/este_paciente_faz_o_uso_de_drogas_e_deve"  relevant="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/usa_injecta_drogas = 1" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido"  relevant="/data/consentimento_sim/registro_de_conviventes/patient_information/consentimento_menor_15_anos = 'sim' or /data/data/geral/idade_calc &gt;= 15" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18"  relevant="/data/data/geral/idade_meses &gt;= 18 and /data/data/geral/idade_calc &lt; 10" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/mae_viva_presente" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/documentation" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/pedir_cartao"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/documentation = 'sim'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/seroestado_conhecido" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/seroestado_da_mae"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/seroestado_conhecido = 'sim'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/crianca_em_seguimento"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/seroestado_da_mae = 'positivo' and /data/data/geral/idade_calc &lt;= 2" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/child_of_seropositivo_mother"  calculate="if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/seroestado_da_mae = 'positivo' and /data/data/geral/idade_meses &gt;= 18 and /data/data/geral/idade_calc &lt; 10, 1, 0)" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/child_at_risk"  calculate="if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/internada_ultimos_6meses = 'sim' or /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/lesao_ultimos_6meses = 'sim' or /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/severe_health_issues = 'sim', 1, 0)" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/internada_ultimos_6meses" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/lesao_ultimos_6meses" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/severe_health_issues" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos"  relevant="/data/data/geral/idade_calc = 10 and /data/data/geral/idade_calc &lt;= 18" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/mae_viva_presente" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/hospitalised_6months" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_teve_uma_leso_extensa_que_no_melhora_com_o_tratamento" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/nos_ultimos_3_meses_teve_algum_problema_de_saude_persistente_como_perda_de_" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_tem_corrimento" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_tem_um_dos_seguintes_problemas"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_tem_corrimento = 'sim'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/adolescente_risco"  calculate="if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/hospitalised_6months = 'sim' or /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_teve_uma_leso_extensa_que_no_melhora_com_o_tratamento = 'sim' or /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/nos_ultimos_3_meses_teve_algum_problema_de_saude_persistente_como_perda_de_ = 'sim' or /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_tem_corrimento = 'sim', 1, 0)" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/este_adolescente_est_em_risco_e_deve_ser_testado" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testado_hiv_vez" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testar_na_us"  calculate="cond(/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/referir_para_teste = '1', 1, 0)" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/fez_pcr"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testado_hiv_vez = 'sim' and /data/data/geral/idade_meses &lt; 18" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/resultado_previo_hiv"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testado_hiv_vez = 'sim' and /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/fez_pcr != 'não'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/child_still_breastfeeding"  relevant="/data/data/geral/idade_calc &lt; 5 and /data/data/geral/idade_meses &gt;= 18 and /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/resultado_previo_hiv = 'negativo'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/mai_parou_amamentar"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/child_still_breastfeeding = 'no'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/child_risk_evaluated"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/mai_parou_amamentar = 'sim'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/tem_nid"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/resultado_previo_hiv = 'positivo' and /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/fez_pcr != 'nao'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/nid" type="xsd:string" constraint="regex(., &quot;^([0-9]{8})([0-9]{2})?\/[0-9]{2}\/[0-9]{1,4}&quot;)" jr:constraintMsg="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/nid-constraintMsg')"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/tem_nid = 'sim'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testado_por_hiv_recente"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/resultado_previo_hiv = 'negativo' and /data/data/geral/idade_meses &gt;= 18 or (/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/child_still_breastfeeding = 'yes' or /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/mai_parou_amamentar = 'nao')" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/data_ultimo_teste_hiv" type="xsd:date"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testado_por_hiv_recente = 'sim'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/restagem_3_meses"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testado_por_hiv_recente = 'sim'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/em_tratamento_hiv"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/resultado_previo_hiv = 'positivo' and /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/fez_pcr != 'nao'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/em_seguimento_ccr"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/resultado_previo_hiv = 'negativo' and /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/fez_pcr = 'sim'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/should_be_tested"  calculate="if(((/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testado_hiv_vez = 'nao' or /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testado_por_hiv_recente = 'nao' or (/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testado_hiv_vez = 'sim' and /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/resultado_previo_hiv = 'indeterminado')) and /data/consentimento_sim/registro_de_conviventes/patient_information/partner_of_hiv_index = 1) or ((/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/fez_pcr = 'nao' or /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testado_hiv_vez = 'nao') and /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/child_of_seropositivo_mother = 1) or /data/consentimento_sim/registro_de_conviventes/testagem_para_adultos/adult_at_risk = 1 or /data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/homens_que_tem_sexo_homens = 1 or /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/child_at_risk = 1 or /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/adolescente_risco = 1 or /data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/usa_injecta_drogas = 1 or /data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/trabalhadora_de_sexo = 1 or (instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/tipo_de_paciente = 'sexual_partner' and /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testado_hiv_vez = 'nao') or (selected(/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/crianca_em_seguimento, 'nao') and /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/child_of_seropositivo_mother = 1), 1, 0)" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/lbl_no_test"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testado_hiv_vez = 'sim' and /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testado_por_hiv_recente = 'sim'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/contact_doesnt_require_test"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/should_be_tested != 1" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/test_patient_anyway"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/should_be_tested != 1 and /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/referir_para_teste = 'sim'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/reason_to_test_hiv" type="xsd:string"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/test_patient_anyway = 'yes'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/querer_testar"  relevant="(/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/should_be_tested = 1 and /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/resultado_previo_hiv != 'positivo') or /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/should_be_tested = 1 or /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/test_patient_anyway = 'yes'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/si_nao"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/querer_testar = 'nao'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/activista_capacitado_testagem"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/querer_testar = 'sim'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/referir_para_teste"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/activista_capacitado_testagem = 'no'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/outcomes" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/outcomes/referir_e_aconselhar"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/em_tratamento_hiv = 'nao'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/outcomes/referir_crianca_ccr"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/em_seguimento_ccr = 'nao'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/outcomes/aconselhado_adesao"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/em_tratamento_hiv = 'sim'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/outcomes/aconselhado_saude_infantil"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/em_seguimento_ccr = 'sim'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/outcomes/aconselhado_negativo"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testado_por_hiv_recente = 'sim' and /data/data/geral/idade_meses &lt; 24" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/querer_testar = 'sim' and /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/activista_capacitado_testagem = 'sim'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/ver_os_pasos_test1" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_1"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/ver_os_pasos_test1 = 'sim'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_1/preparacao" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_1/preparacao/reunir_itens" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_1/preparacao/tira_teste" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_1/preparacao/rotule_cartao" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_1/preparacao/remover_cobertura" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_1/colhendo_amostra" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_1/colhendo_amostra/colhar_amostra" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_1/aplicando_amostra" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_1/aplicando_amostra/aplicar_amostra" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_1/aplicando_amostra/sangue_total" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_1/obtener_resultados" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_1/obtener_resultados/tempo_resultados" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_1/obtener_resultados/registrar_resultados" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_1/interpretacao_teste" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_teste_rapido_determine" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/Quer_ver_os_pasos"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_teste_rapido_determine = 'reativo'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_2"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/Quer_ver_os_pasos = 'sim'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_2/unigold_preparacao" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_2/unigold_preparacao/unigold_reunir_itens" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_2/unigold_dispositivo_embalagem" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_2/unigold_colhendo_amostra" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_2/unigold_colhendo_amostra/unigold_colhar_amostra" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_2/unigold_aplicando_amostra" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_2/unigold_aplicando_amostra/unigold_aplicar_amostra" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_2/unigold_aplicando_amostra/unigold_sangue_total" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_2/obtener_resultados" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_2/obtener_resultados/tempo_resultados" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_2/obtener_resultados/registrar_resultados" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_2/interpretacao_teste" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_teste_rapido_unigold"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_teste_rapido_determine = 'reativo'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_final" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_final/display_resultado_do_teste_rapido" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_final/resultado_indeterminado_repetir"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_do_teste_rapido = 'indeterminado'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_do_teste_rapido"  calculate="if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_teste_rapido_determine = &quot;reativo&quot; and /data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_teste_rapido_unigold = &quot;reativo&quot;, &quot;positivo&quot;, if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_teste_rapido_determine = &quot;reativo&quot; and /data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_teste_rapido_unigold = &quot;nao_reativo&quot;, &quot;indeterminado&quot;, if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_teste_rapido_determine = &quot;nao_reativo&quot;, &quot;negativo&quot;, &quot;na&quot;)))" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_do_teste_rapido = 'indeterminado'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/ver_os_pasos_test1" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_1"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/ver_os_pasos_test1 = 'sim'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_1/preparacao" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_1/preparacao/reunir_itens" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_1/preparacao/tira_teste" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_1/preparacao/rotule_cartao" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_1/preparacao/remover_cobertura" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_1/colhendo_amostra" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_1/colhendo_amostra/colhar_amostra" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_1/aplicando_amostra" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_1/aplicando_amostra/aplicar_amostra" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_1/aplicando_amostra/sangue_total" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_1/obtener_resultados" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_1/obtener_resultados/tempo_resultados" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_1/obtener_resultados/registrar_resultados" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_1/interpretacao_teste" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_teste_rapido_determine" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/Quer_ver_os_pasos"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_teste_rapido_determine = 'reativo'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_2"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/Quer_ver_os_pasos = 'sim'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_2/unigold_preparacao" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_2/unigold_preparacao/unigold_reunir_itens" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_2/unigold_dispositivo_embalagem" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_2/unigold_colhendo_amostra" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_2/unigold_colhendo_amostra/unigold_colhar_amostra" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_2/unigold_aplicando_amostra" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_2/unigold_aplicando_amostra/unigold_aplicar_amostra" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_2/unigold_aplicando_amostra/unigold_sangue_total" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_2/obtener_resultados" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_2/obtener_resultados/tempo_resultados" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_2/obtener_resultados/registrar_resultados" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_2/interpretacao_teste" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_teste_rapido_unigold"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_teste_rapido_determine = 'reativo'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_final" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_final/display_resultado_do_teste_rapido" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_final/indeterminado_segunda"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_do_teste_rapido_2 = 'indeterminado'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_do_teste_rapido_2"  calculate="if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_teste_rapido_determine = &quot;reativo&quot; and /data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_teste_rapido_unigold = &quot;reativo&quot;, &quot;positivo&quot;, if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_teste_rapido_determine = &quot;reativo&quot; and /data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_teste_rapido_unigold = &quot;nao_reativo&quot;, &quot;indeterminado&quot;, if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_teste_rapido_determine = &quot;nao_reativo&quot;, &quot;negativo&quot;, &quot;na&quot;)))" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/couseling" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/couseling/aconselhamento_pos"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_do_teste_rapido_2 = 'positivo' or /data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_do_teste_rapido_2 = 'positivo'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/referir_para_teste = '0'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_determine"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/querer_testar = 'sim'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_determine_coregir" type="xsd:int" constraint=". &lt; 5" jr:constraintMsg="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_determine_coregir-constraintMsg')"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_determine = 'nao_corecto'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_unigold"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/querer_testar = 'sim'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_unigold_coregir" type="xsd:int" constraint=". &lt; 5" jr:constraintMsg="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_unigold_coregir-constraintMsg')"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_unigold = 'nao_corecto'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/referencia" relevant="false()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/referencia/resultado_negativo_referral"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_teste_rapido_determine = 'nao_reativo' and /data/data/geral/idade_meses &gt; 24" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/referencia/referir_adulto"  relevant="/data/data/geral/idade_calc &gt;= 14 and (/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_teste_rapido_unigold = 'reativo' or /data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_do_teste_rapido_2 = 'positivo')" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/referencia/referir_crianca"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/documentation = 'nao' or /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/crianca_em_seguimento = 'nao' or /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/seroestado_da_mae = 'positivo'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/referencia/referir_mae_crianca"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/documentation = 'nao' and /data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_teste_rapido_unigold = 'reativo'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/referencia/pos_seguimento"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/crianca_em_seguimento = 'sim' or /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/seroestado_da_mae = 'negativo'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/referencia/neg_crianca_testado"  relevant="/data/data/geral/idade_calc &lt; 14 and /data/data/geral/idade_meses &gt; 18 and /data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_do_teste_rapido = 'negativo'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership"  relevant="/data/data/geral/testado_durante_visita = 1" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/chw_testagem" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/activista_fez_testagem_hiv" type="xsd:string"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/chw_testagem = 'sim'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/tem_numero_de_telefone"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/chw_testagem = 'sim'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/telefone" type="xsd:string" constraint="regex(., '^[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]$')" jr:constraintMsg="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/telefone-constraintMsg')"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/tem_numero_de_telefone = 'sim'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/rastreio_tb_display" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/antes_de_comenar_o_rastreio_lembre-se_d_en" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/ja_em_tratamento" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/verificar_adesao"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/ja_em_tratamento = 'sim'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/nit" type="xsd:string" constraint="string-length(.) &gt;= 5" jr:constraintMsg="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/nit-constraintMsg')"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/ja_em_tratamento = 'sim'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/contacto_ultimo_ano"  constraint="if(instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/tb_patient_in_household = 1, . != 'nao', . != &quot;&quot;)" jr:constraintMsg="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/contacto_ultimo_ano-constraintMsg')"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/ja_em_tratamento = 'nao'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15" constraint="if(selected(., 'nenhum'), count-selected(.) = 1, count-selected(.) &gt; 0)" jr:constraintMsg="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15-constraintMsg')"  relevant="/data/data/geral/idade_calc &lt; 15 and /data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/ja_em_tratamento = 'nao'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15" constraint="if(selected(., 'nenhum'), count-selected(.) = 1, count-selected(.) &gt; 0)" jr:constraintMsg="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-constraintMsg')"  relevant="/data/data/geral/idade_calc &gt;= 15 and /data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/ja_em_tratamento = 'nao'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/cough" type="xsd:int"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15 = 'tem_tosse' or /data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15 = 'tem_tosse'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/cough_with_blood" type="xsd:int"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15 = 'sangue'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/fever" type="xsd:int"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15 = 'febre_2_semanas' or /data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15 = 'febre_2_semanas'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/lost_weight" type="xsd:int"  relevant="selected(/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15, 'perda_de_peso') or selected(/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15, 'perda_de_peso')" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/fatigue" type="xsd:int"  relevant="selected(/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15, 'Tem_falta_de_vontade_de_brincar') or selected(/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15, 'cansado')" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/night_sweating" type="xsd:int"  relevant="selected(/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15, 'transpira')" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/diarrhea" type="xsd:int"  relevant="selected(/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15, 'diarreia')" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_screening_result"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/rastreio_positivo_tb = 1" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_screening_result/referido_rastreio_tb" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_screening_result/lbl_refer_exposed_child_tb"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/crianca_exposta_tb = 1" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_screening_result/hiv_exposed"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/hiv_exposto_tb = 1" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_screening_result/lbl_tb_symptoms"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/sintomas_clinicos_tb = 1" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/referido_rastreio_tb"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/sintomas_clinicos_tb = 1" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/referido_rastreio_tb/instruccoes_frascos" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/referido_rastreio_tb/instruccoes"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/sintomas_clinicos_tb = 1" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/escarro"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/referido_rastreio_tb/instruccoes = 'sim'" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/escarro/question9" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/patient_received_container"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/sintomas_clinicos_tb = 1" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/not_received_container" type="xsd:string"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/patient_received_container = 'no'" required="true()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/tb_patient_in_household"  calculate="if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/tb_positivo = 1, 1, instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/tb_patient_in_household)" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/tb_positivo"  calculate="if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/ja_em_tratamento = 'sim', 1, 0)" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/coinfectado"  calculate="if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/tb_positivo = 1 and /data/data/geral/hiv_positivo = 1, 1, 0)" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/crianca_exposta_tb"  calculate="if((/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/tb_patient_in_household = 1 or /data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/contacto_ultimo_ano = 'sim') and /data/data/geral/idade_calc &lt; 15 and /data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/ja_em_tratamento = 'nao', 1, 0)" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/hiv_exposto_tb"  calculate="if(/data/data/geral/hiv_positivo = 1 and /data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/tb_patient_in_household = 1 and /data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/ja_em_tratamento = 'nao', 1, 0)" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/sintomas_clinicos_tb"  calculate="if(count-selected(/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15) &gt;= 2 or ((/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/tb_patient_in_household = 1 or /data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/contacto_ultimo_ano = 'sim') and not(selected(/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15, 'nenhum')) and count-selected(/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15) &gt; 0) or (not(selected(/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15, 'nenhum')) and count-selected(/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15) &gt; 0), 1, 0)" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/patient_for_tpi"  calculate="if(((/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/crianca_exposta_tb = 1 and /data/data/geral/idade_calc &lt; 5) or /data/data/geral/hiv_positivo = 1) and /data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/sintomas_clinicos_tb = 0 and /data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/tb_positivo = 0, 1, 0)" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/patient_needs_tpi"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/patient_for_tpi = 1" calculate="1" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/rastreio_positivo_tb"  calculate="if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/sintomas_clinicos_tb = 1 or /data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/crianca_exposta_tb = 1 or /data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/hiv_exposto_tb = 1, 1, 0)" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/first_observation_date" calculate="today()" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/second_observation_date" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/third_observation_date" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/resultado_tb" calculate="&quot;Unknown&quot;" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/patient_on_tpi" calculate="0" />
+			<bind  nodeset="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/data_rastreio_tb" calculate="today()" />
+			<bind  nodeset="/data/referrals"  relevant="/data/consentimento_registo = 'sim'" />
+			<bind  nodeset="/data/referrals/required_referrals"  relevant="/data/data/referencia/refer_to_us = 1" />
+			<bind  nodeset="/data/referrals/required_referrals/list_required_referrals" />
+			<bind  nodeset="/data/referrals/required_referrals/list_required_referrals/referir_paciente" />
+			<bind  nodeset="/data/referrals/required_referrals/list_required_referrals/lbl_hiv_indeterminate"  relevant="/data/data/geral/indeterminado_hiv_testado = 1" />
+			<bind  nodeset="/data/referrals/required_referrals/list_required_referrals/lbl_new_pregnancy"  relevant="/data/data/geral/hiv_nova_gravidez = 1" />
+			<bind  nodeset="/data/referrals/required_referrals/list_required_referrals/lbl_new_breastfeeding"  relevant="/data/data/geral/hiv_nova_lactancia = 1" />
+			<bind  nodeset="/data/referrals/required_referrals/list_required_referrals/lbl_tb_hiv_positive"  relevant="/data/data/geral/positivo_hiv_testado = 1" />
+			<bind  nodeset="/data/referrals/required_referrals/list_required_referrals/lbl_refer_for_ccr" relevant="false()" />
+			<bind  nodeset="/data/referrals/required_referrals/list_required_referrals/lbl_refer_child_pos_tb_screening"  relevant="/data/data/geral/crianca_para_testar = 1" />
+			<bind  nodeset="/data/referrals/required_referrals/list_required_referrals/pacinete_para_testar_na_unidade_sanitria"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testar_na_us = 1 and /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/querer_testar = 'sim'" />
+			<bind  nodeset="/data/referrals/required_referrals/list_required_referrals/lbl_iniciar_tarv"  relevant="/data/data/geral/iniciar_tarv = 1" />
+			<bind  nodeset="/data/referrals/required_referrals/list_required_referrals/resultado_negativo_referral"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_teste_rapido_determine = 'nao_reativo' and /data/data/geral/idade_meses &gt; 24" />
+			<bind  nodeset="/data/referrals/required_referrals/list_required_referrals/pos_seguimento"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/crianca_em_seguimento = 'nao'" />
+			<bind  nodeset="/data/referrals/required_referrals/list_required_referrals/neg_crianca_testado"  relevant="/data/data/geral/idade_calc &lt; 14 and /data/data/geral/idade_meses &gt; 18 and /data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_do_teste_rapido = 'negativo'" />
+			<bind  nodeset="/data/referrals/required_referrals/list_required_referrals/lbl_tb_positive"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/rastreio_positivo_tb = 1" />
+			<bind  nodeset="/data/referrals/required_referrals/list_required_referrals/lbl_refer_hiv_for_tpi"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/patient_for_tpi = 1" />
+			<bind  nodeset="/data/referrals/required_referrals/list_required_referrals/lbl_refer_exposed_child_tb"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/crianca_exposta_tb = 1" />
+			<bind  nodeset="/data/referrals/required_referrals/list_required_referrals/hiv_exposed"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/hiv_exposto_tb = 1" />
+			<bind  nodeset="/data/referrals/required_referrals/list_required_referrals/lbl_tb_symptoms"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/sintomas_clinicos_tb = 1" />
+			<bind  nodeset="/data/referrals/required_referrals/fez_referencia" required="true()" />
+			<bind  nodeset="/data/referrals/required_referrals/does_patients_name_accepts_to_receive_care_at_chw_hf_name"  relevant="/data/referrals/required_referrals/fez_referencia = 'sim'" required="true()" />
+			<bind  nodeset="/data/referrals/required_referrals/preferred_health_facility_grp"  relevant="/data/referrals/required_referrals/does_patients_name_accepts_to_receive_care_at_chw_hf_name = '0'" />
+			<bind  nodeset="/data/referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province" required="true()" />
+			<bind  nodeset="/data/referrals/required_referrals/preferred_health_facility_grp/hf_health_facility" required="true()"                                 />
+			<bind  nodeset="/data/referrals/required_referrals/preferred_health_facility_grp/hf_selected_partner_ids"  relevant="/data/referrals/required_referrals/preferred_health_facility_grp/hf_health_facility != ''"  calculate="join(' ', instance('locations')/locations/location[@type = 'unidade-sanitaria'][location_data/location_code = /data/referrals/required_referrals/preferred_health_facility_grp/hf_health_facility]/@partner_id)" />
+			<bind  nodeset="/data/referrals/required_referrals/preferred_health_facility_grp/chw_current_province" calculate="instance('locations')/locations/location[@id = instance('commcaresession')/session/user/data/commcare_location_id]/@province_name" />
+			<bind  nodeset="/data/referrals/required_referrals/preferred_health_facility_grp/current_chw_partner_id" calculate="instance('locations')/locations/location[@id = instance('commcaresession')/session/user/data/commcare_location_id]/@partner_id" />
+			<bind  nodeset="/data/referrals/required_referrals/preferred_health_facility_grp/selected_hf_has_current_partner"  calculate="cond(contains(/data/referrals/required_referrals/preferred_health_facility_grp/hf_selected_partner_ids, /data/referrals/required_referrals/preferred_health_facility_grp/current_chw_partner_id), 1, 0)" />
+			<bind  nodeset="/data/referrals/required_referrals/preferred_health_facility_grp/lbl_transfer_to_current_chw_partner"  relevant="/data/referrals/required_referrals/preferred_health_facility_grp/selected_hf_has_current_partner = 1" />
+			<bind  nodeset="/data/referrals/required_referrals/preferred_health_facility_grp/select_partner"  relevant="/data/referrals/required_referrals/preferred_health_facility_grp/hf_selected_partner_ids != '' and /data/referrals/required_referrals/preferred_health_facility_grp/selected_hf_has_current_partner != 1" />
+			<bind  nodeset="/data/referrals/required_referrals/preferred_health_facility_grp/selected_hf_partner"  calculate="cond(/data/referrals/required_referrals/preferred_health_facility_grp/selected_hf_has_current_partner = 1, instance('locations')/locations/location[@type = 'unidade-sanitaria' and @partner_id = /data/referrals/required_referrals/preferred_health_facility_grp/current_chw_partner_id][location_data/location_code = /data/referrals/required_referrals/preferred_health_facility_grp/hf_health_facility]/@id, instance('locations')/locations/location[@type = 'unidade-sanitaria'][location_data/location_code = /data/referrals/required_referrals/preferred_health_facility_grp/hf_health_facility and @partner_id = /data/referrals/required_referrals/preferred_health_facility_grp/select_partner]/@id)" />
+			<bind  nodeset="/data/referrals/required_referrals/preferred_health_facility_grp/lbl_no_partner_in_hf"  relevant="string-length(join('', instance('locations')/locations/location[@type = 'partner'][contains(/data/referrals/required_referrals/preferred_health_facility_grp/hf_selected_partner_ids, @id)]/name)) &lt;= 1" />
+			<bind  nodeset="/data/referrals/required_referrals/preferred_health_facility_grp/close_case_no_partner_hf" />
+			<bind  nodeset="/data/referrals/required_referrals/preferred_health_facility_grp/current_chw_province_code" calculate="lower-case(instance('locations')/locations/location[@id = instance('locations')/locations/location[@id = instance('commcaresession')/session/user/data/commcare_location_id]/@provincia_id]/location_data/location_code)" />
+			<bind  nodeset="/data/referrals/required_referrals/preferred_health_facility_grp/patiient_chose_other_hf"  calculate="cond(/data/referrals/required_referrals/does_patients_name_accepts_to_receive_care_at_chw_hf_name = '1' or /data/referrals/required_referrals/preferred_health_facility_grp/selected_hf_has_current_partner = 1, 0, 1)" />
+			<bind  nodeset="/data/referrals/required_referrals/consentimento_busca_activa" required="true()" />
+			<bind  nodeset="/data/referrals/required_referrals/intentar_convencer"  relevant="/data/referrals/required_referrals/fez_referencia = 'nao'" />
+			<bind  nodeset="/data/referrals/required_referrals/test" relevant="instance('commcaresession')/session/user/data/organizacao = 'test'" />
+			<bind  nodeset="/data/referrals/required_referrals/test/test_data_de_referencia" type="xsd:date" />
+			<bind  nodeset="/data/referrals/required_referrals/test/test_data_proxima_visita" type="xsd:date" />
+			<bind  nodeset="/data/referrals/no_referrals" />
+			<bind  nodeset="/data/referrals/no_referrals/outras_referencias"  relevant="/data/data/referencia/refer_to_us != 1" />
+			<bind  nodeset="/data/referrals/no_referrals/outra_doenca" type="xsd:string"  relevant="selected(/data/referrals/no_referrals/outras_referencias, 'outra')" />
+			<bind  nodeset="/data/contacts_registration_concent"  relevant="(instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/tipo_de_paciente = 'sexual_partner' or instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/tipo_de_paciente = 'community_member') and /data/consentimento_registo = 'sim'" required="true()" />
+			<bind  nodeset="/data/register_conviventes_during_visit"  relevant="/data/contacts_registration_concent = 'yes' and /data/data/geral/tipo_de_paciente = 'convivente'" required="true()" />
+			<bind  nodeset="/data/hh_reg" />
+			<bind  nodeset="/data/hh_reg/mais_conviventes"  relevant="/data/register_conviventes_during_visit = 'nao' or (/data/consentimento_registo = 'nao')" required="true()" />
+			<bind  nodeset="/data/hh_reg/confirmar_registo_conviventes_completo"  relevant="/data/hh_reg/mais_conviventes = 'sim'" required="true()" />
+			<bind  nodeset="/data/display_new_convivente"  relevant="/data/hh_reg/mais_conviventes = 'sim'" />
+			<bind  nodeset="/data/data" />
+			<bind  nodeset="/data/data/referencia" />
+			<bind  nodeset="/data/data/referencia/referido"  relevant="/data/referrals/required_referrals/fez_referencia = 'sim'" calculate="1" />
+			<bind  nodeset="/data/data/referencia/data_de_referencia"  calculate="coalesce(/data/referrals/required_referrals/test/test_data_de_referencia, today())" />
+			<bind  nodeset="/data/data/referencia/referido_por" calculate="instance('commcaresession')/session/context/username" />
+			<bind  nodeset="/data/data/referencia/nome_da_referencia"  calculate="concat(/data/data/geral/nome_concat, ' ', today())" />
+			<bind  nodeset="/data/data/referencia/referencia_aberto"  calculate="if(/data/referrals/required_referrals/fez_referencia = 'sim', 1, 0)" />
+			<bind  nodeset="/data/data/referencia/refer_to_us"  calculate="if(/data/data/geral/indeterminado_hiv_testado = 1 or /data/data/geral/hiv_nova_lactancia = 1 or /data/data/geral/hiv_nova_gravidez = 1 or /data/data/geral/positivo_hiv_testado = 1 or /data/data/geral/crianca_para_testar = 1 or /data/data/geral/iniciar_tarv = 1 or /data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/rastreio_positivo_tb = 1 or /data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/patient_for_tpi = 1 or /data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/crianca_exposta_tb = 1 or /data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/hiv_exposto_tb = 1 or /data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/sintomas_clinicos_tb = 1 or /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testar_na_us = 1 or /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/crianca_em_seguimento = 'nao' or (/data/data/geral/idade_meses &gt; 18 and /data/data/geral/idade_calc &lt; 14 and /data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_do_teste_rapido = 'negativo'), 1, 0)" />
+			<bind  nodeset="/data/data/referencia/numero_de_referencias"  calculate="if(/data/data/referencia/referido = 1, 1, 0)" />
+			<bind  nodeset="/data/data/referencia/owner_id"  calculate="coalesce(/data/referrals/required_referrals/preferred_health_facility_grp/selected_hf_partner, instance('locations')/locations/location[@id = instance('commcaresession')/session/user/data/commcare_location_id][@type = 'activista']/@unidade-sanitaria_id)" />
+			<bind  nodeset="/data/data/referencia/health_facility_referral_crianza_menos_18_meses"  calculate="if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/mae_viva_presente = 'nao', 1, 0)" />
+			<bind  nodeset="/data/data/referencia/ba_referido_filtro"  calculate="if((/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/rastreio_positivo_tb = 1 and /data/data/geral/hiv_positivo != 1) or (/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/crianca_exposta_tb = 1 and /data/data/geral/hiv_positivo != 1), 1, 0)" />
+			<bind  nodeset="/data/data/referencia/referido_tb"  calculate="if(/data/referrals/required_referrals/fez_referencia = 'sim' and /data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/rastreio_positivo_tb = 1, 1, 0)" />
+			<bind  nodeset="/data/data/referencia/household_name" />
+			<bind  nodeset="/data/data/referencia/create_ref"  calculate="cond(/data/referrals/required_referrals/fez_referencia != 'sim' or (/data/referrals/required_referrals/fez_referencia = 'sim' and /data/referrals/required_referrals/preferred_health_facility_grp/close_case_no_partner_hf = 1), 0, 1)" />
+			<bind  nodeset="/data/data/referencia/transfer_status"  calculate="cond(/data/referrals/required_referrals/does_patients_name_accepts_to_receive_care_at_chw_hf_name = '1' or /data/referrals/required_referrals/preferred_health_facility_grp/selected_hf_has_current_partner = 1, 0, 1)" />
+			<bind  nodeset="/data/data/referencia/transferral"  calculate="cond(/data/referrals/required_referrals/does_patients_name_accepts_to_receive_care_at_chw_hf_name = '1' or /data/referrals/required_referrals/preferred_health_facility_grp/selected_hf_has_current_partner = 1, 0, 1)" />
+			<bind  nodeset="/data/data/referencia/cases_transfer"  calculate="cond(/data/data/referencia/transferral = 1, 'paciente', '')" />
+			<bind  nodeset="/data/data/geral" />
+			<bind  nodeset="/data/data/geral/next_form"  relevant="/data/data/geral/hiv_positivo = 1 and /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/em_tratamento_hiv != 'sim'" calculate="'follow_up'" />
+			<bind  nodeset="/data/data/geral/nome" />
+			<bind  nodeset="/data/data/geral/apelido" />
+			<bind  nodeset="/data/data/geral/chegado_a_us" calculate="0" />
+			<bind  nodeset="/data/data/geral/estado_tarv" calculate="&quot;desconhecido&quot;" />
+			<bind  nodeset="/data/data/geral/idade_calc"  calculate="if(/data/consentimento_sim/registro_de_conviventes/patient_information/data_de_nacimento_conhecido = 'sim', int((today() - date(/data/consentimento_sim/registro_de_conviventes/patient_information/data_do_nacimento)) div 365.25), /data/consentimento_sim/registro_de_conviventes/patient_information/idade_perguntar)" />
+			<bind  nodeset="/data/data/geral/idade_meses"  calculate="if(/data/consentimento_sim/registro_de_conviventes/patient_information/data_de_nacimento_conhecido = 'sim', round((today() - date(/data/consentimento_sim/registro_de_conviventes/patient_information/data_do_nacimento)) div 30.4), int(/data/consentimento_sim/registro_de_conviventes/patient_information/idade_perguntar * 12))" />
+			<bind  nodeset="/data/data/geral/data_do_nacimento"  calculate="if(/data/consentimento_sim/registro_de_conviventes/patient_information/data_de_nacimento_conhecido = 'sim', /data/consentimento_sim/registro_de_conviventes/patient_information/data_do_nacimento, date(today() - /data/data/geral/idade_meses * 30.4))" />
+			<bind  nodeset="/data/data/geral/close_case"  calculate="cond(/data/data/referencia/refer_to_us = 1 or /data/referrals/required_referrals/consentimento_busca_activa = 'nao', 0, 1)" />
+			<bind  nodeset="/data/data/geral/indeterminado_hiv_testado"  calculate="if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_do_teste_rapido_2 = 'indeterminado', 1, 0)" />
+			<bind  nodeset="/data/data/geral/retestagem"  calculate="/data/data/geral/indeterminado_hiv_testado = 1 or (/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/child_of_seropositivo_mother = 1 and /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testado_por_hiv_recente = 'sim')" />
+			<bind  nodeset="/data/data/geral/determine_used_calc"  calculate="if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/querer_testar = 'nao', 0, if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/querer_testar = 'sim' and (/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_do_teste_rapido = 'negativo' or /data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_do_teste_rapido = 'positivo'), 1, 2))" />
+			<bind  nodeset="/data/data/geral/determine_used_final"  calculate="if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_determine = 'nao_corecto', /data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_determine_coregir, /data/data/geral/determine_used_calc)" />
+			<bind  nodeset="/data/data/geral/unigold_used_calc"  calculate="if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/querer_testar = 'nao' or /data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_teste_rapido_determine = 'nao_reativo', 0, if((/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_do_teste_rapido = 'indeterminado' and /data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_do_teste_rapido_2 = 'negativo') or /data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_do_teste_rapido = 'positivo', 1, 2))" />
+			<bind  nodeset="/data/data/geral/unigold_used_final"  calculate="if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_unigold = 'nao_corecto', /data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_unigold_coregir, /data/data/geral/unigold_used_calc)" />
+			<bind  nodeset="/data/data/geral/us" calculate="instance('locations')/locations/location[@id = instance('locations')/locations/location[@id = instance('commcaresession')/session/user/data/commcare_location_id]/@unidade-sanitaria_id]/name" />
+			<bind  nodeset="/data/data/geral/data_registro_cc" calculate="today()" />
+			<bind  nodeset="/data/data/geral/data_ultimo_teste_hiv"  calculate="coalesce(/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/data_ultimo_teste_hiv, if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/querer_testar = 'sim', today(), ''))" />
+			<bind  nodeset="/data/data/geral/data_ultimo_rastreio_tb" calculate="today()" />
+			<bind  nodeset="/data/data/geral/paciente_index"  calculate="cond(instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/nome != '' or instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/apelido != '', 1, 0)" />
+			<bind  nodeset="/data/data/geral/tipo_de_paciente"  calculate="cond(/data/data/geral/paciente_index = 1, instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/tipo_de_paciente, 'convivente')" />
+			<bind  nodeset="/data/data/geral/nome_concat"  calculate="concat(coalesce(/data/consentimento_sim/registro_de_conviventes/patient_information/nome_primero, instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/nome), ' ', coalesce(/data/consentimento_sim/registro_de_conviventes/patient_information/apelido, instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/apelido))" />
+			<bind  nodeset="/data/data/geral/activista_responsavel_paciente" />
+			<bind  nodeset="/data/data/geral/contact_phone_number"  calculate="concat('+258', /data/consentimento_sim/registro_de_conviventes/patient_information/telefone)" />
+			<bind  nodeset="/data/data/geral/contact_phone_number_is_verified"  calculate="if(/data/consentimento_sim/registro_de_conviventes/patient_information/telefone != '', 1, 0)" />
+			<bind  nodeset="/data/data/geral/testado_por_hiv_uma_vez"  calculate="if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_teste_rapido_determine != '' or /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/resultado_previo_hiv = &quot;positivo&quot; or /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testado_por_hiv_recente = &quot;sim&quot;, 1, 0)" />
+			<bind  nodeset="/data/data/geral/testado_durante_visita"  calculate="if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_teste_rapido_determine != '', 1, 0)" />
+			<bind  nodeset="/data/data/geral/positivo_hiv_testado"  calculate="if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_do_teste_rapido = 'positivo' or /data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_do_teste_rapido_2 = 'positivo', 1, 0)" />
+			<bind  nodeset="/data/data/geral/hiv_nova_lactancia"  calculate="if(/data/data/geral/hiv_positivo = 1 and /data/consentimento_sim/registro_de_conviventes/patient_information/lactante = 1, 1, 0)" />
+			<bind  nodeset="/data/data/geral/hiv_nova_gravidez"  calculate="if(/data/data/geral/hiv_positivo = 1 and /data/consentimento_sim/registro_de_conviventes/patient_information/gravida = 1, 1, 0)" />
+			<bind  nodeset="/data/data/geral/crianca_para_testar"  calculate="if((/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/crianca_em_seguimento = &quot;nao&quot;) and /data/data/geral/positivo_hiv_testado != 1 and /data/data/geral/idade_calc &lt; 2, 1, 0)" />
+			<bind  nodeset="/data/data/geral/iniciar_tarv"  calculate="if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/em_tratamento_hiv = 'nao', 1, 0)" />
+			<bind  nodeset="/data/data/geral/patient_registered" calculate="1" />
+			<bind  nodeset="/data/data/geral/hiv_positivo"  calculate="if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/resultado_previo_hiv = &quot;positivo&quot; or /data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_do_teste_rapido = &quot;positivo&quot; or /data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_do_teste_rapido_2 = &quot;positivo&quot;, 1, 0)" />
+			<bind  nodeset="/data/data/geral/localizado" calculate="1" />
+			<bind  nodeset="/data/data/geral/testado_por_hiv"  calculate="if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testado_por_hiv_recente = 'sim' or /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/resultado_previo_hiv = &quot;positivo&quot; or /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/em_tratamento_hiv = 'sim', 1, 0)" />
+			<bind  nodeset="/data/data/geral/provincia" calculate="instance('locations')/locations/location[@id = instance('locations')/locations/location[@id = instance('commcaresession')/session/user/data/commcare_location_id]/@provincia_id]/name" />
+			<bind  nodeset="/data/data/geral/distrito" calculate="instance('locations')/locations/location[@id = instance('locations')/locations/location[@id = instance('commcaresession')/session/user/data/commcare_location_id]/@distrito_id]/name" />
+			<bind  nodeset="/data/data/geral/unidade_sanitaria" calculate="instance('locations')/locations/location[@id = instance('locations')/locations/location[@id = instance('commcaresession')/session/user/data/commcare_location_id]/@unidade-sanitaria_id]/name" />
+			<bind  nodeset="/data/data/geral/location_id" calculate="instance('commcaresession')/session/user/data/commcare_location_id" />
+			<bind  nodeset="/data/data/geral/motivos_de_nao_testar"  calculate="if(/data/data/geral/testado_durante_visita = 1, &quot;não aplicável&quot;, if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/resultado_previo_hiv = &quot;positivo&quot;, &quot;já em tratamento&quot;, if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testado_por_hiv_recente = &quot;sim&quot;, &quot;testado recentamente&quot;, if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/querer_testar = &quot;nao&quot; or /data/consentimento_sim/registro_de_conviventes/patient_information/consentimento_menor_15_anos = 'nao', &quot;negou&quot;, if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/test_patient_anyway = 'nao', &quot;não elegível&quot;, &quot;desconhecido&quot;)))))" />
+			<bind  nodeset="/data/data/geral/perfil_de_paciente"  calculate="/data/data/geral/tipo_de_paciente" />
+			<bind  nodeset="/data/data/geral/index_perfil" />
+			<bind  nodeset="/data/data/geral/priority" calculate="5" />
+			<bind  nodeset="/data/data/geral/nego"  calculate="if(/data/referrals/required_referrals/fez_referencia = &quot;nao&quot;, 1, 0)" />
+			<bind  nodeset="/data/data/geral/age_range1"  calculate="if(/data/data/geral/idade_calc &lt; 1, &quot;&lt; 1 anos&quot;, if(/data/data/geral/idade_calc &gt;= 1 and /data/data/geral/idade_calc &lt; 3, &quot;1-2 anos&quot;, if(/data/data/geral/idade_calc &gt;= 3 and /data/data/geral/idade_calc &lt; 5, &quot;3-4 anos&quot;, if(/data/data/geral/idade_calc &gt;= 5 and /data/data/geral/idade_calc &lt; 10, &quot;5-9 anos&quot;, if(/data/data/geral/idade_calc &gt;= 10 and /data/data/geral/idade_calc &lt; 15, &quot;10-14 anos&quot;, if(/data/data/geral/idade_calc &lt;= 15 and /data/data/geral/idade_calc &lt; 20, &quot;15-19 anos&quot;, if(/data/data/geral/idade_calc &gt;= 20 and /data/data/geral/idade_calc &lt; 25, &quot;20-24 anos&quot;, if(/data/data/geral/idade_calc &gt;= 25 and /data/data/geral/idade_calc &lt; 50, &quot;25-49&quot;, &quot;50+&quot;))))))))" />
+			<bind  nodeset="/data/data/geral/age_range2"  calculate="cond(/data/data/geral/idade_calc &lt; 1, &quot;&lt; 1 anos&quot;, /data/data/geral/idade_calc &gt;= 1 and /data/data/geral/idade_calc &lt;= 4, &quot;1-4 anos&quot;, /data/data/geral/idade_calc &gt;= 5 and /data/data/geral/idade_calc &lt;= 9, &quot;5-9 anos&quot;, /data/data/geral/idade_calc &gt;= 10 and /data/data/geral/idade_calc &lt;= 14, &quot;10-14 anos&quot;, /data/data/geral/idade_calc &gt;= 15 and /data/data/geral/idade_calc &lt;= 19, &quot;15-19 anos&quot;, /data/data/geral/idade_calc &gt;= 20 and /data/data/geral/idade_calc &lt;= 24, &quot;20-24 anos&quot;, /data/data/geral/idade_calc &gt;= 25 and /data/data/geral/idade_calc &lt;= 49, &quot;25-49 anos&quot;, &quot;50+&quot;)" />
+			<bind  nodeset="/data/data/geral/parceiro_do_index"  calculate="if(/data/consentimento_sim/registro_de_conviventes/patient_information/grau_de_parentesco = 'esposo' and (/data/data/geral/testado_por_hiv_uma_vez = 1 or /data/data/geral/testado_durante_visita = 1), 1, 0)" />
+			<bind  nodeset="/data/data/geral/import_validated" calculate="1" />
+			<bind  nodeset="/data/data/geral/familia_directa"  calculate="if(/data/consentimento_sim/registro_de_conviventes/patient_information/grau_de_parentesco = 'esposo' or /data/consentimento_sim/registro_de_conviventes/patient_information/grau_de_parentesco = 'filho' or /data/consentimento_sim/registro_de_conviventes/patient_information/grau_de_parentesco = 'namorado' or /data/consentimento_sim/registro_de_conviventes/patient_information/grau_de_parentesco = 'pai' or /data/consentimento_sim/registro_de_conviventes/patient_information/grau_de_parentesco = 'irmao', 1, 0)" />
+			<bind  nodeset="/data/data/geral/transfer_status"  calculate="/data/data/referencia/transfer_status" />
+			<bind  nodeset="/data/data/busca_activa" />
+			<bind  nodeset="/data/data/busca_activa/nao_busca_activa"  calculate="if(/data/referrals/required_referrals/consentimento_busca_activa = 1, 1, 0)" />
+			<bind  nodeset="/data/data/busca_activa/busca_activa" calculate="0" />
+			<bind  nodeset="/data/data/busca_activa/a_faltar" calculate="0" />
+			<bind  nodeset="/data/data/busca_activa/numero_de_faltas" calculate="0" />
+			<bind  nodeset="/data/casa" />
+			<bind  nodeset="/data/casa/conviventes" />
+			<bind  nodeset="/data/casa/conviventes/convivente1"  relevant="/data/casa/testagem/num_conviventes_registrado = 1"  calculate="concat(/data/data/geral/nome_concat, &quot; &quot;, /data/data/geral/idade_calc, &quot;anos&quot;)" />
+			<bind  nodeset="/data/casa/conviventes/convivente2"  relevant="/data/casa/testagem/num_conviventes_registrado = 2"  calculate="concat(/data/data/geral/nome_concat, &quot; &quot;, /data/data/geral/idade_calc, &quot;anos&quot;)" />
+			<bind  nodeset="/data/casa/conviventes/convivente3"  relevant="/data/casa/testagem/num_conviventes_registrado = 3"  calculate="concat(/data/data/geral/nome_concat, &quot; &quot;, /data/data/geral/idade_calc, &quot;anos&quot;)" />
+			<bind  nodeset="/data/casa/conviventes/convivente4"  relevant="/data/casa/testagem/num_conviventes_registrado = 4"  calculate="concat(/data/data/geral/nome_concat, &quot; &quot;, /data/data/geral/idade_calc, &quot;anos&quot;)" />
+			<bind  nodeset="/data/casa/conviventes/convivente5"  relevant="/data/casa/testagem/num_conviventes_registrado = 5"  calculate="concat(/data/data/geral/nome_concat, &quot; &quot;, /data/data/geral/idade_calc, &quot;anos&quot;)" />
+			<bind  nodeset="/data/casa/conviventes/convivente6"  relevant="/data/casa/testagem/num_conviventes_registrado = 6"  calculate="concat(/data/data/geral/nome_concat, &quot; &quot;, /data/data/geral/idade_calc, &quot;anos&quot;)" />
+			<bind  nodeset="/data/casa/conviventes/convivente7"  relevant="/data/casa/testagem/num_conviventes_registrado = 7"  calculate="concat(/data/data/geral/nome_concat, &quot; &quot;, /data/data/geral/idade_calc, &quot;anos&quot;)" />
+			<bind  nodeset="/data/casa/conviventes/convivente8"  relevant="/data/casa/testagem/num_conviventes_registrado = 8"  calculate="concat(/data/data/geral/nome_concat, &quot; &quot;, /data/data/geral/idade_calc, &quot;anos&quot;)" />
+			<bind  nodeset="/data/casa/conviventes/convivente9"  relevant="/data/casa/testagem/num_conviventes_registrado = 9"  calculate="concat(/data/data/geral/nome_concat, &quot; &quot;, /data/data/geral/idade_calc, &quot;anos&quot;)" />
+			<bind  nodeset="/data/casa/conviventes/convivente10"  relevant="/data/casa/testagem/num_conviventes_registrado = 10"  calculate="concat(/data/data/geral/nome_concat, &quot; &quot;, /data/data/geral/idade_calc, &quot;anos&quot;)" />
+			<bind  nodeset="/data/casa/conviventes/convivente11"  relevant="/data/casa/testagem/num_conviventes_registrado = 11"  calculate="concat(/data/data/geral/nome_concat, &quot; &quot;, /data/data/geral/idade_calc, &quot;anos&quot;)" />
+			<bind  nodeset="/data/casa/conviventes/convivente12"  relevant="/data/casa/testagem/num_conviventes_registrado = 11"  calculate="concat(/data/data/geral/nome_concat, &quot; &quot;, /data/data/geral/idade_calc, &quot;anos&quot;)" />
+			<bind  nodeset="/data/casa/conviventes/convivente13"  relevant="/data/casa/testagem/num_conviventes_registrado = 13"  calculate="concat(/data/data/geral/nome_concat, &quot; &quot;, /data/data/geral/idade_calc, &quot;anos&quot;)" />
+			<bind  nodeset="/data/casa/conviventes/convivente14"  relevant="/data/casa/testagem/num_conviventes_registrado = 14"  calculate="concat(/data/data/geral/nome_concat, &quot; &quot;, /data/data/geral/idade_calc, &quot;anos&quot;)" />
+			<bind  nodeset="/data/casa/conviventes/convivente15"  relevant="/data/casa/testagem/num_conviventes_registrado = 15"  calculate="concat(/data/data/geral/nome_concat, &quot; &quot;, /data/data/geral/idade_calc, &quot;anos&quot;)" />
+			<bind  nodeset="/data/casa/conviventes/convivente16"  relevant="/data/casa/testagem/num_conviventes_registrado = 16"  calculate="concat(/data/data/geral/nome_concat, &quot; &quot;, /data/data/geral/idade_calc, &quot;anos&quot;)" />
+			<bind  nodeset="/data/casa/conviventes/convivente17"  relevant="/data/casa/testagem/num_conviventes_registrado = 17"  calculate="concat(/data/data/geral/nome_concat, &quot; &quot;, /data/data/geral/idade_calc, &quot;anos&quot;)" />
+			<bind  nodeset="/data/casa/conviventes/convivente18"  relevant="/data/casa/testagem/num_conviventes_registrado = 18"  calculate="concat(/data/data/geral/nome_concat, &quot; &quot;, /data/data/geral/idade_calc, &quot;anos&quot;)" />
+			<bind  nodeset="/data/casa/conviventes/convivente19"  relevant="/data/casa/testagem/num_conviventes_registrado = 19"  calculate="concat(/data/data/geral/nome_concat, &quot; &quot;, /data/data/geral/idade_calc, &quot;anos&quot;)" />
+			<bind  nodeset="/data/casa/conviventes/convivente20"  relevant="/data/casa/testagem/num_conviventes_registrado = 20"  calculate="concat(/data/data/geral/nome_concat, &quot; &quot;, /data/data/geral/idade_calc, &quot;anos&quot;)" />
+			<bind  nodeset="/data/casa/conviventes/close_casa"  calculate="cond(/data/consentimento_registo = 'nao' and instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/nome != '', 1, 0)" />
+			<bind  nodeset="/data/casa/testagem" />
+			<bind  nodeset="/data/casa/testagem/numero_de_filhos_positivos"  calculate="if(/data/consentimento_sim/registro_de_conviventes/patient_information/grau_de_parentesco = &quot;filho&quot; and /data/data/geral/hiv_positivo = 1, instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/numero_de_filhos_positivos + 1, instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/numero_de_filhos_positivos)" />
+			<bind  nodeset="/data/casa/testagem/numero_de_filhos_testados"  calculate="if(/data/consentimento_sim/registro_de_conviventes/patient_information/grau_de_parentesco = &quot;filho&quot; and /data/data/geral/testado_por_hiv_uma_vez = 1, instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/numero_de_filhos_testados + 1, instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/numero_de_filhos_testados)" />
+			<bind  nodeset="/data/casa/testagem/parceiro_serologia"  calculate="if(instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/parceiro_serologia &gt; 0, instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/parceiro_serologia, if(/data/consentimento_sim/registro_de_conviventes/patient_information/grau_de_parentesco = &quot;esposo&quot; or /data/consentimento_sim/registro_de_conviventes/patient_information/grau_de_parentesco = &quot;namorado&quot;, /data/data/geral/hiv_positivo, 0))" />
+			<bind  nodeset="/data/casa/testagem/parceiro_testado"  calculate="if(instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/parceiro_testado &gt; 0, instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/parceiro_testado, if(/data/consentimento_sim/registro_de_conviventes/patient_information/grau_de_parentesco = &quot;esposo&quot; or /data/consentimento_sim/registro_de_conviventes/patient_information/grau_de_parentesco = &quot;namorado&quot;, 1, 0))" />
+			<bind  nodeset="/data/casa/testagem/num_conviventes_positivos"  calculate="if(/data/data/geral/hiv_positivo = 1 and (instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/registration_reason = '' or instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/registration_reason = 'convivente'), coalesce(instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/num_conviventes_hiv_pos, 0) + 1, instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/num_conviventes_hiv_pos)" />
+			<bind  nodeset="/data/casa/testagem/num_conviventes_referido"  calculate="if(/data/referrals/required_referrals/fez_referencia = 'sim' and (instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/registration_reason = '' or instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/registration_reason = 'convivente'), coalesce(instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/num_conviventes_referido, 0) + 1, instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/num_conviventes_referido)" />
+			<bind  nodeset="/data/casa/testagem/num_conviventes_testado_positivo"  calculate="if(/data/data/geral/positivo_hiv_testado = 1, coalesce(instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/num_conviventes_testado_positivo, 0) + 1, instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/num_conviventes_testado_positivo)" />
+			<bind  nodeset="/data/casa/testagem/num_conviventes_testado_hiv"  calculate="if(/data/data/geral/testado_durante_visita = 1, coalesce(instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/num_conviventes_testado_hiv, 0) + 1, instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/num_conviventes_testado_hiv)" />
+			<bind  nodeset="/data/casa/testagem/num_conviventes_registrado"  calculate="cond(instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/registration_reason = '' or instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/registration_reason = 'convivente', coalesce(instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/num_conviventes_registrado, 0) + 1, 0)" />
+			<bind  nodeset="/data/casa/testagem/num_conviventes_rastreado_tb"  calculate="cond(instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/registration_reason = '' or instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/registration_reason = 'convivente', coalesce(instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/num_conviventes_rastreado_tb, 0) + 1, 0)" />
+			<bind  nodeset="/data/casa/testagem/num_conviventes_referido_tb"  calculate="cond((instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/registration_reason = '' or instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/registration_reason = 'convivente') and /data/referrals/required_referrals/fez_referencia = 'sim' and /data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/rastreio_positivo_tb = 1, coalesce(instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/num_conviventes_referido_tb, 0) + 1, instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/num_conviventes_referido_tb)" />
+			<bind  nodeset="/data/casa/index" />
+			<bind  nodeset="/data/casa/index/registo_de_conviventes_completo"  calculate="if(/data/hh_reg/mais_conviventes = 'sim', 1, 0)" />
+			<bind  nodeset="/data/casa/index/primera_visita_completo" calculate="1" />
+			<bind  nodeset="/data/casa/index/registou_convivente"  calculate="if(/data/casa/testagem/num_conviventes_registrado &gt;= 1, 1, 0)" />
+			<bind  nodeset="/data/casa/index/testou_convivente"  calculate="if(/data/casa/testagem/num_conviventes_testado_hiv &gt;= 1, 1, 0)" />
+			<bind  nodeset="/data/casa/index/rastreiou_convivente_tb" calculate="1" />
+			<bind  nodeset="/data/casa/nome" />
+			<bind  nodeset="/data/casa/apelido" />
+			<bind  nodeset="/data/indicators_v4" />
+			<bind  nodeset="/data/indicators_v4/rastreado_tb"  calculate="if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/ja_em_tratamento = 'nao', 1, instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/rastreado_tb)" />
+			<bind  nodeset="/data/indicators_v4/ind_rastreio_positivo_tb"  calculate="if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/sintomas_clinicos_tb = 1, 1, instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/ind_rastreio_positivo_tb)" />
+			<bind  nodeset="/data/indicators_v4/hiv_testado"  calculate="if((/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testado_hiv_vez = 'sim' and /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testado_por_hiv_recente = 'sim') or /data/data/geral/testado_durante_visita = 1, 1, 0)" />
+			<bind  nodeset="/data/indicators_v4/testado_hiv_ultimos_3_meses"  calculate="if((today() - date(/data/data/geral/data_ultimo_teste_hiv)) &lt;= 91, 1, 0)" />
+			<bind  nodeset="/data/indicators_v4/ind_positivo_hiv_testado"  calculate="if(/data/data/geral/positivo_hiv_testado = 1, 1, 0)" />
+			<bind  nodeset="/data/indicators_v4/resultado_discordante"  calculate="if(/data/data/geral/index_perfil != 'tb' and /data/data/geral/hiv_positivo = 0, 1, 0)" />
+			<bind  nodeset="/data/indicators_v4/ind_patient_for_tpi"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/patient_for_tpi = 1 and /data/data/referencia/referido = 1" calculate="1" />
+			<bind  nodeset="/data/indicators_v4/ind_patient_needs_tpi"  relevant="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties/patient_for_tpi = 1" calculate="1" />
+			<bind  nodeset="/data/calendario" />
+			<bind  nodeset="/data/calendario/data_proxima_consulta" calculate="today()" />
+			<bind  nodeset="/data/calendario/visita_numero" calculate="1" />
+			<bind  nodeset="/data/calendario/em_acompanhamento" calculate="0" />
+			<bind  nodeset="/data/calendario/data_ultima_visita" calculate="today()" />
+			<bind  nodeset="/data/calendario/mes" calculate="0" />
+			<bind  nodeset="/data/convivente_cascade" />
+			<bind  nodeset="/data/convivente_cascade/registado" calculate="1" />
+			<bind  nodeset="/data/convivente_cascade/to_test"  calculate="if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/should_be_tested = 1, 1, 0)" />
+			<bind  nodeset="/data/convivente_cascade/tested"  calculate="if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_teste_rapido_determine != &quot;&quot;, 1, 0)" />
+			<bind  nodeset="/data/convivente_cascade/tested_positive"  calculate="if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_do_teste_rapido = &quot;positivo&quot; or /data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_do_teste_rapido_2 = &quot;positivo&quot;, 1, 0)" />
+			<bind  nodeset="/data/convivente_cascade/should_refer"  calculate="if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_teste_rapido_unigold = &quot;reativo&quot; or /data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_teste_rapido_unigold = &quot;reativo&quot; or /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/crianca_em_seguimento = &quot;nao&quot; or /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/seroestado_da_mae = 'negativo' or /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/documentation = 'nao' or /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/seroestado_da_mae = &quot;positivo&quot; and /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/mai_parou_amamentar = 'nao' or /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/em_tratamento_hiv = &quot;nao&quot; or /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/em_seguimento_ccr = &quot;nao&quot; or /data/data/geral/indeterminado_hiv_testado = 1, 1, 0)" />
+			<bind  nodeset="/data/convivente_cascade/referred"  calculate="if(/data/referrals/required_referrals/fez_referencia = 'sim' and /data/convivente_cascade/should_refer = 1, 1, 0)" />
+			<bind  nodeset="/data/convivente_cascade/has_nid"  calculate="if(/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/tem_nid = 'sim', 1, 0)" />
+			<bind  nodeset="/data/convivente_cascade/age_range"  calculate="if(/data/data/geral/idade_meses &gt;= 24, &quot;24+ meses&quot;, if(/data/data/geral/idade_meses &gt; 18, &quot;18 - 24 meses&quot;, &quot;0 - 18 meses&quot;))" />
+			<bind  nodeset="/data/convivente_cascade/prev_positivo_or_pcr"  calculate="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/fez_pcr = 'sim' or /data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/resultado_previo_hiv = 'positivo'" />
+			<bind  nodeset="/data/organizacao" calculate="instance('commcaresession')/session/user/data/organizacao" />
+			<bind  nodeset="/data/fgh_needs_visit"  relevant="/data/organizacao = 'FGH'" calculate="0" />
+			<bind  nodeset="/data/household_name" />
+			<setvalue event="xforms-ready"  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/apelido"  value="instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/apelido" />
+			<setvalue event="xforms-ready"  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/nome_primero"  value="if(instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/paciente_index = 1, instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/nome, &quot;&quot;)" />
+			<setvalue event="xforms-ready"  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/genero"  value="if(instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/paciente_index = 1, instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/genero, &quot;&quot;)" />
+			<setvalue event="xforms-ready"  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/estado_civil" value="'solteiro'" />
+			<setvalue event="xforms-ready"  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/tem_numero_de_telefone"  value="if(instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/paciente_index = 1, instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/tem_numero_de_telefone, &quot;&quot;)" />
+			<setvalue event="xforms-ready"  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/telefone"  value="if(instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/paciente_index = 1, instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/telefone, &quot;&quot;)" />
+			<setvalue event="xforms-ready"  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/numero_conviventes"  value="instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/numero_conviventes" />
+			<setvalue event="xforms-ready"  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/num_parceiros"  value="instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/num_parceiros" />
+			<setvalue event="xforms-ready"  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/numero_conviventes_under5"  value="instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/numero_conviventes_under5" />
+			<setvalue event="xforms-ready"  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/numero_conviventes_5_to_14"  value="instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/numero_conviventes_5_to_14" />
+			<setvalue event="xforms-ready"  ref="/data/consentimento_sim/registro_de_conviventes/address"  value="coalesce(instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/endereco_fisico, instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/address)" />
+			<setvalue event="xforms-ready"  ref="/data/referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province" value="lower-case(instance('locations')/locations/location[@id = instance('locations')/locations/location[@id = instance('commcaresession')/session/user/data/commcare_location_id]/@provincia_id]/location_data/location_code)" />
+			<setvalue event="xforms-ready"  ref="/data/data/referencia/household_name"  value="instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/nome_do_index" />
+			<setvalue event="xforms-ready"  ref="/data/data/geral/nome"  value="instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/nome" />
+			<setvalue event="xforms-ready"  ref="/data/data/geral/apelido"  value="instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/apelido" />
+			<setvalue event="xforms-ready"  ref="/data/data/geral/activista_responsavel_paciente" value="instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/@owner_id" />
+			<setvalue event="xforms-ready"  ref="/data/data/geral/index_perfil"  value="instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/index_perfil" />
+			<setvalue event="xforms-ready"  ref="/data/household_name"  value="instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id_casa]/case_name" />
+			<itext>
+				<translation lang="en" default="">
+					<text id="consentimento_registo-label">
+						<value>### Does the patient agree to be registered?</value>
+						<value form="markdown">### Does the patient agree to be registered?</value>
+					</text>
+					<text id="consentimento_registo-sim-label">
+						<value>Yes</value>
+					</text>
+					<text id="consentimento_registo-nao-label">
+						<value>No</value>
+					</text>
+					<text id="referencia_de_localizacao/referecencia_gps-label">
+						<value>Capture GPS coordinates</value>
+						<value form="markdown">Capture GPS coordinates</value>
+					</text>
+					<text id="consentimento_sim-label">
+						<value>Agreed</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes-label">
+						<value>Family members registratio</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information-label">
+						<value>Patient Information</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/lbl_confirmar_informacao-label">
+						<value>Please confirm the information of the patient</value>
+					</text>
+					<text id="apelido-label">
+						<value>**Last name**  </value>
+						<value form="markdown">**Last name**  </value>
+					</text>
+					<text id="nome_primero-label">
+						<value>**First name**</value>
+						<value form="markdown">**First name**</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/nome_primero-hint">
+						<value>Incluir todos os nomes do paciente, sem o apelido.</value>
+					</text>
+					<text id="genero-label">
+						<value>**Gender**</value>
+						<value form="markdown">**Gender**</value>
+					</text>
+					<text id="genero-masculino-label">
+						<value>Male</value>
+					</text>
+					<text id="genero-feminino-label">
+						<value>Female</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/data_de_nacimento_conhecido-label">
+						<value>Is the date of birth know?</value>
+						<value form="markdown">Is the date of birth know?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/data_de_nacimento_conhecido-sim-label">
+						<value>Yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/data_de_nacimento_conhecido-nao-label">
+						<value>No</value>
+					</text>
+					<text id="data_do_nacimiento-label">
+						<value>Date of Birth:</value>
+						<value form="markdown">Date of Birth:</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/data_do_nacimento-constraintMsg">
+						<value>The date can't be in the future</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/idade_perguntar-label">
+						<value>What's approximate age?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/idade_perguntar-constraintMsg">
+						<value>The date can't be higher than 99 years</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/question1/display_idade_meses-label">
+						<value>Age: <output value="/data/data/geral/idade_meses"  /> months.</value>
+						<value form="markdown">Age: <output value="/data/data/geral/idade_meses"  /> months.</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/question1/display_idade_anos-label">
+						<value>Age:<output value="/data/data/geral/idade_calc"  /> years.</value>
+						<value form="markdown">Age:<output value="/data/data/geral/idade_calc"  /> years.</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/question1/lbl_breasfeeding_child-label">
+						<value>If the child is breastfeeding and has an HIV+ mother, don't register the baby as a contact. This child has to be registered as an ACT patient.</value>
+						<value form="markdown">If the child is breastfeeding and has an HIV+ mother, don't register the baby as a contact. This child has to be registered as an ACT patient.</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez-label">
+						<value>Confirm pregnancy</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez/nova_gravidez-label">
+						<value>Is the patient pregnant?</value>
+						<value form="markdown">Is the patient pregnant?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez/nova_gravidez-sim-label">
+						<value>Yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez/nova_gravidez-nao-label">
+						<value>No</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez/tem_edd-label">
+						<value>Do you have the EDD?</value>
+						<value form="markdown">Do you have the EDD?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez/tem_edd-sim-label">
+						<value>Yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez/tem_edd-nao-label">
+						<value>No</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez/edd-label">
+						<value>What is the expected delivery date?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_lactancia-label">
+						<value>Confirm breastfeeding </value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_lactancia/nova_lactancia-label">
+						<value>Is the patient breasfeeding?</value>
+						<value form="markdown">Is the patient breasfeeding?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_lactancia/nova_lactancia-sim-label">
+						<value>Yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_lactancia/nova_lactancia-nao-label">
+						<value>No</value>
+					</text>
+					<text id="estado_civil-label">
+						<value>Marital status </value>
+						<value form="markdown">Marital status </value>
+					</text>
+					<text id="estado_civil-solteiro-label">
+						<value>Single</value>
+					</text>
+					<text id="estado_civil-casado-label">
+						<value>Married</value>
+					</text>
+					<text id="estado_civil-viuvo-label">
+						<value>Widow</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/estado_civil-uniao_de_fact-label">
+						<value>Common-law marriage</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/estado_civil-divorcado-label">
+						<value>Divorced</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/escolaridade-label">
+						<value>Education </value>
+						<value form="markdown">Education </value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/escolaridade-hint">
+						<value>Please select the maximum study level of the patient</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/escolaridade-nenhuma-label">
+						<value>None</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/escolaridade-primario-label">
+						<value>Primary</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/escolaridade-secundario-label">
+						<value>Secundary</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/escolaridade-universitario-label">
+						<value>Universitary</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/ocupacao-label">
+						<value>Occupation </value>
+						<value form="markdown">Occupation </value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/ocupacao-camionista-label">
+						<value>Truck driver</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/ocupacao-militar-label">
+						<value>Military</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/ocupacao-mineiro-label">
+						<value>Miiner</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/ocupacao-trab_sexo-label">
+						<value>Sex worker</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/ocupacao-trab_saude-label">
+						<value>Health worker</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/ocupacao-educacao-label">
+						<value>Education worker</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/ocupacao-estudante-label">
+						<value>Student</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/ocupacao-informal-label">
+						<value>Informal</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/ocupacao-domestica-label">
+						<value>Domestic worker</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/ocupacao-policia-label">
+						<value>Police</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/ocupacao-campones-label">
+						<value>Farmer</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/ocupacao-recluso-label">
+						<value>Recluse</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/ocupacao-outro-label">
+						<value>Other</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/ocupacao_outro-label">
+						<value>Other:</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/nome_empresa-label">
+						<value>Name of the company where works</value>
+					</text>
+					<text id="grau_de_parentesco-label">
+						<value>Relationship to index patient</value>
+						<value form="markdown">Relationship to index patient</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/grau_de_parentesco-constraintMsg">
+						<value>Children less that 12-years old cannot be marked as partners.</value>
+					</text>
+					<text id="grau_de_parentesco-esposo-label">
+						<value>Husband or Wife</value>
+					</text>
+					<text id="grau_de_parentesco-filho-label">
+						<value>Son or Daughter</value>
+					</text>
+					<text id="grau_de_parentesco-namorado-label">
+						<value>Partner</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/grau_de_parentesco-pai-label">
+						<value>Mother</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/grau_de_parentesco-sobrinho-label">
+						<value>Nephew</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/grau_de_parentesco-irmao-label">
+						<value>Brother</value>
+					</text>
+					<text id="grau_de_parentesco-outro-label">
+						<value>Other</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/parceiro_fora_da_casa_perguntar-label">
+						<value>(to delete) Is this a partner that lives in another household?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/parceiro_fora_da_casa_perguntar-sim-label">
+						<value>Yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/parceiro_fora_da_casa_perguntar-nao-label">
+						<value>No</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/sexual_partner_info-label">
+						<value>Sexual Partner Info</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/sexual_partner_info/num_parceiros_fora_casa-label">
+						<value>Number of  sexual partners outside house</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/sexual_partner_info/num_parceiros_fora_casa-hint">
+						<value>Inside and Outside the House</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/sexual_partner_info/register_info_sexual_lbl-label">
+						<value>Should you have more details for Sexual Partners Outside the house, please use the form Register Sexual Partners to fill this information.</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/parceiro_fora_da_casa_endereco-label">
+						<value>Please indicate the address of this partner</value>
+					</text>
+					<text id="outro_grau_de_parentesco-label">
+						<value>Other:</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/tem_numero_de_telefone-label">
+						<value>Has a phone number?</value>
+						<value form="markdown">Has a phone number?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/tem_numero_de_telefone-sim-label">
+						<value>Yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/tem_numero_de_telefone-nao-label">
+						<value>No</value>
+					</text>
+					<text id="telefone-label">
+						<value>Contact phone number</value>
+						<value form="markdown">Contact phone number</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/telefone-constraintMsg">
+						<value>Telephone number has to contain 9 digits</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/consentimento_menor_15_anos-label">
+						<value>The contact is **under 15 years**. Does the responsible adult agrees with the child being registered?</value>
+						<value form="markdown">The contact is **under 15 years**. Does the responsible adult agrees with the child being registered?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/consentimento_menor_15_anos-sim-label">
+						<value>Yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/consentimento_menor_15_anos-nao-label">
+						<value>No</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member-label">
+						<value>Contacts information</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-label">
+						<value> **number of household members.**</value>
+						<value form="markdown"> **number of household members.**</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-hint">
+						<value>The same number of contacts for patients with TB</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-0-label">
+						<value>0</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-1-label">
+						<value>1</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-2-label">
+						<value>2</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-3-label">
+						<value>3</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-4-label">
+						<value>4</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-5-label">
+						<value>5</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-6-label">
+						<value>6</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-7-label">
+						<value>7</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-8-label">
+						<value>8</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-9-label">
+						<value>9</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-10-label">
+						<value>10</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-11-label">
+						<value>11</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-12-label">
+						<value>12</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-13-label">
+						<value>13</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-14-label">
+						<value>14</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-15-label">
+						<value>15</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-16-label">
+						<value>16</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-17-label">
+						<value>17</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-18-label">
+						<value>18</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-19-label">
+						<value>19</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-20-label">
+						<value>20</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/num_parceiros-label">
+						<value>Number of partners living the house</value>
+						<value form="markdown">Number of partners living the house</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes_under5-label">
+						<value>Number of HH members under 5 years</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes_5_to_14-label">
+						<value>Number of HH members between 5 - 14 years</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/filhos_fora_hh-label">
+						<value>Children outside HH</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/filhos_fora_hh/children_living_outside_the_hh-label">
+						<value>Children living outside the HH?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/filhos_fora_hh/children_living_outside_the_hh-yes-label">
+						<value>yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/filhos_fora_hh/children_living_outside_the_hh-no-label">
+						<value>No</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/filhos_fora_hh/number_of_children_living_outside_the_house-label">
+						<value>Number of children living outside the house</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/filhos_fora_hh/lbl_counsel-label">
+						<value>It is necessary to remind the patient that testing the child is very important.Incentivize the patient to get in touch with the relative where this child lives and explain that he should take it to the Sanitary Unit to test</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/o_paciente__sexualmente_activo-label">
+						<value>Is the patient sexualy active?</value>
+						<value form="markdown">Is the patient sexualy active?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/o_paciente__sexualmente_activo-sim-label">
+						<value>yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/o_paciente__sexualmente_activo-no-label">
+						<value>no</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/tipo_de_sexo-label">
+						<value>What is the type type of sex </value>
+						<value form="markdown">What is the type type of sex </value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/tipo_de_sexo-anal-label">
+						<value>anal</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/tipo_de_sexo-oral-label">
+						<value>oral</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/tipo_de_sexo-vaginal-label">
+						<value>vaginal</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/relacoes_mesmo_sexo-label">
+						<value>Does the patient have sexual intercourse with the same sex or both?</value>
+						<value form="markdown">Does the patient have sexual intercourse with the same sex or both?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/relacoes_mesmo_sexo-sim-label">
+						<value>yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/relacoes_mesmo_sexo-no-label">
+						<value>no</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/o_paciente_tem_mais_de_um_parceiro_sexual-label">
+						<value>Does the patient have more than one sexual partner ?</value>
+						<value form="markdown">Does the patient have more than one sexual partner ?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/o_paciente_tem_mais_de_um_parceiro_sexual-sim-label">
+						<value>yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/o_paciente_tem_mais_de_um_parceiro_sexual-no-label">
+						<value>no</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/alguma_vez_foi_solicitado_a_ter_relaes_sexuais_com_algum_em_troca_de_dinhei-label">
+						<value>Have you ever been asked to have sex with someone in exchange for money or gifts?</value>
+						<value form="markdown">Have you ever been asked to have sex with someone in exchange for money or gifts?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/alguma_vez_foi_solicitado_a_ter_relaes_sexuais_com_algum_em_troca_de_dinhei-sim-label">
+						<value>yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/alguma_vez_foi_solicitado_a_ter_relaes_sexuais_com_algum_em_troca_de_dinhei-no-label">
+						<value>no</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/consome_bebidas_alcolicas-label">
+						<value>Do you drink alcohol?
+</value>
+						<value form="markdown">Do you drink alcohol?
+</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/consome_bebidas_alcolicas-sim-label">
+						<value>yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/consome_bebidas_alcolicas-nao-label">
+						<value>no</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/que_tipo_costuma_consumir-label">
+						<value>What type do you usually consume?</value>
+						<value form="markdown">What type do you usually consume?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/consome_outras_drogas-label">
+						<value>Are you currently using any drugs?</value>
+						<value form="markdown">Are you currently using any drugs?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/consome_outras_drogas-sim-label">
+						<value>yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/consome_outras_drogas-nao-label">
+						<value>no</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/frequencia_drogas-label">
+						<value>How often do you use these drugs?</value>
+						<value form="markdown">How often do you use these drugs?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos-label">
+						<value>HIV adult testing </value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/indique_os_factores_de_risco_que_o_paciente_apresenta-label">
+						<value>### Does the patient present any of these risk factors?</value>
+						<value form="markdown">### Does the patient present any of these risk factors?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/indique_os_factores_de_risco_que_o_paciente_apresenta-constraintMsg">
+						<value>Because you have selected the option 'None' you can't have other symptoms selected!</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/indique_os_factores_de_risco_que_o_paciente_apresenta-nenhum-label">
+						<value>None</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/indique_os_factores_de_risco_que_o_paciente_apresenta-esteve_internado_nos_ultimos_6_meses-label">
+						<value>Was hospitalised in the past 6 months</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/indique_os_factores_de_risco_que_o_paciente_apresenta-parceiro_de_PVHIV-label">
+						<value>Is the patient a sexual partner of a PVHIV?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/indique_os_factores_de_risco_que_o_paciente_apresenta-o_paciente_usa_preservativo_durante_as_relaes_sexuai-label">
+						<value>Does the patient use condoms during sex?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-label">
+						<value>### Does the patient present any of the symptoms?</value>
+						<value form="markdown">### Does the patient present any of the symptoms?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-constraintMsg">
+						<value>Because you have selected the option 'None' you can't have other symptoms selected!</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-nenhum-label">
+						<value>None</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-sinais_e_sintomas_respiratorios-label">
+						<value>Respiratory signs and symptoms</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-corrimento_ou_feridas_genitais-label">
+						<value>Genital discharge or wounds</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-inchaco-label">
+						<value>Swelling of lower limbs</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-perda_de_peso-label">
+						<value>Visible weight loss
+ </value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-diarreia-label">
+						<value>Diarrhea for more than 15 days</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-febre-label">
+						<value>Inexplicable persistent fever
+ </value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-dificuldades_comer-label">
+						<value>Sores on the mouth or difficulty eating</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-problema_pele-label">
+						<value>Skin problems such as itching, night burn, wounds</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-outro-label">
+						<value>other</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/outro-label">
+						<value>Other</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/este__um_adulto_em_risco_e_deve_ser_testado-label">
+						<value>This adult is at risk and should be tested</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population-label">
+						<value>HIV screening for key population</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens-label">
+						<value>Men who have sex with men</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/produto_lubrificacao-label">
+						<value>Have you ever used a lubrification product during anal sex?</value>
+						<value form="markdown">Have you ever used a lubrification product during anal sex?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/produto_lubrificacao-sim-label">
+						<value>yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/produto_lubrificacao-nao-label">
+						<value>no</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/tipo_lubricador-label">
+						<value>Qual foi o produto de lubrificação que usou durante o sexo anal?</value>
+						<value form="markdown">Qual foi o produto de lubrificação que usou durante o sexo anal?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/sabe_sobre_HIV-label">
+						<value>Have you heard of ITS and HIV?</value>
+						<value form="markdown">Have you heard of ITS and HIV?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/sabe_sobre_HIV-sim-label">
+						<value>yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/sabe_sobre_HIV-no-label">
+						<value>no</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/sabe_prevenir-label">
+						<value>Knows how to prevent the desease?</value>
+						<value form="markdown">Knows how to prevent the desease?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/sabe_prevenir-sim-label">
+						<value>yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/sabe_prevenir-nao-label">
+						<value>no</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/acredita_HIV-label">
+						<value>Does the patient believe that through anal sex he can get ITS or HIV?</value>
+						<value form="markdown">Does the patient believe that through anal sex he can get ITS or HIV?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/acredita_HIV-sim-label">
+						<value>yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/acredita_HIV-nao-label">
+						<value>no</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/disieases-label">
+						<value>Patient ever had sores or discharge, irritations, or comichoes in the anus or penis?</value>
+						<value form="markdown">Patient ever had sores or discharge, irritations, or comichoes in the anus or penis?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/disieases-sim-label">
+						<value>yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/disieases-nao-label">
+						<value>sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/procurou_tratamento-label">
+						<value>Looked for treatment?</value>
+						<value form="markdown">Looked for treatment?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/procurou_tratamento-sim_en-label">
+						<value>sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/procurou_tratamento-no_en-label">
+						<value>não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/este_peciente_est_em_risco_e_deve_ser_testado_pois_apresenta_factores_de_ho-label">
+						<value>This patient should be tested because he presents factors of men that have sexual intercourse with men.</value>
+						<value form="markdown">This patient should be tested because he presents factors of men that have sexual intercourse with men.</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46-label">
+						<value>Trabalhadoras de sexo</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/txt_reaction-label">
+						<value>What has been your reaction when a client pays more not to use condoms?</value>
+						<value form="markdown">What has been your reaction when a client pays more not to use condoms?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/ja_ouviu_falar_de_its_hiv-label">
+						<value>Have you heard about ITS?HIV/SIDA?</value>
+						<value form="markdown">Have you heard about ITS?HIV/SIDA?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/ja_ouviu_falar_de_its_hiv-sim-label">
+						<value>yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/ja_ouviu_falar_de_its_hiv-no-label">
+						<value>no</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/sabe_como_se_prevenir_para_no_contrair-label">
+						<value>Do you know how to prevent it from contracting?</value>
+						<value form="markdown">Do you know how to prevent it from contracting?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/sabe_como_se_prevenir_para_no_contrair-sim-label">
+						<value>yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/sabe_como_se_prevenir_para_no_contrair-no-label">
+						<value>no</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/usa_o_preservativo_com_os_clientes_e_tambm_com_seu_parceiro-label">
+						<value>
+Do you use the condom with clients and also with your partner?</value>
+						<value form="markdown">
+Do you use the condom with clients and also with your partner?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/usa_o_preservativo_com_os_clientes_e_tambm_com_seu_parceiro-sim-label">
+						<value>yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/usa_o_preservativo_com_os_clientes_e_tambm_com_seu_parceiro-no-label">
+						<value>no</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/usa_em_todas_as_practicas_sexuais-label">
+						<value>Patient uses in all sexual practices?</value>
+						<value form="markdown">Patient uses in all sexual practices?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/usa_em_todas_as_practicas_sexuais-sim-label">
+						<value>yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/usa_em_todas_as_practicas_sexuais-nao-label">
+						<value>no</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/produto_lubrificacao-label">
+						<value>Have you ever used a lubrification product during anal sex?</value>
+						<value form="markdown">Have you ever used a lubrification product during anal sex?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/produto_lubrificacao-sim-label">
+						<value>yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/produto_lubrificacao-nao-label">
+						<value>no</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/tipo_lubricador-label">
+						<value>Qual foi o produto de lubrificação que usou durante o sexo anal?</value>
+						<value form="markdown">Qual foi o produto de lubrificação que usou durante o sexo anal?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/onde_tem_praticado_sua_actividade_como_trabalhadora-label">
+						<value>Onde tem praticado sua actividade como trabalhadora?</value>
+						<value form="markdown">Onde tem praticado sua actividade como trabalhadora?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/onde_tem_praticado_sua_actividade_como_trabalhadora-rua-label">
+						<value>street</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/onde_tem_praticado_sua_actividade_como_trabalhadora-barracas-label">
+						<value>barraca</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/onde_tem_praticado_sua_actividade_como_trabalhadora-casa-label">
+						<value>home</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/onde_tem_praticado_sua_actividade_como_trabalhadora-hotel-label">
+						<value>hotel</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/esta_paciente__trabalhadora_de_sexo_e_deve_ser_testada-label">
+						<value>This patient is a sex worker and should be tested</value>
+						<value form="markdown">This patient is a sex worker and should be tested</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas-label">
+						<value>
+Testing for people who use and inject drugs</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/relation_after_drugs-label">
+						<value>How have your sexual intercourse been after drug use?</value>
+						<value form="markdown">How have your sexual intercourse been after drug use?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/usa_preservativo_durante_as_suas_relacoes_sxuais-label">
+						<value>Does the patient wear a condom during sexual intercouse?</value>
+						<value form="markdown">Does the patient wear a condom during sexual intercouse?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/usa_preservativo_durante_as_suas_relacoes_sxuais-sim-label">
+						<value>yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/usa_preservativo_durante_as_suas_relacoes_sxuais-nao-label">
+						<value>no</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/usa_drogas_injectaveis-label">
+						<value>Usa drogas injectaveis?</value>
+						<value form="markdown">Usa drogas injectaveis?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/usa_drogas_injectaveis-sim-label">
+						<value>yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/usa_drogas_injectaveis-nao-label">
+						<value>no</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/com_que_frequencia_usa_estas_drogas-label">
+						<value>How frequent makes use of these drugs?</value>
+						<value form="markdown">How frequent makes use of these drugs?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/j_partilhou_agulhas_ou_seringas-label">
+						<value>Já partilhou agulhas ou seringas?</value>
+						<value form="markdown">Já partilhou agulhas ou seringas?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/j_partilhou_agulhas_ou_seringas-sim-label">
+						<value>yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/j_partilhou_agulhas_ou_seringas-nao-label">
+						<value>no</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/acha_que_alguem_que_usa_drogas_injectaveis_corre_risco_de_contrair_o_hiv-label">
+						<value>Do you think someone who uses injectable drugs is at risk for HIV?</value>
+						<value form="markdown">Do you think someone who uses injectable drugs is at risk for HIV?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/acha_que_alguem_que_usa_drogas_injectaveis_corre_risco_de_contrair_o_hiv-sim-label">
+						<value>yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/acha_que_alguem_que_usa_drogas_injectaveis_corre_risco_de_contrair_o_hiv-nao-label">
+						<value>no</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/este_paciente_faz_o_uso_de_drogas_e_deve-label">
+						<value>This patiente makes use of drugs and should be tested</value>
+						<value form="markdown">This patiente makes use of drugs and should be tested</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido-label">
+						<value>Test</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment-label">
+						<value>pre-test assessment</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18-label">
+						<value>HIV testing for child under 10</value>
+					</text>
+					<text id="testagem_HIV/hiv_mostrar_apenas_menos_18/amamentacao-label">
+						<value>Is the mother alive and present with documented information?</value>
+						<value form="markdown">Is the mother alive and present with documented information?</value>
+					</text>
+					<text id="testagem_HIV/hiv_mostrar_apenas_menos_18/amamentacao-sim-label">
+						<value>Yes</value>
+					</text>
+					<text id="testagem_HIV/hiv_mostrar_apenas_menos_18/amamentacao-nao-label">
+						<value>No</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/documentation-label">
+						<value>Does the contact have the PTV information in the child's health card?</value>
+						<value form="markdown">Does the contact have the PTV information in the child's health card?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/documentation-sim-label">
+						<value>Yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/documentation-nao-label">
+						<value>No</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/pedir_cartao-label">
+						<value>Ask for the card and check the information.</value>
+						<value form="image">jr://file/commcare/image/data/paciente_index/cartao_disponivel.jpg</value>
+						<value form="markdown">Ask for the card and check the information.</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/seroestado_conhecido-label">
+						<value>Do you know the mother's HIV status?</value>
+						<value form="markdown">Do you know the mother's HIV status?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/seroestado_conhecido-sim-label">
+						<value>Yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/seroestado_conhecido-nao-label">
+						<value>No</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/seroestado_da_mae-label">
+						<value>What's the mother's HIV rest result?</value>
+						<value form="markdown">What's the mother's HIV rest result?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/seroestado_da_mae-positivo-label">
+						<value>Positive</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/seroestado_da_mae-negativo-label">
+						<value>Negative</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/crianca_em_seguimento-label">
+						<value>Is the child in CCR follow-up?</value>
+						<value form="markdown">Is the child in CCR follow-up?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/crianca_em_seguimento-sim-label">
+						<value>Yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/crianca_em_seguimento-nao-label">
+						<value>No</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/internada_ultimos_6meses-label">
+						<value>
+Has the child been hospitalized in the last six months?</value>
+						<value form="markdown">
+Has the child been hospitalized in the last six months?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/internada_ultimos_6meses-sim-label">
+						<value>yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/internada_ultimos_6meses-no-label">
+						<value>no</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/lesao_ultimos_6meses-label">
+						<value>Has the child had any extensive skin lesions in the past 6 months or an injury that has not improved with treatment?</value>
+						<value form="markdown">Has the child had any extensive skin lesions in the past 6 months or an injury that has not improved with treatment?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/lesao_ultimos_6meses-sim-label">
+						<value>yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/lesao_ultimos_6meses-nao-label">
+						<value>no</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/severe_health_issues-label">
+						<value>
+Has the child had any severe health problems in the past 3 months?</value>
+						<value form="markdown">
+Has the child had any severe health problems in the past 3 months?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/severe_health_issues-sim-label">
+						<value>yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/severe_health_issues-no-label">
+						<value>no</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos-label">
+						<value>HIV test for teenager (10-18 years)</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/hospitalised_6months-label">
+						<value>Patient was hospitalised in the last 6 months?</value>
+						<value form="markdown">Patient was hospitalised in the last 6 months?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/hospitalised_6months-sim-label">
+						<value>yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/hospitalised_6months-no-label">
+						<value>no</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_teve_uma_leso_extensa_que_no_melhora_com_o_tratamento-label">
+						<value>Patient had an extensive injury that didn't heal with treatment</value>
+						<value form="markdown">Patient had an extensive injury that didn't heal with treatment</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_teve_uma_leso_extensa_que_no_melhora_com_o_tratamento-sim-label">
+						<value>yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_teve_uma_leso_extensa_que_no_melhora_com_o_tratamento-no-label">
+						<value>No</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/nos_ultimos_3_meses_teve_algum_problema_de_saude_persistente_como_perda_de_-label">
+						<value>Patient had a severe and persistent health problem in the last 3 months</value>
+						<value form="markdown">Patient had a severe and persistent health problem in the last 3 months</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/nos_ultimos_3_meses_teve_algum_problema_de_saude_persistente_como_perda_de_-sim-label">
+						<value>yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/nos_ultimos_3_meses_teve_algum_problema_de_saude_persistente_como_perda_de_-no-label">
+						<value>no</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_tem_corrimento-label">
+						<value>Does the patient have discharge? </value>
+						<value form="markdown">Does the patient have discharge? </value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_tem_corrimento-sim-label">
+						<value>yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_tem_corrimento-no-label">
+						<value>no</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_tem_um_dos_seguintes_problemas-label">
+						<value>Please indicate</value>
+						<value form="markdown">Please indicate</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_tem_um_dos_seguintes_problemas-corrimento_vaginal-label">
+						<value>vaginal discharge
+ </value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_tem_um_dos_seguintes_problemas-corrimento_uretral-label">
+						<value>urethral discharge
+ </value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_tem_um_dos_seguintes_problemas-ulcera_genital-label">
+						<value>Genital ulcer</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/este_adolescente_est_em_risco_e_deve_ser_testado-label">
+						<value>This adolescente is at risk and should be tested.</value>
+						<value form="markdown">This adolescente is at risk and should be tested.</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions-label">
+						<value>Patient questions</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testado_hiv_vez-label">
+						<value>Have you ever been tested for HIV?</value>
+						<value form="markdown">Have you ever been tested for HIV?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testado_hiv_vez-sim-label">
+						<value>Yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testado_hiv_vez-nao-label">
+						<value>No</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/fez_pcr-label">
+						<value>Did PCR?</value>
+						<value form="markdown">Did PCR?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/fez_pcr-sim-label">
+						<value>Yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/fez_pcr-não-label">
+						<value>No</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/resultado_previo_hiv-label">
+						<value>What was the result?</value>
+						<value form="markdown">What was the result?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/resultado_previo_hiv-positivo-label">
+						<value>Positive</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/resultado_previo_hiv-negativo-label">
+						<value>Negative</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/resultado_previo_hiv-indeterminado-label">
+						<value>Indetermindado</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/child_still_breastfeeding-label">
+						<value>Is the child still breastfeeding?</value>
+						<value form="markdown">Is the child still breastfeeding?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/child_still_breastfeeding-yes-label">
+						<value>Yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/child_still_breastfeeding-no-label">
+						<value>No</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/mai_parou_amamentar-label">
+						<value>Was the child tested at least two months after the mother stopped breastfeeding?</value>
+						<value form="markdown">Was the child tested at least two months after the mother stopped breastfeeding?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/mai_parou_amamentar-sim-label">
+						<value>Yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/mai_parou_amamentar-nao-label">
+						<value>No</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/child_risk_evaluated-label">
+						<value>The child was sufficiently evaluated for their risk of transmission via their mother. Generally, it is not necessary to test this child until they present some risky behavior. </value>
+						<value form="markdown">The child was sufficiently evaluated for their risk of transmission via their mother. Generally, it is not necessary to test this child until they present some risky behavior. </value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/tem_nid-label">
+						<value>Does the patient have a NID?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/tem_nid-sim-label">
+						<value>Yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/tem_nid-nao-label">
+						<value>No</value>
+					</text>
+					<text id="nid-label">
+						<value>NID number</value>
+						<value form="markdown">NID number</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/nid-constraintMsg">
+						<value>The fill rule of NID: ######## / ## / ##</value>
+					</text>
+					<text id="testado_por_hiv_recente-label">
+						<value>Have you been tested for HIV in the last 3 months?</value>
+						<value form="markdown">Have you been tested for HIV in the last 3 months?</value>
+					</text>
+					<text id="testado_por_hiv_recente-sim-label">
+						<value>Yes</value>
+					</text>
+					<text id="testado_por_hiv_recente-nao-label">
+						<value>No</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/data_ultimo_teste_hiv-label">
+						<value>When approximately was the test done?</value>
+						<value form="markdown">When approximately was the test done?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/restagem_3_meses-label">
+						<value>The contact should be retested three months after the last test.</value>
+						<value form="markdown">The contact should be retested three months after the last test.</value>
+					</text>
+					<text id="em_tratamento_hiv-label">
+						<value>In treatment for HIV?</value>
+						<value form="markdown">In treatment for HIV?</value>
+					</text>
+					<text id="em_tratamento_hiv-sim-label">
+						<value>Yes</value>
+					</text>
+					<text id="em_tratamento_hiv-nao-label">
+						<value>No</value>
+					</text>
+					<text id="em_tratamento_hiv-label2">
+						<value>Is the contact in CCR follow-up?</value>
+						<value form="markdown">Is the contact in CCR follow-up?</value>
+					</text>
+					<text id="em_tratamento_hiv-sim-label2">
+						<value>Yes</value>
+					</text>
+					<text id="em_tratamento_hiv-nao-label2">
+						<value>No</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/lbl_no_test-label">
+						<value>**The patient does not need to test for HIV because he knows his status**</value>
+						<value form="markdown">**The patient does not need to test for HIV because he knows his status**</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/contact_doesnt_require_test-label">
+						<value>**The patient does not need to be tested for HIV.**
+This contact already knows his/her sero-status, is not the index patient's partner, and is not a child under 10 with a seropositive mother.</value>
+						<value form="markdown">**The patient does not need to be tested for HIV.**
+This contact already knows his/her sero-status, is not the index patient's partner, and is not a child under 10 with a seropositive mother.</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/test_patient_anyway-label">
+						<value>Is there any exceptional reason to test this patient?</value>
+						<value form="markdown">Is there any exceptional reason to test this patient?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/test_patient_anyway-yes-label">
+						<value>Yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/test_patient_anyway-nao-label">
+						<value>No</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/reason_to_test_hiv-label">
+						<value>Reason:</value>
+						<value form="markdown">Reason:</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/querer_testar-label">
+						<value>Does the patient want to be tested for HIV?</value>
+						<value form="markdown">Does the patient want to be tested for HIV?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/querer_testar-sim-label">
+						<value>Yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/querer_testar-nao-label">
+						<value>No</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/si_nao-label">
+						<value>If not, why?</value>
+						<value form="markdown">If not, why?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/si_nao-nao_tem_interesse-label">
+						<value>Not interested</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/si_nao-teme_resultado-label">
+						<value>Fear for result</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/si_nao-ja_sabe_diagnostico-label">
+						<value>Are aware of his/her diagnosis </value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/activista_capacitado_testagem-label">
+						<value>Is the Chw able to do the testing?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/activista_capacitado_testagem-sim-label">
+						<value>yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/activista_capacitado_testagem-no-label">
+						<value>no</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/referir_para_teste-label">
+						<value>Quer referir este paciente para a US para testar?</value>
+						<value form="markdown">Quer referir este paciente para a US para testar?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/referir_para_teste-1-label">
+						<value>Sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/referir_para_teste-0-label">
+						<value>Não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/outcomes-label">
+						<value>Outcomes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/outcomes/referir_e_aconselhar-label">
+						<value>Advise and refer the patient to the Health Facility to initiate ART</value>
+						<value form="markdown">Advise and refer the patient to the Health Facility to initiate ART</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/outcomes/referir_crianca_ccr-label">
+						<value>Refer the patient to the health facility for CCR</value>
+						<value form="markdown">Refer the patient to the health facility for CCR</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/outcomes/aconselhado_adesao-label">
+						<value>Medication intake counselling</value>
+						<value form="markdown">Medication intake counselling</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/outcomes/aconselhado_saude_infantil-label">
+						<value>Counseling in child health.</value>
+						<value form="markdown">Counseling in child health.</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/outcomes/aconselhado_negativo-label">
+						<value>Verify education module</value>
+						<value form="markdown">Verify education module</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV-label">
+						<value>HIV testing</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos-label">
+						<value>New HIV Testing</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/ver_os_pasos_test1-label">
+						<value>Do you to see the steps to conduct the Determine Test?</value>
+						<value form="markdown">Do you to see the steps to conduct the Determine Test?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/ver_os_pasos_test1-sim-label">
+						<value>Yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/ver_os_pasos_test1-nao-label">
+						<value>No</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1-label">
+						<value>Test 1</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/preparacao-label">
+						<value>Determine: Preparation</value>
+						<value form="markdown">Determine: Preparation</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/preparacao/reunir_itens-label">
+						<value>1. Gather the items for test and any other neccesary consumibles</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/hiv_mostrar_apenas_mais_18/preparacao/reunir_itens.png</value>
+						<value form="markdown">1. Gather the items for test and any other neccesary consumibles</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/preparacao/tira_teste-label">
+						<value>2. hospitale a strip per test and preserve the lot number on the remaining packaging</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/teste_1/preparacao/tira_teste.png</value>
+						<value form="markdown">2. hospitale a strip per test and preserve the lot number on the remaining packaging</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/preparacao/rotule_cartao-label">
+						<value>3. Label the card with the hospitaler identification number.</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/teste_1/preparacao/rotule_cartao.jpg</value>
+						<value form="markdown">3. Label the card with the hospitaler identification number.</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/preparacao/remover_cobertura-label">
+						<value>4. Remove the metal protective cover.</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/teste_1/preparacao/remover_cobertura.jpg</value>
+						<value form="markdown">4. Remove the metal protective cover.</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/colhendo_amostra-label">
+						<value>Determine: Taking samples</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/colhendo_amostra/colhar_amostra-label">
+						<value>5. Collect 50 ul of sample to a capillary tube or a pipette,</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/teste_1/colhendo_amostra/colhar_amostra.jpg</value>
+						<value form="markdown">5. Collect 50 ul of sample to a capillary tube or a pipette,</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/aplicando_amostra-label">
+						<value>Determine: Taking the sample and cover the sample reactive</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/aplicando_amostra/aplicar_amostra-label">
+						<value>6. Apply the sample in the absorbent part of the testing strip</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/teste_1/aplicando_amostra/aplicar_amostra.jpg</value>
+						<value form="markdown">6. Apply the sample in the absorbent part of the testing strip</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/aplicando_amostra/sangue_total-label">
+						<value>7. For whole blood only, add 1 drop of buffer in the sample window.</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/teste_1/aplicando_amostra/sangue_total.jpg</value>
+						<value form="markdown">7. For whole blood only, add 1 drop of buffer in the sample window.</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/obtener_resultados-label">
+						<value>Determine: Obtaining the results</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/obtener_resultados/tempo_resultados-label">
+						<value>8. Wait for 15 minutes (no more than 60 min) to read the results</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/teste_1/obtener_resultados/tempo_resultados.jpg</value>
+						<value form="markdown">8. Wait for 15 minutes (no more than 60 min) to read the results</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/obtener_resultados/registrar_resultados-label">
+						<value>9. Read and record the results and other relevant information on the worksheet</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/teste_1/obtener_resultados/registrar_resultados.jpg</value>
+						<value form="markdown">9. Read and record the results and other relevant information on the worksheet</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/interpretacao_teste-label">
+						<value>Determine - Test Interpretation</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/teste_1/interpretacao_teste.jpg</value>
+						<value form="markdown">Determine - Test Interpretation</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/resultado_teste_rapido_determine-label">
+						<value>Result of the Rapid Test</value>
+						<value form="markdown">Result of the Rapid Test</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/resultado_teste_rapido_determine-positivo-label">
+						<value>Reactive</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/resultado_teste_rapido_determine-negativo-label">
+						<value>Not reactive</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/Quer_ver_os_pasos-label">
+						<value>Do you to see the steps to conduct the Unigold test?</value>
+						<value form="markdown">Do you to see the steps to conduct the Unigold test?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/Quer_ver_os_pasos-sim-label">
+						<value>Yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/Quer_ver_os_pasos-nao-label">
+						<value>No</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2-label">
+						<value>Test 2 Unigold</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/unigold_preparacao-label">
+						<value>Determine: Preparation</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/unigold_preparacao/unigold_reunir_itens-label">
+						<value>1. Gather the items for test and any other neccesary consumibles</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/hiv_mostrar_apenas_mais_18/preparacao/reunir_itens.jpg</value>
+						<value form="markdown">1. Gather the items for test and any other neccesary consumibles</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/unigold_preparacao/unigold_dispositivo_embalagem-label">
+						<value>2. Remove the packing device and label the device with the hospitaler identification number.</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/teste_2/unigold_preparacao/unigold_dispositivo_embalagem.jpg</value>
+						<value form="markdown">2. Remove the packing device and label the device with the hospitaler identification number.</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/unigold_colhendo_amostra-label">
+						<value>Uni-Gold: Taking samples</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/unigold_colhendo_amostra/unigold_colhar_amostra-label">
+						<value>3. Collect sample to a capillary tube or a pipette,</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/teste_2/unigold_colhendo_amostra/unigold_colhar_amostra.png</value>
+						<value form="markdown">3. Collect sample to a capillary tube or a pipette,</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/unigold_aplicando_amostra-label">
+						<value>Uni-Gold: Adding Sample and Reagent to Device Port of Entry</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/unigold_aplicando_amostra/unigold_aplicar_amostra-label">
+						<value>4. Apply 2 drops (approx. 60μl) of sample on the device's sample window.</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/teste_2/unigold_aplicando_amostra/unigold_aplicar_amostra.png</value>
+						<value form="markdown">4. Apply 2 drops (approx. 60μl) of sample on the device's sample window.</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/unigold_aplicando_amostra/unigold_sangue_total-label">
+						<value>5. Add 2 drops (± 60μL) of the kit buffer in the sample window</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/teste_2/unigold_aplicando_amostra/unigold_sangue_total.png</value>
+						<value form="markdown">5. Add 2 drops (± 60μL) of the kit buffer in the sample window</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/obtener_resultados-label">
+						<value>Uni-Gold: Obtaining the results</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/obtener_resultados/tempo_resultados-label">
+						<value>6. Wait for 10 minutes (no more than 20 min) to read the results</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/teste_2/obtener_resultados/tempo_resultados.jpg</value>
+						<value form="markdown">6. Wait for 10 minutes (no more than 20 min) to read the results</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/obtener_resultados/registrar_resultados-label">
+						<value>7. Read and record the results and other relevant information on the worksheet</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/teste_2/obtener_resultados/registrar_resultados.png</value>
+						<value form="markdown">7. Read and record the results and other relevant information on the worksheet</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/interpretacao_teste-label">
+						<value>Uni-Gold: Test Interpretation</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/teste_2/interpretacao_teste.png</value>
+						<value form="markdown">Uni-Gold: Test Interpretation</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/resultado_teste_rapido_unigold-label">
+						<value>Result of the Unig-Gold test</value>
+						<value form="markdown">Result of the Unig-Gold test</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/resultado_teste_rapido_unigold-postivo-label">
+						<value>Reactive</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/resultado_teste_rapido_unigold-negativo-label">
+						<value>Not reactive</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_final-label">
+						<value>Final result</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_final/display_resultado_do_teste_rapido-label">
+						<value>Result of the Rapid HIV Test:**<output value="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_do_teste_rapido"  />**</value>
+						<value form="markdown">Result of the Rapid HIV Test:**<output value="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_do_teste_rapido"  />**</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_final/resultado_indeterminado_repetir-label">
+						<value>**The testing process should be repeated.**</value>
+						<value form="markdown">**The testing process should be repeated.**</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2-label">
+						<value>Second HIV test</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/ver_os_pasos_test1-label">
+						<value>Do you to see the steps to conduct the Determine Test?</value>
+						<value form="markdown">Do you to see the steps to conduct the Determine Test?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/ver_os_pasos_test1-sim-label">
+						<value>Yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/ver_os_pasos_test1-nao-label">
+						<value>No</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/Quer_ver_os_pasos-label">
+						<value>Do you to see the steps to conduct the Unigold test?</value>
+						<value form="markdown">Do you to see the steps to conduct the Unigold test?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/Quer_ver_os_pasos-sim-label">
+						<value>Yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/Quer_ver_os_pasos-nao-label">
+						<value>No</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_final-label">
+						<value>Final result</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_final/display_resultado_do_teste_rapido-label">
+						<value>Result of the Rapid HIV Test: **<output value="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_do_teste_rapido_2"  />**</value>
+						<value form="markdown">Result of the Rapid HIV Test: **<output value="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_do_teste_rapido_2"  />**</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/question7-label">
+						<value>-Indeterminate HIV test result</value>
+						<value form="markdown">-Indeterminate HIV test result</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/couseling-label">
+						<value>Couseling</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/couseling/aconselhamento_pos-label">
+						<value>The result was positive. Talk with the person about the following subjects:
+
+* There is no cure for HIV/AIDS, mas has treatment;
+* HIV/AIDS treatment must be done throughout all life;
+* Before starting with the HIV/AIDS medication the patient's health must be evaluated, if it's too sick the person initiate the treatment but if not it will follow the consultations
+* It's important to prevent the transmission
+* It's important to comply with the medication, the follow up consultations and laboratory tests in the scheduled dates</value>
+						<value form="markdown">The result was positive. Talk with the person about the following subjects:
+
+* There is no cure for HIV/AIDS, mas has treatment;
+* HIV/AIDS treatment must be done throughout all life;
+* Before starting with the HIV/AIDS medication the patient's health must be evaluated, if it's too sick the person initiate the treatment but if not it will follow the consultations
+* It's important to prevent the transmission
+* It's important to comply with the medication, the follow up consultations and laboratory tests in the scheduled dates</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used-label">
+						<value>Tests Used</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_determine-label">
+						<value>Number of Determine tests used: **<output value="/data/data/geral/determine_used_calc"  />**</value>
+						<value form="markdown">Number of Determine tests used: **<output value="/data/data/geral/determine_used_calc"  />**</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_determine-corecto-label">
+						<value>Correct</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_determine-nao_corecto-label">
+						<value>Incorrect</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_determine_coregir-label">
+						<value>Number of Determine tests used:</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_determine_coregir-constraintMsg">
+						<value>A resposta não pode ser maior a 5</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_unigold-label">
+						<value>Number of Unigold tests used: **<output value="/data/data/geral/unigold_used_calc"  />**</value>
+						<value form="markdown">Number of Unigold tests used: **<output value="/data/data/geral/unigold_used_calc"  />**</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_unigold-corecto-label">
+						<value>Correct</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_unigold-nao_corecto-label">
+						<value>Incorrect</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_unigold_coregir-label">
+						<value>Number of Unigold tests used:</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_unigold_coregir-constraintMsg">
+						<value>A resposta não pode ser maior a 5</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/referencia-label">
+						<value>Referral</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/resultado_negativo_referral-label">
+						<value>-Please review the education module</value>
+						<value form="markdown">-Please review the education module</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/copy-1-of-resultado_positivo_referral_teste_vih-label">
+						<value>-HIV positive test</value>
+						<value form="markdown">-HIV positive test</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/referencia/referir_crianca-label">
+						<value>Refer the child to the health facility for CCR.</value>
+						<value form="markdown">Refer the child to the health facility for CCR.</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/referencia/referir_mae_crianca-label">
+						<value>Refer the child and mother to the health facility</value>
+						<value form="markdown">Refer the child and mother to the health facility</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/referencia/pos_seguimento-label">
+						<value>Child health counseling</value>
+						<value form="markdown">Child health counseling</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/referencia/neg_crianca_testado-label">
+						<value>Nutricional counseling</value>
+						<value form="markdown">Nutricional counseling</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership-label">
+						<value>Test Ownership</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/chw_testagem-label">
+						<value>Did the test was perform by another CHW?</value>
+						<value form="markdown">Did the test was perform by another CHW?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/chw_testagem-sim-label">
+						<value>Yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/chw_testagem-nao-label">
+						<value>No</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/activista_fez_testagem_hiv-label">
+						<value>By who?</value>
+						<value form="markdown">By who?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/tem_numero_de_telefone-label">
+						<value>Does the chw has a phone number?</value>
+						<value form="markdown">Does the chw has a phone number?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/tem_numero_de_telefone-sim-label">
+						<value>Yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/tem_numero_de_telefone-nao-label">
+						<value>No</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/telefone-constraintMsg">
+						<value>Telephone number has to contain 9 digits</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb-label">
+						<value>TB Screening</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/rastreio_tb_display-label">
+						<value>## TB Screening</value>
+						<value form="markdown">## TB Screening</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/antes_de_comenar_o_rastreio_lembre-se_d_en-label">
+						<value>Remember before you start the treatment, pay attention to the following symptoms </value>
+						<value form="image">jr://file/commcare/image/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/antes_de_comenar_o_rastreio_lembre-se_d_en-elh6qm.jpg</value>
+						<value form="markdown">Remember before you start the treatment, pay attention to the following symptoms </value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/ja_em_tratamento-label">
+						<value>Is the contact on TB treatment?</value>
+						<value form="markdown">Is the contact on TB treatment?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/ja_em_tratamento-sim-label">
+						<value>Yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/ja_em_tratamento-nao-label">
+						<value>No</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/verificar_adesao-label">
+						<value>Verify medication intake</value>
+						<value form="markdown">Verify medication intake</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/nit-label">
+						<value>What is the NIT?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/nit-constraintMsg">
+						<value>The NIT format is: ## / ## (ex: 123/22)</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/contacto_ultimo_ano-label">
+						<value>Did you have any contact with someone infected with TB during the last year?</value>
+						<value form="markdown">Did you have any contact with someone infected with TB during the last year?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/contacto_ultimo_ano-constraintMsg">
+						<value>O membro habita com um doente de TB!</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/contacto_ultimo_ano-sim-label">
+						<value>Yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/contacto_ultimo_ano-nao-label">
+						<value>No</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15-label">
+						<value>Does the contact have any of the following syntomphs</value>
+						<value form="markdown">Does the contact have any of the following syntomphs</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15-constraintMsg">
+						<value>Because you have selected the option 'None' you can't have other symptoms selected!</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15-nenhum-label">
+						<value>None</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15-tem_tosse-label">
+						<value>Cough </value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15-febre_2_semanas-label">
+						<value>Fever </value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15-perda_de_peso-label">
+						<value>Lost weight </value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15-Tem_falta_de_vontade_de_brincar-label">
+						<value>Fadigue or unwillingness to play</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15-Tem_caroço_no_pescoço_que_não_doi-label">
+						<value>Appearance of localized painless nodes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15-nao_responde_aos_suplementos-label">
+						<value>Not responding to nutritional supplements</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15-pneumonia_neonatal-label">
+						<value>Neonatal pneomonia</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-label">
+						<value>Does the contact has any of the following syntomphs</value>
+						<value form="markdown">Does the contact has any of the following syntomphs</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-constraintMsg">
+						<value>Because you have selected the option 'None' you can't have other symptoms selected!</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-nenhum-label">
+						<value>None</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-tem_tosse-label">
+						<value>Cough</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-sangue-label">
+						<value>Cough with blood</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-febre_2_semanas-label">
+						<value>Fever </value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-perda_de_peso-label">
+						<value>Lost weight </value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-transpira-label">
+						<value>Night sweating </value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-Tem_caroço_no_pescoço_que_não_doi-label">
+						<value>Lumps</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-cansado-label">
+						<value>Constant tiredness</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-diarreia-label">
+						<value>Diarrhea</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-fam_tb-label">
+						<value>Herpes Zoster</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details-label">
+						<value>symptoms details</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/cough-label">
+						<value>For how many week patient has presented cough?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/cough_with_blood-label">
+						<value>For how many week patient has presented cough with blood</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/fever-label">
+						<value>Fow how many weeks the patient has presented fever?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/lost_weight-label">
+						<value>How many kilos has the patient lost in the last month</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/fatigue-label">
+						<value>How many days the patient has presented fatigue</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/night_sweating-label">
+						<value>Fow how many weeks the patient has presented night sweating?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/diarrhea-label">
+						<value>How many days the patient has presented diarrhea?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_screening_result-label">
+						<value>Screening Result</value>
+						<value form="markdown">Screening Result</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_screening_result/referido_rastreio_tb-label">
+						<value>**The patient has a positive screening for TB for the following reasons**</value>
+						<value form="markdown">**The patient has a positive screening for TB for the following reasons**</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_screening_result/lbl_refer_exposed_child_tb-label">
+						<value>* TB designation - child exposed to TB</value>
+						<value form="markdown">* TB designation - child exposed to TB</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_screening_result/hiv_exposed-label">
+						<value>* TB designation - HIV + exposed to TB</value>
+						<value form="markdown">* TB designation - HIV + exposed to TB</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_screening_result/lbl_tb_symptoms-label">
+						<value>* TB designation- Clinical TB symptoms</value>
+						<value form="markdown">* TB designation- Clinical TB symptoms</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/referido_rastreio_tb-label">
+						<value>Positive Screening</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/referido_rastreio_tb/instruccoes_frascos-label">
+						<value>Leave one sample container, and explain that they must sneeze into the container the next morning as soon as they wake up, and bring it to the health facility to submit to the lab.</value>
+						<value form="markdown">Leave one sample container, and explain that they must sneeze into the container the next morning as soon as they wake up, and bring it to the health facility to submit to the lab.</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/referido_rastreio_tb/instruccoes-label">
+						<value>Do you want to see more instructions about the sputum collection?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/referido_rastreio_tb/instruccoes-sim-label">
+						<value>Yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/referido_rastreio_tb/instruccoes-nao-label">
+						<value>No</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/escarro-label">
+						<value>How to collect the sputum for analysis</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/escarro/question9-label">
+						<value>#### Instructions to collect the sputum sample:
+
+1. You have to drink plenty of water during the night
+2. In the next morning, must collect the expectoration before eating
+3. Must wash the hands and gargle before spitting
+4. Must spit in an open place, not inside the house
+5. Inhale deeply through the nose
+6. Hold the air for a few moments and expire
+7. After repeating 3 times the previous process, inhale deeply and exhale forcefully and cough
+8. After coughing, open the spittoon and expectorate the secretion inside the container without touching the inside
+9. Repeat the procedure until you have a sample of 5 and 10 ml
+10. Close the container tightly, place inside a plastic bag and protect from the sunlight
+11. Take the sample to the health facility and give to the "Gestor de casos" until 9 AM</value>
+						<value form="markdown">#### Instructions to collect the sputum sample:
+
+1. You have to drink plenty of water during the night
+2. In the next morning, must collect the expectoration before eating
+3. Must wash the hands and gargle before spitting
+4. Must spit in an open place, not inside the house
+5. Inhale deeply through the nose
+6. Hold the air for a few moments and expire
+7. After repeating 3 times the previous process, inhale deeply and exhale forcefully and cough
+8. After coughing, open the spittoon and expectorate the secretion inside the container without touching the inside
+9. Repeat the procedure until you have a sample of 5 and 10 ml
+10. Close the container tightly, place inside a plastic bag and protect from the sunlight
+11. Take the sample to the health facility and give to the "Gestor de casos" until 9 AM</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/patient_received_container-label">
+						<value>Did the patient received the container for delivering the sputum?</value>
+						<value form="markdown">Did the patient received the container for delivering the sputum?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/patient_received_container-yes-label">
+						<value>Yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/patient_received_container-no-label">
+						<value>No</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/not_received_container-label">
+						<value>If not, why?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties-label">
+						<value>TB properties</value>
+					</text>
+					<text id="referrals-label">
+						<value>Referrals</value>
+					</text>
+					<text id="referrals/required_referrals-label">
+						<value>Required Referrals</value>
+					</text>
+					<text id="referrals/required_referrals/list_required_referrals-label">
+						<value>Required Referrals</value>
+					</text>
+					<text id="referrals/required_referrals/list_required_referrals/referir_paciente-label">
+						<value>**Refer the patient to the health facility for the following referrals:**</value>
+						<value form="markdown">**Refer the patient to the health facility for the following referrals:**</value>
+					</text>
+					<text id="referrals/required_referrals/list_required_referrals/lbl_new_pregnancy-label">
+						<value>-New pregnancy to register in the facility</value>
+						<value form="markdown">-New pregnancy to register in the facility</value>
+					</text>
+					<text id="referrals/required_referrals/list_required_referrals/lbl_new_breastfeeding-label">
+						<value>-New breastfeeding status to register in facility</value>
+						<value form="markdown">-New breastfeeding status to register in facility</value>
+					</text>
+					<text id="referrals/required_referrals/list_required_referrals/lbl_refer_for_ccr-label">
+						<value>-Child to enroll in CCR</value>
+						<value form="markdown">-Child to enroll in CCR</value>
+					</text>
+					<text id="referrals/required_referrals/list_required_referrals/lbl_refer_child_pos_tb_screening-label">
+						<value>-Review Child for testing HIV</value>
+						<value form="markdown">-Review Child for testing HIV</value>
+					</text>
+					<text id="referrals/required_referrals/list_required_referrals/pacinete_para_testar_na_unidade_sanitria-label">
+						<value>- Patient to be Tested at the Health Facility</value>
+					</text>
+					<text id="referrals/required_referrals/list_required_referrals/lbl_iniciar_tarv-label">
+						<value>-Patient to initiate TARV</value>
+						<value form="markdown">-Patient to initiate TARV</value>
+					</text>
+					<text id="referrals/required_referrals/list_required_referrals/pos_seguimento-label">
+						<value>-Child health counseling*</value>
+						<value form="markdown">-Child health counseling*</value>
+					</text>
+					<text id="referrals/required_referrals/list_required_referrals/neg_crianca_testado-label">
+						<value>-Nutricional counseling</value>
+						<value form="markdown">-Nutricional counseling</value>
+					</text>
+					<text id="referrals/required_referrals/list_required_referrals/lbl_tb_positive-label">
+						<value>-Positive TB screening</value>
+						<value form="markdown">-Positive TB screening</value>
+					</text>
+					<text id="referrals/required_referrals/list_required_referrals/lbl_refer_hiv_for_tpi-label">
+						<value>* TB designation - Patient for TPI</value>
+						<value form="markdown">* TB designation - Patient for TPI</value>
+					</text>
+					<text id="referrals/required_referrals/list_required_referrals/lbl_refer_exposed_child_tb-label">
+						<value>* TB designation - child exposed to TB</value>
+						<value form="markdown">* TB designation - child exposed to TB</value>
+					</text>
+					<text id="referrals/required_referrals/list_required_referrals/hiv_exposed-label">
+						<value>* TB designation - HIV + exposed to TB</value>
+						<value form="markdown">* TB designation - HIV + exposed to TB</value>
+					</text>
+					<text id="referrals/required_referrals/list_required_referrals/lbl_tb_symptoms-label">
+						<value>* TB designation- Clinical TB symptoms</value>
+						<value form="markdown">* TB designation- Clinical TB symptoms</value>
+					</text>
+					<text id="referrals/required_referrals/fez_referencia-label">
+						<value>Does **<output value="/data/data/geral/nome_concat"  /> **  agrees to go to the health facility?</value>
+						<value form="markdown">Does **<output value="/data/data/geral/nome_concat"  /> **  agrees to go to the health facility?</value>
+					</text>
+					<text id="referrals/required_referrals/fez_referencia-sim-label">
+						<value>Yes</value>
+					</text>
+					<text id="referrals/required_referrals/fez_referencia-nao-label">
+						<value>No</value>
+					</text>
+					<text id="referrals/required_referrals/does_patients_name_accepts_to_receive_care_at_chw_hf_name-label">
+						<value>Does **<output value="/data/data/geral/nome_concat"  />**   accepts to receive care at  **<output value="/data/data/geral/us"  />** ?</value>
+						<value form="markdown">Does **<output value="/data/data/geral/nome_concat"  />**   accepts to receive care at  **<output value="/data/data/geral/us"  />** ?</value>
+					</text>
+					<text id="referrals/required_referrals/does_patients_name_accepts_to_receive_care_at_chw_hf_name-1-label">
+						<value>Yes</value>
+					</text>
+					<text id="referrals/required_referrals/does_patients_name_accepts_to_receive_care_at_chw_hf_name-0-label">
+						<value>No</value>
+					</text>
+					<text id="referrals/required_referrals/preferred_health_facility_grp-label">
+						<value>Preferred Health Facility</value>
+					</text>
+					<text id="referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-label">
+						<value>Select Health Facility Province</value>
+						<value form="markdown">Select Health Facility Province</value>
+					</text>
+					<text id="referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-maputo_cidade-label">
+						<value>Maputo Cidade</value>
+					</text>
+					<text id="referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-maputo_provincia-label">
+						<value>Maputo Provincia</value>
+					</text>
+					<text id="referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-gaza-label">
+						<value>Gaza</value>
+					</text>
+					<text id="referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-inhambane-label">
+						<value>Inhambane</value>
+					</text>
+					<text id="referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-niassa-label">
+						<value>Niassa</value>
+					</text>
+					<text id="referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-manica-label">
+						<value>Manica</value>
+					</text>
+					<text id="referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-sofala-label">
+						<value>Sofala</value>
+					</text>
+					<text id="referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-zambezia-label">
+						<value>Zambezia</value>
+					</text>
+					<text id="referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-nampula-label">
+						<value>Nampula</value>
+					</text>
+					<text id="referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-cabo_delgado-label">
+						<value>Cabo Delgado</value>
+					</text>
+					<text id="referrals/required_referrals/preferred_health_facility_grp/hf_health_facility-label">
+						<value>Select Health Facility  </value>
+						<value form="markdown">Select Health Facility  </value>
+					</text>
+					<text id="referrals/required_referrals/preferred_health_facility_grp/lbl_transfer_to_current_chw_partner-label">
+						<value>This patient will be transferred to current CHW partner at selected health Facility</value>
+					</text>
+					<text id="referrals/required_referrals/preferred_health_facility_grp/select_partner-label">
+						<value>Select Partner</value>
+					</text>
+					<text id="referrals/required_referrals/preferred_health_facility_grp/lbl_no_partner_in_hf-label">
+						<value>The Health Facility doesn't currently have infomovel.</value>
+					</text>
+					<text id="referrals/required_referrals/consentimento_busca_activa-label">
+						<value>Does <output value="/data/data/geral/nome_concat"  />  consent to be visited if they don't go to the health facility?</value>
+					</text>
+					<text id="referrals/required_referrals/consentimento_busca_activa-sim-label">
+						<value>Yes</value>
+					</text>
+					<text id="referrals/required_referrals/consentimento_busca_activa-nao-label">
+						<value>No</value>
+					</text>
+					<text id="referrals/required_referrals/intentar_convencer-label">
+						<value>Please, counsel the patient and try to convince them to go to the hospital</value>
+						<value form="markdown">Please, counsel the patient and try to convince them to go to the hospital</value>
+					</text>
+					<text id="referrals/required_referrals/test-label">
+						<value>test</value>
+					</text>
+					<text id="referrals/required_referrals/test/test_data_de_referencia-label">
+						<value>Data de referencia (set)</value>
+					</text>
+					<text id="referrals/required_referrals/test/test_data_proxima_visita-label">
+						<value>data_proxima_visita (set)</value>
+					</text>
+					<text id="referrals/no_referrals-label">
+						<value>No required referrals</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-label">
+						<value>Does the patient needs a referral for one of the following diseases?</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-nunhum-label">
+						<value>None</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-hipertensao-label">
+						<value>Hypertension</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-infeccao_de_transmission_sexual-label">
+						<value>Sexually Transmitted Infections</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-consulta_pre_natal-label">
+						<value>Prenatal consultation</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-malaria-label">
+						<value>Malaria</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-epilepsia-label">
+						<value>Epilepsy</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-doencas_de_pele-label">
+						<value>Skin diseases</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-diarreia-label">
+						<value>Diarrhea</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-circuncisao_masculina-label">
+						<value>Male circumcision</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-ptv-label">
+						<value>PTV</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-violenca_sexual-label">
+						<value>Sexual violence</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-violencia-label">
+						<value>Physical violence</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-grupo_de_apoio-label">
+						<value>Support group</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-despite_cancro_uterino-label">
+						<value>Uterine and breast cancer screening </value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-despiste_cancro_de_prostata-label">
+						<value>Prostate cancer Screening</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-outra-label">
+						<value>Other</value>
+					</text>
+					<text id="referrals/no_referrals/outra_doenca-label">
+						<value>Other disease:</value>
+					</text>
+					<text id="contacts_registration_concent-label">
+						<value>Do you consent the registration of your contacts?</value>
+						<value form="markdown">Do you consent the registration of your contacts?</value>
+					</text>
+					<text id="contacts_registration_concent-yes-label">
+						<value>Yes</value>
+					</text>
+					<text id="contacts_registration_concent-no-label">
+						<value>No</value>
+					</text>
+					<text id="register_conviventes_during_visit-label">
+						<value>Do you want to register more contacts ***today***?</value>
+						<value form="markdown">Do you want to register more contacts ***today***?</value>
+					</text>
+					<text id="register_conviventes_during_visit-sim-label">
+						<value>Yes</value>
+					</text>
+					<text id="register_conviventes_during_visit-nao-label">
+						<value>No</value>
+					</text>
+					<text id="hh_reg-label">
+						<value>Close Household Registration</value>
+					</text>
+					<text id="hh_reg/mais_conviventes-label">
+						<value>Do you want to finish the contacts registration for this house?</value>
+					</text>
+					<text id="hh_reg/mais_conviventes-sim-label">
+						<value>Yes</value>
+					</text>
+					<text id="hh_reg/mais_conviventes-nao-label">
+						<value>No</value>
+					</text>
+					<text id="hh_reg/confirmar_registo_conviventes_completo-label">
+						<value>**Isto vai fechar a opção de registar novos contactos. Se não quer fechar, responder "Não" acima.**</value>
+						<value form="markdown">**Isto vai fechar a opção de registar novos contactos. Se não quer fechar, responder "Não" acima.**</value>
+					</text>
+					<text id="hh_reg/confirmar_registo_conviventes_completo-ok-label">
+						<value>OK</value>
+					</text>
+					<text id="display_new_convivente-label">
+						<value>Please submit this form and enter the form again to register a new contact.</value>
+					</text>
+					<text id="data-label">
+						<value>data</value>
+					</text>
+					<text id="data/referencia-label">
+						<value>referencia</value>
+					</text>
+					<text id="data/geral-label">
+						<value>geral</value>
+					</text>
+					<text id="data/busca_activa-label">
+						<value>busca_activa</value>
+					</text>
+					<text id="casa-label">
+						<value>casa</value>
+					</text>
+					<text id="casa/conviventes-label">
+						<value>Conviventes</value>
+					</text>
+					<text id="casa/testagem-label">
+						<value>testagem</value>
+					</text>
+					<text id="casa/index-label">
+						<value>index</value>
+					</text>
+					<text id="indicators_v4-label">
+						<value>Indicators V4</value>
+					</text>
+					<text id="calendario-label">
+						<value>calendario</value>
+					</text>
+				</translation>
+				<translation lang="por">
+					<text id="consentimento_registo-label">
+						<value>### O paciente aceita ser registrado?</value>
+						<value form="markdown">### O paciente aceita ser registrado?</value>
+					</text>
+					<text id="consentimento_registo-sim-label">
+						<value>Sim</value>
+					</text>
+					<text id="consentimento_registo-nao-label">
+						<value>Não</value>
+					</text>
+					<text id="referencia_de_localizacao/referecencia_gps-label">
+						<value>### Tira os dados das coordenadas
+
+*Não esqueser que a localização do paciente é imporante para poder pesquisar no paciente*</value>
+						<value form="markdown">### Tira os dados das coordenadas
+
+*Não esqueser que a localização do paciente é imporante para poder pesquisar no paciente*</value>
+					</text>
+					<text id="consentimento_sim-label">
+						<value>Consentiu</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes-label">
+						<value>Registo de contactos</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information-label">
+						<value>Patient Information</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/lbl_confirmar_informacao-label">
+						<value>Por favor confirme os dados do paciente</value>
+					</text>
+					<text id="apelido-label">
+						<value>### Apelido: </value>
+						<value form="markdown">### Apelido: </value>
+					</text>
+					<text id="nome_primero-label">
+						<value>### Nome:</value>
+						<value form="markdown">### Nome:</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/nome_primero-hint">
+						<value>Incluir todos os nomes do paciente, sem o apelido.</value>
+					</text>
+					<text id="genero-label">
+						<value>### Sexo</value>
+						<value form="markdown">### Sexo</value>
+					</text>
+					<text id="genero-masculino-label">
+						<value>Masculino</value>
+					</text>
+					<text id="genero-feminino-label">
+						<value>Feminino</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/data_de_nacimento_conhecido-label">
+						<value>### Conhece a Data de Nascimento?</value>
+						<value form="markdown">### Conhece a Data de Nascimento?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/data_de_nacimento_conhecido-sim-label">
+						<value>Sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/data_de_nacimento_conhecido-nao-label">
+						<value>Não</value>
+					</text>
+					<text id="data_do_nacimiento-label">
+						<value>### Data de nascimento:</value>
+						<value form="markdown">### Data de nascimento:</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/data_do_nacimento-constraintMsg">
+						<value>A data não pode ser no futuro.</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/idade_perguntar-label">
+						<value>Digitar a idade aproximada:</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/idade_perguntar-constraintMsg">
+						<value>A data não pode ser maior a 99 anos</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/question1/display_idade_meses-label">
+						<value>### Idade: <output value="/data/data/geral/idade_meses"  /> meses.</value>
+						<value form="markdown">### Idade: <output value="/data/data/geral/idade_meses"  /> meses.</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/question1/display_idade_anos-label">
+						<value>### Idade:<output value="/data/data/geral/idade_calc"  /> anos.</value>
+						<value form="markdown">### Idade:<output value="/data/data/geral/idade_calc"  /> anos.</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/question1/lbl_breasfeeding_child-label">
+						<value>Se a criança tem **mãe sero positiva** e ainda esta a **mamar**, ele **não tem que ser registado** como um convivente, mas como um **paciente em seguimento mãe-filho**</value>
+						<value form="markdown">Se a criança tem **mãe sero positiva** e ainda esta a **mamar**, ele **não tem que ser registado** como um convivente, mas como um **paciente em seguimento mãe-filho**</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez-label">
+						<value>Confirmar a Gravidez</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez/nova_gravidez-label">
+						<value>### A paciente está grávida?</value>
+						<value form="markdown">### A paciente está grávida?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez/nova_gravidez-sim-label">
+						<value>Sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez/nova_gravidez-nao-label">
+						<value>Não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez/tem_edd-label">
+						<value>### Tem a Data provável do parto?</value>
+						<value form="markdown">### Tem a Data provável do parto?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez/tem_edd-sim-label">
+						<value>Sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez/tem_edd-nao-label">
+						<value>Não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez/edd-label">
+						<value>Qual é a data provável do parto?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_lactancia-label">
+						<value>Confirmar a lactancia</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_lactancia/nova_lactancia-label">
+						<value>### O paciente é lactante?</value>
+						<value form="markdown">### O paciente é lactante?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_lactancia/nova_lactancia-sim-label">
+						<value>Sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_lactancia/nova_lactancia-nao-label">
+						<value>Não</value>
+					</text>
+					<text id="estado_civil-label">
+						<value>### Estado Civil </value>
+						<value form="markdown">### Estado Civil </value>
+					</text>
+					<text id="estado_civil-solteiro-label">
+						<value>Solteiro(a)</value>
+					</text>
+					<text id="estado_civil-casado-label">
+						<value>Casado(a)</value>
+					</text>
+					<text id="estado_civil-viuvo-label">
+						<value>Viúvo(a)</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/estado_civil-uniao_de_fact-label">
+						<value>União de facto</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/estado_civil-divorcado-label">
+						<value>Divorciado(a)</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/escolaridade-label">
+						<value>### Escolaridade </value>
+						<value form="markdown">### Escolaridade </value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/escolaridade-hint">
+						<value>Seleccione o último grau acadêmico adiquirido</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/escolaridade-nenhuma-label">
+						<value>Nenhuma</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/escolaridade-primario-label">
+						<value>Primário</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/escolaridade-secundario-label">
+						<value>Secundário</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/escolaridade-universitario-label">
+						<value>Universitário</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/ocupacao-label">
+						<value>### Ocupação</value>
+						<value form="markdown">### Ocupação</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/ocupacao-camionista-label">
+						<value>Camionista</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/ocupacao-militar-label">
+						<value>Militar</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/ocupacao-mineiro-label">
+						<value>Mineiro</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/ocupacao-trab_sexo-label">
+						<value>Trabalhador de Sexo</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/ocupacao-trab_saude-label">
+						<value>Trabalhador de Saúde</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/ocupacao-educacao-label">
+						<value>Trabalhador em Educação</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/ocupacao-estudante-label">
+						<value>Estudante</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/ocupacao-informal-label">
+						<value>Informal</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/ocupacao-domestica-label">
+						<value>Doméstica</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/ocupacao-policia-label">
+						<value>Polícia</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/ocupacao-campones-label">
+						<value>Camponês</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/ocupacao-recluso-label">
+						<value>Recluso</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/ocupacao-outro-label">
+						<value>Outro</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/ocupacao_outro-label">
+						<value>Outro:</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/nome_empresa-label">
+						<value>Nome da empresa onde trabalha</value>
+					</text>
+					<text id="grau_de_parentesco-label">
+						<value>### Quem é o contacto para o paciente índice</value>
+						<value form="markdown">### Quem é o contacto para o paciente índice</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/grau_de_parentesco-constraintMsg">
+						<value>Crianças menores de 12 anos não podem ser marcadas como parceiros.</value>
+					</text>
+					<text id="grau_de_parentesco-esposo-label">
+						<value>Esposo/a</value>
+					</text>
+					<text id="grau_de_parentesco-filho-label">
+						<value>Filho/filha</value>
+					</text>
+					<text id="grau_de_parentesco-namorado-label">
+						<value>Parceiro/a</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/grau_de_parentesco-pai-label">
+						<value>Pai/Mãe</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/grau_de_parentesco-sobrinho-label">
+						<value>Sobrinho/a</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/grau_de_parentesco-irmao-label">
+						<value>Irmão/Irmã</value>
+					</text>
+					<text id="grau_de_parentesco-outro-label">
+						<value>Outro</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/parceiro_fora_da_casa_perguntar-label">
+						<value>O parceiro vive em outra casa?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/parceiro_fora_da_casa_perguntar-sim-label">
+						<value>Sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/parceiro_fora_da_casa_perguntar-nao-label">
+						<value>Não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/sexual_partner_info-label">
+						<value>Sexual Partner Info</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/sexual_partner_info/num_parceiros_fora_casa-label">
+						<value>Nr. Parceiros fora da casa</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/sexual_partner_info/num_parceiros_fora_casa-hint">
+						<value>Dentro e fora da casa</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/sexual_partner_info/register_info_sexual_lbl-label">
+						<value>Se tiver informação de parceiros fora da casa por favor use o formulário de Registro de Parceiros Fora da Casa para registrar a informação</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/parceiro_fora_da_casa_endereco-label">
+						<value>Qual é o endereço deste parceiro?</value>
+					</text>
+					<text id="outro_grau_de_parentesco-label">
+						<value>Outro:</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/tem_numero_de_telefone-label">
+						<value>### Tem número de telefone?</value>
+						<value form="markdown">### Tem número de telefone?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/tem_numero_de_telefone-sim-label">
+						<value>Sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/tem_numero_de_telefone-nao-label">
+						<value>Não</value>
+					</text>
+					<text id="telefone-label">
+						<value>### Nº de telefone</value>
+						<value form="markdown">### Nº de telefone</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/telefone-constraintMsg">
+						<value>Nº de telefone deve ter 9 dígitos</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/consentimento_menor_15_anos-label">
+						<value>O paciente é **menor de 15 anos**. O adulto presente **aceita que ele seja registado**?</value>
+						<value form="markdown">O paciente é **menor de 15 anos**. O adulto presente **aceita que ele seja registado**?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/consentimento_menor_15_anos-sim-label">
+						<value>Sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/patient_information/consentimento_menor_15_anos-nao-label">
+						<value>Não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member-label">
+						<value>Informação dos contactos</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-label">
+						<value>### Número de conviventes</value>
+						<value form="markdown">### Número de conviventes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-hint">
+						<value>O mesmo que 'numero de contactos' para pacientes com TB</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-0-label">
+						<value>0</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-1-label">
+						<value>1</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-2-label">
+						<value>2</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-3-label">
+						<value>3</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-4-label">
+						<value>4</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-5-label">
+						<value>5</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-6-label">
+						<value>6</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-7-label">
+						<value>7</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-8-label">
+						<value>8</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-9-label">
+						<value>9</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-10-label">
+						<value>10</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-11-label">
+						<value>11</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-12-label">
+						<value>12</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-13-label">
+						<value>13</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-14-label">
+						<value>14</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-15-label">
+						<value>15</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-16-label">
+						<value>16</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-17-label">
+						<value>17</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-18-label">
+						<value>18</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-19-label">
+						<value>19</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-20-label">
+						<value>20</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/num_parceiros-label">
+						<value>### Nº de parceiros vivem na casa</value>
+						<value form="markdown">### Nº de parceiros vivem na casa</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes_under5-label">
+						<value>Número de conviventes menores de 5 anos</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes_5_to_14-label">
+						<value>Número de conviventes entre 5 - 14 anos</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/filhos_fora_hh-label">
+						<value>Identificação de filhos fora da casa</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/filhos_fora_hh/children_living_outside_the_hh-label">
+						<value>Filhos menores de 18 anos fora da casa</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/filhos_fora_hh/children_living_outside_the_hh-yes-label">
+						<value>sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/filhos_fora_hh/children_living_outside_the_hh-no-label">
+						<value>Não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/filhos_fora_hh/number_of_children_living_outside_the_house-label">
+						<value>Número de filhos menores de 18 anos fora da casa</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/filhos_fora_hh/lbl_counsel-label">
+						<value>É necessário lembrar ao paciente que testar a criança é muito importante. Sensibilizar o paciente para entrar em contato com o parente onde esta criança mora e explicar que ele deve levá-lo à Unidade Sanitária para testar</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/o_paciente__sexualmente_activo-label">
+						<value>### O paciente é sexualmente activo?</value>
+						<value form="markdown">### O paciente é sexualmente activo?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/o_paciente__sexualmente_activo-sim-label">
+						<value>sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/o_paciente__sexualmente_activo-no-label">
+						<value>não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/tipo_de_sexo-label">
+						<value>### Qual é o tipo de sexo que pratica?</value>
+						<value form="markdown">### Qual é o tipo de sexo que pratica?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/tipo_de_sexo-anal-label">
+						<value>anal</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/tipo_de_sexo-oral-label">
+						<value>oral</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/tipo_de_sexo-vaginal-label">
+						<value>vaginal</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/relacoes_mesmo_sexo-label">
+						<value>### O paciente tem relações sexuais com homens ou ambos sexos?</value>
+						<value form="markdown">### O paciente tem relações sexuais com homens ou ambos sexos?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/relacoes_mesmo_sexo-sim-label">
+						<value>sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/relacoes_mesmo_sexo-no-label">
+						<value>não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/o_paciente_tem_mais_de_um_parceiro_sexual-label">
+						<value>### O paciente tem mais de um parceiro sexual?</value>
+						<value form="markdown">### O paciente tem mais de um parceiro sexual?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/o_paciente_tem_mais_de_um_parceiro_sexual-sim-label">
+						<value>sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/o_paciente_tem_mais_de_um_parceiro_sexual-no-label">
+						<value>não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/alguma_vez_foi_solicitado_a_ter_relaes_sexuais_com_algum_em_troca_de_dinhei-label">
+						<value>### Alguma vez foi solicitado a ter relações sexuais com alguém em troca de dinheiro ou presentes?</value>
+						<value form="markdown">### Alguma vez foi solicitado a ter relações sexuais com alguém em troca de dinheiro ou presentes?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/alguma_vez_foi_solicitado_a_ter_relaes_sexuais_com_algum_em_troca_de_dinhei-sim-label">
+						<value>sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/alguma_vez_foi_solicitado_a_ter_relaes_sexuais_com_algum_em_troca_de_dinhei-no-label">
+						<value>não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/consome_bebidas_alcolicas-label">
+						<value>### Consome bebidas alcoólicas?</value>
+						<value form="markdown">### Consome bebidas alcoólicas?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/consome_bebidas_alcolicas-sim-label">
+						<value>sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/consome_bebidas_alcolicas-nao-label">
+						<value>não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/que_tipo_costuma_consumir-label">
+						<value>### Que tipo costuma consumir?</value>
+						<value form="markdown">### Que tipo costuma consumir?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/consome_outras_drogas-label">
+						<value>### Está actualmente a consumir outras drogas?</value>
+						<value form="markdown">### Está actualmente a consumir outras drogas?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/consome_outras_drogas-sim-label">
+						<value>sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/consome_outras_drogas-nao-label">
+						<value>não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/frequencia_drogas-label">
+						<value>### Com que frequencia consome estas drogas?</value>
+						<value form="markdown">### Com que frequencia consome estas drogas?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos-label">
+						<value>Testagem para adultos</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/indique_os_factores_de_risco_que_o_paciente_apresenta-label">
+						<value>### O paciente apresenta algum dos fatores de risco?</value>
+						<value form="markdown">### O paciente apresenta algum dos fatores de risco?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/indique_os_factores_de_risco_que_o_paciente_apresenta-constraintMsg">
+						<value>Por ter seleccionado 'Nenhum' como opção não pode ter outros sintomas seleccionados!</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/indique_os_factores_de_risco_que_o_paciente_apresenta-nenhum-label">
+						<value>Nenhum</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/indique_os_factores_de_risco_que_o_paciente_apresenta-esteve_internado_nos_ultimos_6_meses-label">
+						<value>Esteve hospitalisado nos últimos 6 meses</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/indique_os_factores_de_risco_que_o_paciente_apresenta-parceiro_de_PVHIV-label">
+						<value>O paciente é parceiro de um PVHIV?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/indique_os_factores_de_risco_que_o_paciente_apresenta-o_paciente_usa_preservativo_durante_as_relaes_sexuai-label">
+						<value>O paciente não usa preservativo durante as relações sexuai?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-label">
+						<value>### Indique os sintomas que apresenta</value>
+						<value form="markdown">### Indique os sintomas que apresenta</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-constraintMsg">
+						<value>Por ter seleccionado 'Nenhum' como opção não pode ter outros sintomas seleccionados!</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-nenhum-label">
+						<value>Nenhum</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-sinais_e_sintomas_respiratorios-label">
+						<value>Sinais e sintomas respiratorios</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-corrimento_ou_feridas_genitais-label">
+						<value>Corrimento ou feridas genitais</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-inchaco-label">
+						<value>Inchaço dos memberos inferiores</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-perda_de_peso-label">
+						<value>Perda de peso visivel </value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-diarreia-label">
+						<value>Diarreia a mais de 15 dias</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-febre-label">
+						<value>Febre persistente inexplicavel</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-dificuldades_comer-label">
+						<value>Feridas na boca ou dificuldade para comer</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-problema_pele-label">
+						<value>Problemas na pele como comichão,queimadura da noite,feridas</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-outro-label">
+						<value>outro</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/outro-label">
+						<value>Outro</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_para_adultos/este__um_adulto_em_risco_e_deve_ser_testado-label">
+						<value>Este é um adulto em risco e deve ser testado</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population-label">
+						<value>Testagem HIV para população chave</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens-label">
+						<value>Homens que fazem sexo com homens</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/produto_lubrificacao-label">
+						<value>### Alguma vez usou um produto lubrificante durante o sexo anal?</value>
+						<value form="markdown">### Alguma vez usou um produto lubrificante durante o sexo anal?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/produto_lubrificacao-sim-label">
+						<value>sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/produto_lubrificacao-nao-label">
+						<value>não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/tipo_lubricador-label">
+						<value>### Qual foi o produto de lubrificação que usou durante o sexo anal?</value>
+						<value form="markdown">### Qual foi o produto de lubrificação que usou durante o sexo anal?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/sabe_sobre_HIV-label">
+						<value>### Já ouviu falar em ITS e HIV?</value>
+						<value form="markdown">### Já ouviu falar em ITS e HIV?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/sabe_sobre_HIV-sim-label">
+						<value>sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/sabe_sobre_HIV-no-label">
+						<value>não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/sabe_prevenir-label">
+						<value>### Sabe como se prevenir desta doença?</value>
+						<value form="markdown">### Sabe como se prevenir desta doença?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/sabe_prevenir-sim-label">
+						<value>sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/sabe_prevenir-nao-label">
+						<value>não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/acredita_HIV-label">
+						<value>### O paciente acredita que atravez do sexo anal pode contrair ITS ou HIV?</value>
+						<value form="markdown">### O paciente acredita que atravez do sexo anal pode contrair ITS ou HIV?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/acredita_HIV-sim-label">
+						<value>sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/acredita_HIV-nao-label">
+						<value>não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/disieases-label">
+						<value>### Paciente alguma vez teve feridas ou corrimento, irritaçoes, ou comichoes no anus ou no penis?</value>
+						<value form="markdown">### Paciente alguma vez teve feridas ou corrimento, irritaçoes, ou comichoes no anus ou no penis?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/disieases-sim-label">
+						<value>sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/disieases-nao-label">
+						<value>não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/procurou_tratamento-label">
+						<value>### Procurou tratamento?</value>
+						<value form="markdown">### Procurou tratamento?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/procurou_tratamento-sim_en-label">
+						<value>sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/procurou_tratamento-no_en-label">
+						<value>não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/este_peciente_est_em_risco_e_deve_ser_testado_pois_apresenta_factores_de_ho-label">
+						<value>### Este peciente está em risco e deve ser testado, pois apresenta factores de homens que fazem sexo com homens</value>
+						<value form="markdown">### Este peciente está em risco e deve ser testado, pois apresenta factores de homens que fazem sexo com homens</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46-label">
+						<value>Trabalhadoras de sexo</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/txt_reaction-label">
+						<value>### Qual tem sido a sua reação quando um cliente paga mais para nãu usar preservativos?</value>
+						<value form="markdown">### Qual tem sido a sua reação quando um cliente paga mais para nãu usar preservativos?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/ja_ouviu_falar_de_its_hiv-label">
+						<value>### Já ouviu falar de ITS?HIV/SIDA?</value>
+						<value form="markdown">### Já ouviu falar de ITS?HIV/SIDA?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/ja_ouviu_falar_de_its_hiv-sim-label">
+						<value>sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/ja_ouviu_falar_de_its_hiv-no-label">
+						<value>não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/sabe_como_se_prevenir_para_no_contrair-label">
+						<value>### Sabe como se prevenir para não contrair?</value>
+						<value form="markdown">### Sabe como se prevenir para não contrair?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/sabe_como_se_prevenir_para_no_contrair-sim-label">
+						<value>sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/sabe_como_se_prevenir_para_no_contrair-no-label">
+						<value>não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/usa_o_preservativo_com_os_clientes_e_tambm_com_seu_parceiro-label">
+						<value>### Usa o preservativo com os clientes e também com seu parceiro?</value>
+						<value form="markdown">### Usa o preservativo com os clientes e também com seu parceiro?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/usa_o_preservativo_com_os_clientes_e_tambm_com_seu_parceiro-sim-label">
+						<value>sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/usa_o_preservativo_com_os_clientes_e_tambm_com_seu_parceiro-no-label">
+						<value>não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/usa_em_todas_as_practicas_sexuais-label">
+						<value>### Usa o preservativo em todas as practicas sexuais?</value>
+						<value form="markdown">### Usa o preservativo em todas as practicas sexuais?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/usa_em_todas_as_practicas_sexuais-sim-label">
+						<value>sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/usa_em_todas_as_practicas_sexuais-nao-label">
+						<value>não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/produto_lubrificacao-label">
+						<value>### Alguma vez usou um produto lubrificante durante o sexo anal?</value>
+						<value form="markdown">### Alguma vez usou um produto lubrificante durante o sexo anal?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/produto_lubrificacao-sim-label">
+						<value>sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/produto_lubrificacao-nao-label">
+						<value>não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/tipo_lubricador-label">
+						<value>### Qual foi o produto de lubrificação que usou durante o sexo anal?</value>
+						<value form="markdown">### Qual foi o produto de lubrificação que usou durante o sexo anal?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/onde_tem_praticado_sua_actividade_como_trabalhadora-label">
+						<value>### Onde tem praticado sua actividade como trabalhadora?</value>
+						<value form="markdown">### Onde tem praticado sua actividade como trabalhadora?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/onde_tem_praticado_sua_actividade_como_trabalhadora-rua-label">
+						<value>rua</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/onde_tem_praticado_sua_actividade_como_trabalhadora-barracas-label">
+						<value>barracas</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/onde_tem_praticado_sua_actividade_como_trabalhadora-casa-label">
+						<value>casa</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/onde_tem_praticado_sua_actividade_como_trabalhadora-hotel-label">
+						<value>hotel</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/esta_paciente__trabalhadora_de_sexo_e_deve_ser_testada-label">
+						<value>### Este paciente é trabalhador de sexo e deve ser testado</value>
+						<value form="markdown">### Este paciente é trabalhador de sexo e deve ser testado</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas-label">
+						<value>Testagem para pessoas que usam e injetam drogas</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/relation_after_drugs-label">
+						<value>### Como têm sido as suas relações sexuais após o consumo de drogas?</value>
+						<value form="markdown">### Como têm sido as suas relações sexuais após o consumo de drogas?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/usa_preservativo_durante_as_suas_relacoes_sxuais-label">
+						<value>### Usa preservativo durante as suas relacoes sxuais?</value>
+						<value form="markdown">### Usa preservativo durante as suas relacoes sxuais?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/usa_preservativo_durante_as_suas_relacoes_sxuais-sim-label">
+						<value>sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/usa_preservativo_durante_as_suas_relacoes_sxuais-nao-label">
+						<value>não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/usa_drogas_injectaveis-label">
+						<value>### Usa drogas injectaveis?</value>
+						<value form="markdown">### Usa drogas injectaveis?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/usa_drogas_injectaveis-sim-label">
+						<value>sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/usa_drogas_injectaveis-nao-label">
+						<value>não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/com_que_frequencia_usa_estas_drogas-label">
+						<value>### Com que frequencia usa estas drogas?</value>
+						<value form="markdown">### Com que frequencia usa estas drogas?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/j_partilhou_agulhas_ou_seringas-label">
+						<value>### Já partilhou agulhas ou seringas?</value>
+						<value form="markdown">### Já partilhou agulhas ou seringas?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/j_partilhou_agulhas_ou_seringas-sim-label">
+						<value>sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/j_partilhou_agulhas_ou_seringas-nao-label">
+						<value>não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/acha_que_alguem_que_usa_drogas_injectaveis_corre_risco_de_contrair_o_hiv-label">
+						<value>### Acha que alguem que usa drogas injectaveis corre risco de contrair o HIV?</value>
+						<value form="markdown">### Acha que alguem que usa drogas injectaveis corre risco de contrair o HIV?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/acha_que_alguem_que_usa_drogas_injectaveis_corre_risco_de_contrair_o_hiv-sim-label">
+						<value>sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/acha_que_alguem_que_usa_drogas_injectaveis_corre_risco_de_contrair_o_hiv-nao-label">
+						<value>não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/este_paciente_faz_o_uso_de_drogas_e_deve-label">
+						<value>### Este paciente faz o uso e injecta drogas e deve ser testado</value>
+						<value form="markdown">### Este paciente faz o uso e injecta drogas e deve ser testado</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido-label">
+						<value>Teste</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment-label">
+						<value>pre-test assessment</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18-label">
+						<value>Testagem de HIV para criança mmenor de 10 anos</value>
+					</text>
+					<text id="testagem_HIV/hiv_mostrar_apenas_menos_18/amamentacao-label">
+						<value>### O paciente tem mãe viva e presente?</value>
+						<value form="markdown">### O paciente tem mãe viva e presente?</value>
+					</text>
+					<text id="testagem_HIV/hiv_mostrar_apenas_menos_18/amamentacao-sim-label">
+						<value>Sim</value>
+					</text>
+					<text id="testagem_HIV/hiv_mostrar_apenas_menos_18/amamentacao-nao-label">
+						<value>Não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/documentation-label">
+						<value>### O contacto tem informação do PTV documentada no cartão de saúde da criança?</value>
+						<value form="markdown">### O contacto tem informação do PTV documentada no cartão de saúde da criança?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/documentation-sim-label">
+						<value>Sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/documentation-nao-label">
+						<value>Não / não tem cartão</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/pedir_cartao-label">
+						<value>### Pedir a cartão e verificar a informação.</value>
+						<value form="image">jr://file/commcare/image/data/paciente_index/cartao_disponivel.jpg</value>
+						<value form="markdown">### Pedir a cartão e verificar a informação.</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/seroestado_conhecido-label">
+						<value>### Conhece o resultado do teste de HIV da mãe?</value>
+						<value form="markdown">### Conhece o resultado do teste de HIV da mãe?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/seroestado_conhecido-sim-label">
+						<value>Sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/seroestado_conhecido-nao-label">
+						<value>Não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/seroestado_da_mae-label">
+						<value>### Qual é o resultado do teste de HIV da mãe?</value>
+						<value form="markdown">### Qual é o resultado do teste de HIV da mãe?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/seroestado_da_mae-positivo-label">
+						<value>Positivo</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/seroestado_da_mae-negativo-label">
+						<value>Negativo</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/crianca_em_seguimento-label">
+						<value>### A criança está em seguimento na CCR?</value>
+						<value form="markdown">### A criança está em seguimento na CCR?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/crianca_em_seguimento-sim-label">
+						<value>Sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/crianca_em_seguimento-nao-label">
+						<value>Não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/internada_ultimos_6meses-label">
+						<value>### A criança esteve internada na infermaria nos ultimos 6 meses?</value>
+						<value form="markdown">### A criança esteve internada na infermaria nos ultimos 6 meses?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/internada_ultimos_6meses-sim-label">
+						<value>sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/internada_ultimos_6meses-no-label">
+						<value>não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/lesao_ultimos_6meses-label">
+						<value>### A criança teve alguma lesão extensa na pele nos últimos 6 meses ou lesão que não melhorou com o tratamento?</value>
+						<value form="markdown">### A criança teve alguma lesão extensa na pele nos últimos 6 meses ou lesão que não melhorou com o tratamento?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/lesao_ultimos_6meses-sim-label">
+						<value>sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/lesao_ultimos_6meses-nao-label">
+						<value>não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/severe_health_issues-label">
+						<value>### A criança teve algum problema de saude severo no ultimos 3 meses?</value>
+						<value form="markdown">### A criança teve algum problema de saude severo no ultimos 3 meses?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/severe_health_issues-sim-label">
+						<value>sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/severe_health_issues-no-label">
+						<value>não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos-label">
+						<value>Testagem para HIV de adolescente (10-18 anos)</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/hospitalised_6months-label">
+						<value>### Paciente ficou internado nos ultimos 6 meses?</value>
+						<value form="markdown">### Paciente ficou internado nos ultimos 6 meses?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/hospitalised_6months-sim-label">
+						<value>sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/hospitalised_6months-no-label">
+						<value>não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_teve_uma_leso_extensa_que_no_melhora_com_o_tratamento-label">
+						<value>### O paciente teve uma lesão extensa que não melhora com o tratamento?</value>
+						<value form="markdown">### O paciente teve uma lesão extensa que não melhora com o tratamento?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_teve_uma_leso_extensa_que_no_melhora_com_o_tratamento-sim-label">
+						<value>sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_teve_uma_leso_extensa_que_no_melhora_com_o_tratamento-no-label">
+						<value>Não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/nos_ultimos_3_meses_teve_algum_problema_de_saude_persistente_como_perda_de_-label">
+						<value>### Nos ultimos 3 meses teve algum problema de saude persistente? Como: perda de peso, problemas respiratórios, diarreia a mais de 15 dias</value>
+						<value form="markdown">### Nos ultimos 3 meses teve algum problema de saude persistente? Como: perda de peso, problemas respiratórios, diarreia a mais de 15 dias</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/nos_ultimos_3_meses_teve_algum_problema_de_saude_persistente_como_perda_de_-sim-label">
+						<value>sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/nos_ultimos_3_meses_teve_algum_problema_de_saude_persistente_como_perda_de_-no-label">
+						<value>não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_tem_corrimento-label">
+						<value>### O paciente tem corrimento?</value>
+						<value form="markdown">### O paciente tem corrimento?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_tem_corrimento-sim-label">
+						<value>sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_tem_corrimento-no-label">
+						<value>não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_tem_um_dos_seguintes_problemas-label">
+						<value>### Por favor indique o tipo de corrimento</value>
+						<value form="markdown">### Por favor indique o tipo de corrimento</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_tem_um_dos_seguintes_problemas-corrimento_vaginal-label">
+						<value>corrimento vaginal</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_tem_um_dos_seguintes_problemas-corrimento_uretral-label">
+						<value>corrimento uretral</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_tem_um_dos_seguintes_problemas-ulcera_genital-label">
+						<value>Ulcera genital</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/este_adolescente_est_em_risco_e_deve_ser_testado-label">
+						<value>### Este adolescente está em risco, e deve ser testado.</value>
+						<value form="markdown">### Este adolescente está em risco, e deve ser testado.</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions-label">
+						<value>Patient questions</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testado_hiv_vez-label">
+						<value>### Alguma vez fez o teste de HIV?</value>
+						<value form="markdown">### Alguma vez fez o teste de HIV?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testado_hiv_vez-sim-label">
+						<value>Sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testado_hiv_vez-nao-label">
+						<value>Não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/fez_pcr-label">
+						<value>### Fez PCR?</value>
+						<value form="markdown">### Fez PCR?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/fez_pcr-sim-label">
+						<value>Sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/fez_pcr-não-label">
+						<value>Não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/resultado_previo_hiv-label">
+						<value>### Qual foi o resultado?</value>
+						<value form="markdown">### Qual foi o resultado?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/resultado_previo_hiv-positivo-label">
+						<value>Positivo</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/resultado_previo_hiv-negativo-label">
+						<value>Negativo</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/resultado_previo_hiv-indeterminado-label">
+						<value>Indeterminado</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/child_still_breastfeeding-label">
+						<value>### A criança ainda está a amamentar?</value>
+						<value form="markdown">### A criança ainda está a amamentar?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/child_still_breastfeeding-yes-label">
+						<value>Yes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/child_still_breastfeeding-no-label">
+						<value>No</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/mai_parou_amamentar-label">
+						<value>### Passam mais de dois meses que a mãe parou de amamentar?</value>
+						<value form="markdown">### Passam mais de dois meses que a mãe parou de amamentar?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/mai_parou_amamentar-sim-label">
+						<value>Sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/mai_parou_amamentar-nao-label">
+						<value>Não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/child_risk_evaluated-label">
+						<value>### A criança foi suficientemente avaliada em relação ao risco de transmissão através da mãe.  Geralmente, não necessita ser testada ate que apresente algum comportamento de risco</value>
+						<value form="markdown">### A criança foi suficientemente avaliada em relação ao risco de transmissão através da mãe.  Geralmente, não necessita ser testada ate que apresente algum comportamento de risco</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/tem_nid-label">
+						<value>O paciente tem NID?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/tem_nid-sim-label">
+						<value>Sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/tem_nid-nao-label">
+						<value>Não</value>
+					</text>
+					<text id="nid-label">
+						<value>### NID</value>
+						<value form="markdown">### NID</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/nid-constraintMsg">
+						<value>A regra de preenchimento do NID: ######## / ## / ##</value>
+					</text>
+					<text id="testado_por_hiv_recente-label">
+						<value>### Fez o teste de HIV nos últimos 3 meses?</value>
+						<value form="markdown">### Fez o teste de HIV nos últimos 3 meses?</value>
+					</text>
+					<text id="testado_por_hiv_recente-sim-label">
+						<value>Sim</value>
+					</text>
+					<text id="testado_por_hiv_recente-nao-label">
+						<value>Não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/data_ultimo_teste_hiv-label">
+						<value>### Em que dia aproximadamente foi feito o teste?</value>
+						<value form="markdown">### Em que dia aproximadamente foi feito o teste?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/restagem_3_meses-label">
+						<value>### O contacto deve ser retestado tres meses depois do último teste.</value>
+						<value form="markdown">### O contacto deve ser retestado tres meses depois do último teste.</value>
+					</text>
+					<text id="em_tratamento_hiv-label">
+						<value>### Em tratamento de HIV?</value>
+						<value form="markdown">### Em tratamento de HIV?</value>
+					</text>
+					<text id="em_tratamento_hiv-sim-label">
+						<value>Sim</value>
+					</text>
+					<text id="em_tratamento_hiv-nao-label">
+						<value>Não</value>
+					</text>
+					<text id="em_tratamento_hiv-label2">
+						<value>### O contacto está em seguimento na CCR?</value>
+						<value form="markdown">### O contacto está em seguimento na CCR?</value>
+					</text>
+					<text id="em_tratamento_hiv-sim-label2">
+						<value>Sim</value>
+					</text>
+					<text id="em_tratamento_hiv-nao-label2">
+						<value>Não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/lbl_no_test-label">
+						<value>**O paciente não precisa ser testado para HIV, pois já conhece o seu estado sereologico**</value>
+						<value form="markdown">**O paciente não precisa ser testado para HIV, pois já conhece o seu estado sereologico**</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/contact_doesnt_require_test-label">
+						<value>**O paciente não precisa ser testado para HIV.**
+
+O paciente já conheçe o seu estado serológico, não é parceiro do index, e nãe é criança menor que 10 anos com mãe seropositiva.</value>
+						<value form="markdown">**O paciente não precisa ser testado para HIV.**
+
+O paciente já conheçe o seu estado serológico, não é parceiro do index, e nãe é criança menor que 10 anos com mãe seropositiva.</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/test_patient_anyway-label">
+						<value>### Existe alguma razão excepcional para testar o paciente agora?</value>
+						<value form="markdown">### Existe alguma razão excepcional para testar o paciente agora?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/test_patient_anyway-yes-label">
+						<value>Sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/test_patient_anyway-nao-label">
+						<value>Não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/reason_to_test_hiv-label">
+						<value>### Razão:</value>
+						<value form="markdown">### Razão:</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/querer_testar-label">
+						<value>### O paciente quer fazer o teste de HIV?</value>
+						<value form="markdown">### O paciente quer fazer o teste de HIV?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/querer_testar-sim-label">
+						<value>Sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/querer_testar-nao-label">
+						<value>Não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/si_nao-label">
+						<value>### Porque não quer fazer o teste?</value>
+						<value form="markdown">### Porque não quer fazer o teste?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/si_nao-nao_tem_interesse-label">
+						<value>Não tem interesse</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/si_nao-teme_resultado-label">
+						<value>Teme o resultado</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/si_nao-ja_sabe_diagnostico-label">
+						<value>Já sabe do seu diagnóstico </value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/activista_capacitado_testagem-label">
+						<value>O activista está capacitado a fazer testagem?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/activista_capacitado_testagem-sim-label">
+						<value>sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/activista_capacitado_testagem-no-label">
+						<value>não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/referir_para_teste-label">
+						<value>### Como não está capacitado a testar, quer referir este paciente para a US para testar?</value>
+						<value form="markdown">### Como não está capacitado a testar, quer referir este paciente para a US para testar?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/referir_para_teste-1-label">
+						<value>Sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/referir_para_teste-0-label">
+						<value>Não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/outcomes-label">
+						<value>Outcomes</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/outcomes/referir_e_aconselhar-label">
+						<value>*Aconselhar e referir o paciente ao hospital para iniciar o TARV*</value>
+						<value form="markdown">*Aconselhar e referir o paciente ao hospital para iniciar o TARV*</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/outcomes/referir_crianca_ccr-label">
+						<value>*Referir paciente a hospital para CCR*</value>
+						<value form="markdown">*Referir paciente a hospital para CCR*</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/outcomes/aconselhado_adesao-label">
+						<value>*Aconselhamento de toma de medicamentos.*</value>
+						<value form="markdown">*Aconselhamento de toma de medicamentos.*</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/outcomes/aconselhado_saude_infantil-label">
+						<value>*Aconselhamento em saúde infantil.*</value>
+						<value form="markdown">*Aconselhamento em saúde infantil.*</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/outcomes/aconselhado_negativo-label">
+						<value>*Verifique módulo de educação*</value>
+						<value form="markdown">*Verifique módulo de educação*</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV-label">
+						<value>Testagem de HIV</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos-label">
+						<value>Nova Testagem de HIV</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/ver_os_pasos_test1-label">
+						<value>### Quer ver os passos para fazer o teste de Determine?</value>
+						<value form="markdown">### Quer ver os passos para fazer o teste de Determine?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/ver_os_pasos_test1-sim-label">
+						<value>Sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/ver_os_pasos_test1-nao-label">
+						<value>Não</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1-label">
+						<value>Teste 1</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/preparacao-label">
+						<value>### Determine: Preparação</value>
+						<value form="markdown">### Determine: Preparação</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/preparacao/reunir_itens-label">
+						<value>*1.  Reúna os itens do teste e outros consumíveis necessários*</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/hiv_mostrar_apenas_mais_18/preparacao/reunir_itens.png</value>
+						<value form="markdown">*1.  Reúna os itens do teste e outros consumíveis necessários*</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/preparacao/tira_teste-label">
+						<value>*2.  usa uma tira por teste e preserve o número do lote na embalagem remanescente*</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/teste_1/preparacao/tira_teste.png</value>
+						<value form="markdown">*2.  usa uma tira por teste e preserve o número do lote na embalagem remanescente*</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/preparacao/rotule_cartao-label">
+						<value>*3. Rotule o cartão  com o número de identificação do utente.*</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/teste_1/preparacao/rotule_cartao.jpg</value>
+						<value form="markdown">*3. Rotule o cartão  com o número de identificação do utente.*</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/preparacao/remover_cobertura-label">
+						<value>*4. Remova a cobertura protectora metálica.*</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/teste_1/preparacao/remover_cobertura.jpg</value>
+						<value form="markdown">*4. Remova a cobertura protectora metálica.*</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/colhendo_amostra-label">
+						<value>Determine: Colhendo Amostra</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/colhendo_amostra/colhar_amostra-label">
+						<value>*5. Colha 50 µl de amostra com um tubo capilar ou uma pipeta de precisão*</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/teste_1/colhendo_amostra/colhar_amostra.jpg</value>
+						<value form="markdown">*5. Colha 50 µl de amostra com um tubo capilar ou uma pipeta de precisão*</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/aplicando_amostra-label">
+						<value>Determine: Aplicando Amostra e Tampão à Tira de Teste</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/aplicando_amostra/aplicar_amostra-label">
+						<value>*6. Aplique a amostra na parte absorvente da tira de testagem*</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/teste_1/aplicando_amostra/aplicar_amostra.jpg</value>
+						<value form="markdown">*6. Aplique a amostra na parte absorvente da tira de testagem*</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/aplicando_amostra/sangue_total-label">
+						<value>*7. Para sangue total apenas, adicione 1 gota de tampão na  janela de amostra.*</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/teste_1/aplicando_amostra/sangue_total.jpg</value>
+						<value form="markdown">*7. Para sangue total apenas, adicione 1 gota de tampão na  janela de amostra.*</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/obtener_resultados-label">
+						<value>Determine: Obtendo Resultados</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/obtener_resultados/tempo_resultados-label">
+						<value>*8.  Aguarde 15 minutos (não mais que 60 min) para ler os resultados*</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/teste_1/obtener_resultados/tempo_resultados.jpg</value>
+						<value form="markdown">*8.  Aguarde 15 minutos (não mais que 60 min) para ler os resultados*</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/obtener_resultados/registrar_resultados-label">
+						<value>*9. Leia e registe o resultado e outras informações pertinentes na folha de trabalho*</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/teste_1/obtener_resultados/registrar_resultados.jpg</value>
+						<value form="markdown">*9. Leia e registe o resultado e outras informações pertinentes na folha de trabalho*</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/interpretacao_teste-label">
+						<value>*Determine – Interpretação do Teste*</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/teste_1/interpretacao_teste.jpg</value>
+						<value form="markdown">*Determine – Interpretação do Teste*</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/resultado_teste_rapido_determine-label">
+						<value>### Resultado do teste rápido Determine:</value>
+						<value form="markdown">### Resultado do teste rápido Determine:</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/resultado_teste_rapido_determine-positivo-label">
+						<value>Reativo</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/resultado_teste_rapido_determine-negativo-label">
+						<value>Não reativo</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/Quer_ver_os_pasos-label">
+						<value>### Quer ver os passos para fazer o teste de Uni Gold?</value>
+						<value form="markdown">### Quer ver os passos para fazer o teste de Uni Gold?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/Quer_ver_os_pasos-sim-label">
+						<value>Sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/Quer_ver_os_pasos-nao-label">
+						<value>Não</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2-label">
+						<value>Teste 2 Uni Gold</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/unigold_preparacao-label">
+						<value>Uni-Gold: Preparação</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/unigold_preparacao/unigold_reunir_itens-label">
+						<value>*1. Reúna os itens do teste e outros consumíveis necessários.*</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/hiv_mostrar_apenas_mais_18/preparacao/reunir_itens.jpg</value>
+						<value form="markdown">*1. Reúna os itens do teste e outros consumíveis necessários.*</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/unigold_preparacao/unigold_dispositivo_embalagem-label">
+						<value>*2. Remova o dispositivo da embalagem e rotule o dispositivo com o número de identificação do utente.*</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/teste_2/unigold_preparacao/unigold_dispositivo_embalagem.jpg</value>
+						<value form="markdown">*2. Remova o dispositivo da embalagem e rotule o dispositivo com o número de identificação do utente.*</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/unigold_colhendo_amostra-label">
+						<value>Uni-Gold: Colhendo a Amostra</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/unigold_colhendo_amostra/unigold_colhar_amostra-label">
+						<value>*3. Colha a amostra usando um tubo capilar ou uma pipeta de precisão*</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/teste_2/unigold_colhendo_amostra/unigold_colhar_amostra.png</value>
+						<value form="markdown">*3. Colha a amostra usando um tubo capilar ou uma pipeta de precisão*</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/unigold_aplicando_amostra-label">
+						<value>Uni-Gold: Adicionando Amostra e Reagente ao Porto de Entrada do Dispositivo</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/unigold_aplicando_amostra/unigold_aplicar_amostra-label">
+						<value>*4. Aplique 2 gotas (aprox. 60µl) de amostra na janela de amostra do dispositivo.*</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/teste_2/unigold_aplicando_amostra/unigold_aplicar_amostra.png</value>
+						<value form="markdown">*4. Aplique 2 gotas (aprox. 60µl) de amostra na janela de amostra do dispositivo.*</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/unigold_aplicando_amostra/unigold_sangue_total-label">
+						<value>*5. Adicione 2 gotas (± 60µL) do tampão do kit na janela da amostra*</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/teste_2/unigold_aplicando_amostra/unigold_sangue_total.png</value>
+						<value form="markdown">*5. Adicione 2 gotas (± 60µL) do tampão do kit na janela da amostra*</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/obtener_resultados-label">
+						<value>Uni-Gold: Obtendo Resultados</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/obtener_resultados/tempo_resultados-label">
+						<value>*6. Aguarde 10 minutos (não mais de 20 min) antes de ler os resultados*</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/teste_2/obtener_resultados/tempo_resultados.jpg</value>
+						<value form="markdown">*6. Aguarde 10 minutos (não mais de 20 min) antes de ler os resultados*</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/obtener_resultados/registrar_resultados-label">
+						<value>*7. Leia e registe o resultado e outras informações pertinentes na folha de trabalho*</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/teste_2/obtener_resultados/registrar_resultados.png</value>
+						<value form="markdown">*7. Leia e registe o resultado e outras informações pertinentes na folha de trabalho*</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/interpretacao_teste-label">
+						<value>*Uni-Gold: Interpretação dos Resultados*</value>
+						<value form="image">jr://file/commcare/image/data/registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/teste_2/interpretacao_teste.png</value>
+						<value form="markdown">*Uni-Gold: Interpretação dos Resultados*</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/resultado_teste_rapido_unigold-label">
+						<value>### Resultado do teste Uni-Gold</value>
+						<value form="markdown">### Resultado do teste Uni-Gold</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/resultado_teste_rapido_unigold-postivo-label">
+						<value>Reativo</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/resultado_teste_rapido_unigold-negativo-label">
+						<value>Não reativo</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_final-label">
+						<value>Resultado final</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_final/display_resultado_do_teste_rapido-label">
+						<value>### Resultado final do teste rápido de HIV: **<output value="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_do_teste_rapido"  />**</value>
+						<value form="markdown">### Resultado final do teste rápido de HIV: **<output value="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_do_teste_rapido"  />**</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_final/resultado_indeterminado_repetir-label">
+						<value>### **O processo de testagem deve ser repetido.**</value>
+						<value form="markdown">### **O processo de testagem deve ser repetido.**</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2-label">
+						<value>Testagem de HIV 2</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/ver_os_pasos_test1-label">
+						<value>### Quer ver os passos para fazer o teste de Determine?</value>
+						<value form="markdown">### Quer ver os passos para fazer o teste de Determine?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/ver_os_pasos_test1-sim-label">
+						<value>Sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/ver_os_pasos_test1-nao-label">
+						<value>Não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/Quer_ver_os_pasos-label">
+						<value>### Quer ver os passos para fazer o teste de Uni Gold?</value>
+						<value form="markdown">### Quer ver os passos para fazer o teste de Uni Gold?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/Quer_ver_os_pasos-sim-label">
+						<value>Sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/Quer_ver_os_pasos-nao-label">
+						<value>Não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_final-label">
+						<value>Resultado final</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_final/display_resultado_do_teste_rapido-label">
+						<value>### Resultado final do teste rápido de HIV:  **<output value="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_do_teste_rapido_2"  />**</value>
+						<value form="markdown">### Resultado final do teste rápido de HIV:  **<output value="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_do_teste_rapido_2"  />**</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/question7-label">
+						<value>*-Indeterminado testagem de HIV*</value>
+						<value form="markdown">*-Indeterminado testagem de HIV*</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/couseling-label">
+						<value>Aconselhamento</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/couseling/aconselhamento_pos-label">
+						<value>### O resultado positivo. Fale com a pessoa sobre os temas seguintes:
+
+* *Que o HIV/ SIDA não tem cura, mas tem tratamento;*
+* *O tratamento de HIV/SIDA é feito para toda vida;*
+* *Antes começar a tomar os medicamentos de HIV/SIDA avalia-se o estado de saúde de paciente, se estiver muito doente a pessoa inicia o tratamento e se estiver bem vai seguir as consultas*
+* *É importante prevenir a transmissão*
+* *É importante cumprir com a medicação com o seguimento nas consultas e laboratório nas datas marcadas*</value>
+						<value form="markdown">### O resultado positivo. Fale com a pessoa sobre os temas seguintes:
+
+* *Que o HIV/ SIDA não tem cura, mas tem tratamento;*
+* *O tratamento de HIV/SIDA é feito para toda vida;*
+* *Antes começar a tomar os medicamentos de HIV/SIDA avalia-se o estado de saúde de paciente, se estiver muito doente a pessoa inicia o tratamento e se estiver bem vai seguir as consultas*
+* *É importante prevenir a transmissão*
+* *É importante cumprir com a medicação com o seguimento nas consultas e laboratório nas datas marcadas*</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used-label">
+						<value>Testes Usados</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_determine-label">
+						<value>Numero de testes Determine usados: **<output value="/data/data/geral/determine_used_calc"  />** </value>
+						<value form="markdown">Numero de testes Determine usados: **<output value="/data/data/geral/determine_used_calc"  />** </value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_determine-corecto-label">
+						<value>Correcto</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_determine-nao_corecto-label">
+						<value>Não correcto</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_determine_coregir-label">
+						<value>Número de testes Determine utilizados:</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_determine_coregir-constraintMsg">
+						<value>A resposta não pode ser maior a 5</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_unigold-label">
+						<value>Número de testes Unigold utilizados: **<output value="/data/data/geral/unigold_used_calc"  />** </value>
+						<value form="markdown">Número de testes Unigold utilizados: **<output value="/data/data/geral/unigold_used_calc"  />** </value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_unigold-corecto-label">
+						<value>Correcto</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_unigold-nao_corecto-label">
+						<value>Não correcto</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_unigold_coregir-label">
+						<value>Número de testes Unigold utilizados:</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_unigold_coregir-constraintMsg">
+						<value>A resposta não pode ser maior a 5</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/referencia-label">
+						<value>Referência</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/resultado_negativo_referral-label">
+						<value>*-Verifique o módulo de educação*</value>
+						<value form="markdown">*-Verifique o módulo de educação*</value>
+					</text>
+					<text id="registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/copy-1-of-resultado_positivo_referral_teste_vih-label">
+						<value>*-Teste positivo de HIV*</value>
+						<value form="markdown">*-Teste positivo de HIV*</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/referencia/referir_crianca-label">
+						<value>*Referir a criança ao hospital para CCR.*</value>
+						<value form="markdown">*Referir a criança ao hospital para CCR.*</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/referencia/referir_mae_crianca-label">
+						<value>*Referir a criança e a mãe ao hospital.*</value>
+						<value form="markdown">*Referir a criança e a mãe ao hospital.*</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/referencia/pos_seguimento-label">
+						<value>*Aconselhamento em saúde infantil.*</value>
+						<value form="markdown">*Aconselhamento em saúde infantil.*</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/referencia/neg_crianca_testado-label">
+						<value>*Aconselhamento nutricional*</value>
+						<value form="markdown">*Aconselhamento nutricional*</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership-label">
+						<value>Quem fiz a testagem</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/chw_testagem-label">
+						<value>### A testagem foi feita por algum outro activista?</value>
+						<value form="markdown">### A testagem foi feita por algum outro activista?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/chw_testagem-sim-label">
+						<value>Sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/chw_testagem-nao-label">
+						<value>Não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/activista_fez_testagem_hiv-label">
+						<value>### Qual eo nome do activista que fiz a testagem?</value>
+						<value form="markdown">### Qual eo nome do activista que fiz a testagem?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/tem_numero_de_telefone-label">
+						<value>### O activista tem número de telefone?</value>
+						<value form="markdown">### O activista tem número de telefone?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/tem_numero_de_telefone-sim-label">
+						<value>Sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/tem_numero_de_telefone-nao-label">
+						<value>Não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/telefone-constraintMsg">
+						<value>Nº de telefone deve ter 9 dígitos</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb-label">
+						<value>Rastreio de TB</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/rastreio_tb_display-label">
+						<value>## Rastreio de TB </value>
+						<value form="markdown">## Rastreio de TB </value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/antes_de_comenar_o_rastreio_lembre-se_d_en-label">
+						<value>### Antes de començar o rastreio, lembre-se de prestar atenção aos seguinte sintomas</value>
+						<value form="image">jr://file/commcare/image/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/antes_de_comenar_o_rastreio_lembre-se_d_en-elh6qm.jpg</value>
+						<value form="markdown">### Antes de començar o rastreio, lembre-se de prestar atenção aos seguinte sintomas</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/ja_em_tratamento-label">
+						<value>### Está em tratamento de TB?</value>
+						<value form="markdown">### Está em tratamento de TB?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/ja_em_tratamento-sim-label">
+						<value>Sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/ja_em_tratamento-nao-label">
+						<value>Não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/verificar_adesao-label">
+						<value>### Verificar a toma de medicamentos</value>
+						<value form="markdown">### Verificar a toma de medicamentos</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/nit-label">
+						<value>Qual é o número de NIT?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/nit-constraintMsg">
+						<value>A regra de prencher o NIT é: ## / ## (ex: 123/22)</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/contacto_ultimo_ano-label">
+						<value>### No ultimo ano teve contacto com alguém infectado com TB?</value>
+						<value form="markdown">### No ultimo ano teve contacto com alguém infectado com TB?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/contacto_ultimo_ano-constraintMsg">
+						<value>O membro habita com um doente de TB!</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/contacto_ultimo_ano-sim-label">
+						<value>Sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/contacto_ultimo_ano-nao-label">
+						<value>Nao</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15-label">
+						<value>### Você tem algum dos seguintes sintomas?</value>
+						<value form="markdown">### Você tem algum dos seguintes sintomas?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15-constraintMsg">
+						<value>Por ter seleccionado 'Nenhum' como opção não pode ter outros sintomas seleccionados!</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15-nenhum-label">
+						<value>Nenhum</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15-tem_tosse-label">
+						<value>Tosse </value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15-febre_2_semanas-label">
+						<value>Febre </value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15-perda_de_peso-label">
+						<value>Tem perda de peso ou falência de crescimento</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15-Tem_falta_de_vontade_de_brincar-label">
+						<value>Fadiga ou falta de vontade de brincar</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15-Tem_caroço_no_pescoço_que_não_doi-label">
+						<value>Aparecimento sem causa de gânglios localizados não dolorosos</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15-nao_responde_aos_suplementos-label">
+						<value>Não responde aos suplementos nutricionais</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15-pneumonia_neonatal-label">
+						<value>Pneumonia Neonatal</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-label">
+						<value>### Você tem algum de os seguintes sintomas?</value>
+						<value form="markdown">### Você tem algum de os seguintes sintomas?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-constraintMsg">
+						<value>Por ter seleccionado 'Nenhum' como opção não pode ter outros sintomas seleccionados!</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-nenhum-label">
+						<value>Nenhum</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-tem_tosse-label">
+						<value>Tem tosse </value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-sangue-label">
+						<value>Tem tosse com sangue</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-febre_2_semanas-label">
+						<value>Tem febre </value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-perda_de_peso-label">
+						<value>Tem perda de peso</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-transpira-label">
+						<value>Transpira muito a noite</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-Tem_caroço_no_pescoço_que_não_doi-label">
+						<value>Tem caroços</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-cansado-label">
+						<value>Fica muito cansado</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-diarreia-label">
+						<value>Tem diarreia </value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-fam_tb-label">
+						<value>Herpes Zoster</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details-label">
+						<value>Detalhes dos sintomas</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/cough-label">
+						<value>Por quantas semanas o paciente tem tose?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/cough_with_blood-label">
+						<value>Por quantas semanas o paciente tem tose com sangue?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/fever-label">
+						<value>Por quantas semanas o paciente tem febre?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/lost_weight-label">
+						<value>Quantos kilos o paciente tem perdido no ultimo mes?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/fatigue-label">
+						<value>A quantos dias o paciente tem presentado fatiga?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/night_sweating-label">
+						<value>Por quantas semanas o paciente tem transpirado muito?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/diarrhea-label">
+						<value>A quantos dias o paciente tem presentado diarreia?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_screening_result-label">
+						<value>### Referencia para TB</value>
+						<value form="markdown">### Referencia para TB</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_screening_result/referido_rastreio_tb-label">
+						<value>### O paciente tem uma referencia para TB.</value>
+						<value form="markdown">### O paciente tem uma referencia para TB.</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_screening_result/lbl_refer_exposed_child_tb-label">
+						<value>* *Designação de TB - Criança exposta ao TB*</value>
+						<value form="markdown">* *Designação de TB - Criança exposta ao TB*</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_screening_result/hiv_exposed-label">
+						<value>* *Designação de TB - HIV + exposto ao TB*</value>
+						<value form="markdown">* *Designação de TB - HIV + exposto ao TB*</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_screening_result/lbl_tb_symptoms-label">
+						<value>* *Designação de TB - sintomas clinicos de TB*</value>
+						<value form="markdown">* *Designação de TB - sintomas clinicos de TB*</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/referido_rastreio_tb-label">
+						<value>Rastreio Positivo</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/referido_rastreio_tb/instruccoes_frascos-label">
+						<value>*Deixar um frasco, e explicar ao doente para escarrar no escarrador na manhã seguinte ao acorda, e levar ao unidade sánitaria para entregar no laboratorio.*</value>
+						<value form="markdown">*Deixar um frasco, e explicar ao doente para escarrar no escarrador na manhã seguinte ao acorda, e levar ao unidade sánitaria para entregar no laboratorio.*</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/referido_rastreio_tb/instruccoes-label">
+						<value>Quer ver mais instrucções sobre a recolho do escarro?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/referido_rastreio_tb/instruccoes-sim-label">
+						<value>Sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/referido_rastreio_tb/instruccoes-nao-label">
+						<value>Não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/escarro-label">
+						<value>Como recolher o escarro para análise</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/escarro/question9-label">
+						<value>#### Instruções para colheita de amostra de escarro:
+
+1. Você deve beber muita água durante a noite.
+2. Na manhã seguinte, deve colher a expectoração antes de comer 
+3. Deve lavar as mãos e bochechar com água antes de escarrar
+4. Deve escarrar num local aberto, não dentro de casa
+5. Inspira profundamente pelo nariz
+6. Reter o ar por alguns instantes e expirar
+7. Após repetir 3 vezes o procedimento anterior, inspirar profundamente e expirar com esforço e tossir
+8. Após tossir, abrir o escarrador e expectorar a secreção dentro do frasco sem tocar a parte interna
+9. Repetir o procedimento até alcançar 5 a 10 ml de volume da amostra
+10. Fechar bem o frasco, colocar dentro do saco plástico e proteger da luz solar
+11. Levar a amostra ao centro de saúde e entregar ao gestor de casos até as 9:00 horas.</value>
+						<value form="markdown">#### Instruções para colheita de amostra de escarro:
+
+1. Você deve beber muita água durante a noite.
+2. Na manhã seguinte, deve colher a expectoração antes de comer 
+3. Deve lavar as mãos e bochechar com água antes de escarrar
+4. Deve escarrar num local aberto, não dentro de casa
+5. Inspira profundamente pelo nariz
+6. Reter o ar por alguns instantes e expirar
+7. Após repetir 3 vezes o procedimento anterior, inspirar profundamente e expirar com esforço e tossir
+8. Após tossir, abrir o escarrador e expectorar a secreção dentro do frasco sem tocar a parte interna
+9. Repetir o procedimento até alcançar 5 a 10 ml de volume da amostra
+10. Fechar bem o frasco, colocar dentro do saco plástico e proteger da luz solar
+11. Levar a amostra ao centro de saúde e entregar ao gestor de casos até as 9:00 horas.</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/patient_received_container-label">
+						<value>### O paciente recebeu o frasco para o escarro?</value>
+						<value form="markdown">### O paciente recebeu o frasco para o escarro?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/patient_received_container-yes-label">
+						<value>Sim</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/patient_received_container-no-label">
+						<value>Não</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/not_received_container-label">
+						<value>Se não recibiou, qual é a razão?</value>
+					</text>
+					<text id="consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties-label">
+						<value>TB properties</value>
+					</text>
+					<text id="referrals-label">
+						<value>Referências</value>
+					</text>
+					<text id="referrals/required_referrals-label">
+						<value>Requere Referências</value>
+					</text>
+					<text id="referrals/required_referrals/list_required_referrals-label">
+						<value>Referências Precisadas</value>
+					</text>
+					<text id="referrals/required_referrals/list_required_referrals/referir_paciente-label">
+						<value>### Referir o paciente ao hospital/unidade sanitária para o seguinte:</value>
+						<value form="markdown">### Referir o paciente ao hospital/unidade sanitária para o seguinte:</value>
+					</text>
+					<text id="referrals/required_referrals/list_required_referrals/lbl_new_pregnancy-label">
+						<value>*-Novo gravidez para registar na US*</value>
+						<value form="markdown">*-Novo gravidez para registar na US*</value>
+					</text>
+					<text id="referrals/required_referrals/list_required_referrals/lbl_new_breastfeeding-label">
+						<value>*-Nova lactancia para registar na US*</value>
+						<value form="markdown">*-Nova lactancia para registar na US*</value>
+					</text>
+					<text id="referrals/required_referrals/list_required_referrals/lbl_refer_for_ccr-label">
+						<value>*- Criança a ser inscrita no CCR*</value>
+						<value form="markdown">*- Criança a ser inscrita no CCR*</value>
+					</text>
+					<text id="referrals/required_referrals/list_required_referrals/lbl_refer_child_pos_tb_screening-label">
+						<value>*- Criança para testar HIV*</value>
+						<value form="markdown">*- Criança para testar HIV*</value>
+					</text>
+					<text id="referrals/required_referrals/list_required_referrals/pacinete_para_testar_na_unidade_sanitria-label">
+						<value>- Paciente para testar na Unidade Sanitária</value>
+					</text>
+					<text id="referrals/required_referrals/list_required_referrals/lbl_iniciar_tarv-label">
+						<value>*-Paciente para iniciar TARV*</value>
+						<value form="markdown">*-Paciente para iniciar TARV*</value>
+					</text>
+					<text id="referrals/required_referrals/list_required_referrals/pos_seguimento-label">
+						<value>*- Aconselhamento em saúde infantil.*</value>
+						<value form="markdown">*- Aconselhamento em saúde infantil.*</value>
+					</text>
+					<text id="referrals/required_referrals/list_required_referrals/neg_crianca_testado-label">
+						<value>*-Aconselhamento nutricional*</value>
+						<value form="markdown">*-Aconselhamento nutricional*</value>
+					</text>
+					<text id="referrals/required_referrals/list_required_referrals/lbl_tb_positive-label">
+						<value>*-Referencia para TB*</value>
+						<value form="markdown">*-Referencia para TB*</value>
+					</text>
+					<text id="referrals/required_referrals/list_required_referrals/lbl_refer_hiv_for_tpi-label">
+						<value>***-Designação de TB** - Paciente para TPI*</value>
+						<value form="markdown">***-Designação de TB** - Paciente para TPI*</value>
+					</text>
+					<text id="referrals/required_referrals/list_required_referrals/lbl_refer_exposed_child_tb-label">
+						<value>***-Designação de TB** - Criança exposta ao TB*</value>
+						<value form="markdown">***-Designação de TB** - Criança exposta ao TB*</value>
+					</text>
+					<text id="referrals/required_referrals/list_required_referrals/hiv_exposed-label">
+						<value>***-Designação de TB** - HIV + exposto ao TB*</value>
+						<value form="markdown">***-Designação de TB** - HIV + exposto ao TB*</value>
+					</text>
+					<text id="referrals/required_referrals/list_required_referrals/lbl_tb_symptoms-label">
+						<value>***-Designação de TB** - sintomas clinicos de TB*</value>
+						<value form="markdown">***-Designação de TB** - sintomas clinicos de TB*</value>
+					</text>
+					<text id="referrals/required_referrals/fez_referencia-label">
+						<value>**<output value="/data/data/geral/nome_concat"  />** aceitou a ir a unidade sanitária? (Referir)</value>
+						<value form="markdown">**<output value="/data/data/geral/nome_concat"  />** aceitou a ir a unidade sanitária? (Referir)</value>
+					</text>
+					<text id="referrals/required_referrals/fez_referencia-sim-label">
+						<value>Sim</value>
+					</text>
+					<text id="referrals/required_referrals/fez_referencia-nao-label">
+						<value>Não</value>
+					</text>
+					<text id="referrals/required_referrals/does_patients_name_accepts_to_receive_care_at_chw_hf_name-label">
+						<value>**<output value="/data/data/geral/nome_concat"  />**  aceita receber cuidados médicos na **<output value="/data/data/geral/us"  />**?</value>
+						<value form="markdown">**<output value="/data/data/geral/nome_concat"  />**  aceita receber cuidados médicos na **<output value="/data/data/geral/us"  />**?</value>
+					</text>
+					<text id="referrals/required_referrals/does_patients_name_accepts_to_receive_care_at_chw_hf_name-1-label">
+						<value>Yes</value>
+					</text>
+					<text id="referrals/required_referrals/does_patients_name_accepts_to_receive_care_at_chw_hf_name-0-label">
+						<value>No</value>
+					</text>
+					<text id="referrals/required_referrals/preferred_health_facility_grp-label">
+						<value>Unidade Sanitaria preferida</value>
+					</text>
+					<text id="referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-label">
+						<value>### Escolha a provincia</value>
+						<value form="markdown">### Escolha a provincia</value>
+					</text>
+					<text id="referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-maputo_cidade-label">
+						<value>Maputo Cidade</value>
+					</text>
+					<text id="referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-maputo_provincia-label">
+						<value>Maputo Provincia</value>
+					</text>
+					<text id="referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-gaza-label">
+						<value>Gaza</value>
+					</text>
+					<text id="referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-inhambane-label">
+						<value>Inhambane</value>
+					</text>
+					<text id="referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-niassa-label">
+						<value>Niassa</value>
+					</text>
+					<text id="referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-manica-label">
+						<value>Manica</value>
+					</text>
+					<text id="referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-sofala-label">
+						<value>Sofala</value>
+					</text>
+					<text id="referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-zambezia-label">
+						<value>Zambezia</value>
+					</text>
+					<text id="referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-nampula-label">
+						<value>Nampula</value>
+					</text>
+					<text id="referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-cabo_delgado-label">
+						<value>Cabo Delgado</value>
+					</text>
+					<text id="referrals/required_referrals/preferred_health_facility_grp/hf_health_facility-label">
+						<value>### Escolha a unidade sanitaria</value>
+						<value form="markdown">### Escolha a unidade sanitaria</value>
+					</text>
+					<text id="referrals/required_referrals/preferred_health_facility_grp/lbl_transfer_to_current_chw_partner-label">
+						<value>This patient will be transferred to current CHW partner at selected health Facility</value>
+					</text>
+					<text id="referrals/required_referrals/preferred_health_facility_grp/select_partner-label">
+						<value>Select Partner</value>
+					</text>
+					<text id="referrals/required_referrals/preferred_health_facility_grp/lbl_no_partner_in_hf-label">
+						<value>The Health Facility doesn't currently have infomovel.</value>
+					</text>
+					<text id="referrals/required_referrals/consentimento_busca_activa-label">
+						<value><output value="/data/data/geral/nome_concat"  /> aceita ser visitado se não for a unidade sanitária?</value>
+					</text>
+					<text id="referrals/required_referrals/consentimento_busca_activa-sim-label">
+						<value>Sim</value>
+					</text>
+					<text id="referrals/required_referrals/consentimento_busca_activa-nao-label">
+						<value>Não</value>
+					</text>
+					<text id="referrals/required_referrals/intentar_convencer-label">
+						<value>### Por favor, aconselhar o paciente a ir ao hospital.</value>
+						<value form="markdown">### Por favor, aconselhar o paciente a ir ao hospital.</value>
+					</text>
+					<text id="referrals/required_referrals/test-label">
+						<value>test</value>
+					</text>
+					<text id="referrals/required_referrals/test/test_data_de_referencia-label">
+						<value>Data de referencia (set)</value>
+					</text>
+					<text id="referrals/required_referrals/test/test_data_proxima_visita-label">
+						<value>data_proxima_visita (set)</value>
+					</text>
+					<text id="referrals/no_referrals-label">
+						<value>Não Requere Referências</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-label">
+						<value>O paciente tem que ser referido por alguma das seguintes doenças?</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-nunhum-label">
+						<value>Nenhuma</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-hipertensao-label">
+						<value>Hipertensão</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-infeccao_de_transmission_sexual-label">
+						<value>Infecção de Transmissão Sexual</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-consulta_pre_natal-label">
+						<value>Consulta Pré Natal</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-malaria-label">
+						<value>Malária</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-epilepsia-label">
+						<value>Epilepsia</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-doencas_de_pele-label">
+						<value>Doenças de Pele</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-diarreia-label">
+						<value>Diarreia</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-circuncisao_masculina-label">
+						<value>Circuncisão Masculina</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-ptv-label">
+						<value>PTV</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-violenca_sexual-label">
+						<value>Violência Sexual</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-violencia-label">
+						<value>Violência Física</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-grupo_de_apoio-label">
+						<value>Grupo de Apoio</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-despite_cancro_uterino-label">
+						<value>Despiste cancro uterino e mama</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-despiste_cancro_de_prostata-label">
+						<value>Despiste cancro de próstata</value>
+					</text>
+					<text id="referrals/no_referrals/outras_referencias-outra-label">
+						<value>Outra</value>
+					</text>
+					<text id="referrals/no_referrals/outra_doenca-label">
+						<value>Outra doença:</value>
+					</text>
+					<text id="contacts_registration_concent-label">
+						<value>### Consente o registro dos seus contactos?</value>
+						<value form="markdown">### Consente o registro dos seus contactos?</value>
+					</text>
+					<text id="contacts_registration_concent-yes-label">
+						<value>Sim</value>
+					</text>
+					<text id="contacts_registration_concent-no-label">
+						<value>Não</value>
+					</text>
+					<text id="register_conviventes_during_visit-label">
+						<value>Você quer registar mais contactos ***hoje***? </value>
+						<value form="markdown">Você quer registar mais contactos ***hoje***? </value>
+					</text>
+					<text id="register_conviventes_during_visit-sim-label">
+						<value>Sim</value>
+					</text>
+					<text id="register_conviventes_during_visit-nao-label">
+						<value>Não</value>
+					</text>
+					<text id="hh_reg-label">
+						<value>Fechar Registo da Casa</value>
+					</text>
+					<text id="hh_reg/mais_conviventes-label">
+						<value>Você quer terminar o registo de contactos para nesta ***casa***?</value>
+					</text>
+					<text id="hh_reg/mais_conviventes-sim-label">
+						<value>Sim</value>
+					</text>
+					<text id="hh_reg/mais_conviventes-nao-label">
+						<value>Não</value>
+					</text>
+					<text id="hh_reg/confirmar_registo_conviventes_completo-label">
+						<value>**Isto vai fechar a opção de registar novos contactos. Se não quer fechar, responder "Não" acima.** </value>
+						<value form="markdown">**Isto vai fechar a opção de registar novos contactos. Se não quer fechar, responder "Não" acima.** </value>
+					</text>
+					<text id="hh_reg/confirmar_registo_conviventes_completo-ok-label">
+						<value>OK</value>
+					</text>
+					<text id="display_new_convivente-label">
+						<value>Por favor, submete este formulário, e entrar no formulário de novo para registar outro contacto.</value>
+					</text>
+					<text id="data-label">
+						<value>data</value>
+					</text>
+					<text id="data/referencia-label">
+						<value>referencia</value>
+					</text>
+					<text id="data/geral-label">
+						<value>geral</value>
+					</text>
+					<text id="data/busca_activa-label">
+						<value>busca_activa</value>
+					</text>
+					<text id="casa-label">
+						<value>casa</value>
+					</text>
+					<text id="casa/conviventes-label">
+						<value>Conviventes</value>
+					</text>
+					<text id="casa/testagem-label">
+						<value>testagem</value>
+					</text>
+					<text id="casa/index-label">
+						<value>index</value>
+					</text>
+					<text id="indicators_v4-label">
+						<value>Indicadores V4</value>
+					</text>
+					<text id="calendario-label">
+						<value>calendario</value>
+					</text>
+				</translation>
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+		<select1 ref="/data/consentimento_registo">
+			<label ref="jr:itext('consentimento_registo-label')" />
+			<item>
+				<label ref="jr:itext('consentimento_registo-sim-label')" />
+				<value>sim</value>
+			</item>
+			<item>
+				<label ref="jr:itext('consentimento_registo-nao-label')" />
+				<value>nao</value>
+			</item>
+		</select1>
+		<input  ref="/data/referecencia_gps">
+			<label ref="jr:itext('referencia_de_localizacao/referecencia_gps-label')" />
+		</input>
+		<group  ref="/data/consentimento_sim">
+			<label ref="jr:itext('consentimento_sim-label')" />
+			<group  ref="/data/consentimento_sim/registro_de_conviventes">
+				<label ref="jr:itext('consentimento_sim/registro_de_conviventes-label')" />
+				<group  ref="/data/consentimento_sim/registro_de_conviventes/patient_information">
+					<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information-label')" />
+					<trigger  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/lbl_confirmar_informacao" appearance="minimal">
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/lbl_confirmar_informacao-label')" />
+					</trigger>
+					<input  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/apelido">
+						<label ref="jr:itext('apelido-label')" />
+					</input>
+					<input  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/nome_primero">
+						<label ref="jr:itext('nome_primero-label')" />
+						<hint ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/nome_primero-hint')" />
+					</input>
+					<select1  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/genero">
+						<label ref="jr:itext('genero-label')" />
+						<item>
+							<label ref="jr:itext('genero-masculino-label')" />
+							<value>M</value>
+						</item>
+						<item>
+							<label ref="jr:itext('genero-feminino-label')" />
+							<value>F</value>
+						</item>
+					</select1>
+					<select1  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/data_de_nacimento_conhecido">
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/data_de_nacimento_conhecido-label')" />
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/data_de_nacimento_conhecido-sim-label')" />
+							<value>sim</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/data_de_nacimento_conhecido-nao-label')" />
+							<value>nao</value>
+						</item>
+					</select1>
+					<input  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/data_do_nacimento">
+						<label ref="jr:itext('data_do_nacimiento-label')" />
+						<alert ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/data_do_nacimento-constraintMsg')" />
+					</input>
+					<input  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/idade_perguntar">
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/idade_perguntar-label')" />
+						<alert ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/idade_perguntar-constraintMsg')" />
+					</input>
+					<group  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/question1" appearance="field-list">
+						<trigger  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/question1/display_idade_meses" appearance="minimal">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/question1/display_idade_meses-label')" />
+						</trigger>
+						<trigger  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/question1/display_idade_anos" appearance="minimal">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/question1/display_idade_anos-label')" />
+						</trigger>
+						<trigger  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/question1/lbl_breasfeeding_child" appearance="minimal">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/question1/lbl_breasfeeding_child-label')" />
+						</trigger>
+					</group>
+					<group  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez">
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez-label')" />
+						<select1  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez/nova_gravidez">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez/nova_gravidez-label')" />
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez/nova_gravidez-sim-label')" />
+								<value>sim</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez/nova_gravidez-nao-label')" />
+								<value>nao</value>
+							</item>
+						</select1>
+						<select1  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez/tem_edd">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez/tem_edd-label')" />
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez/tem_edd-sim-label')" />
+								<value>sim</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez/tem_edd-nao-label')" />
+								<value>nao</value>
+							</item>
+						</select1>
+						<input  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez/edd">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_gravidez/edd-label')" />
+						</input>
+					</group>
+					<group  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_lactancia">
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_lactancia-label')" />
+						<select1  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_lactancia/nova_lactancia">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_lactancia/nova_lactancia-label')" />
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_lactancia/nova_lactancia-sim-label')" />
+								<value>sim</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/confirmacao_da_lactancia/nova_lactancia-nao-label')" />
+								<value>nao</value>
+							</item>
+						</select1>
+					</group>
+					<select1  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/estado_civil">
+						<label ref="jr:itext('estado_civil-label')" />
+						<item>
+							<label ref="jr:itext('estado_civil-solteiro-label')" />
+							<value>solteiro</value>
+						</item>
+						<item>
+							<label ref="jr:itext('estado_civil-casado-label')" />
+							<value>casado</value>
+						</item>
+						<item>
+							<label ref="jr:itext('estado_civil-viuvo-label')" />
+							<value>viuvo</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/estado_civil-uniao_de_fact-label')" />
+							<value>uniao_de_fact</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/estado_civil-divorcado-label')" />
+							<value>divorcado</value>
+						</item>
+					</select1>
+					<select1  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/escolaridade">
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/escolaridade-label')" />
+						<hint ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/escolaridade-hint')" />
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/escolaridade-nenhuma-label')" />
+							<value>nenhuma</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/escolaridade-primario-label')" />
+							<value>primario</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/escolaridade-secundario-label')" />
+							<value>secundario</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/escolaridade-universitario-label')" />
+							<value>universitario</value>
+						</item>
+					</select1>
+					<select1  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/ocupacao">
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/ocupacao-label')" />
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/ocupacao-camionista-label')" />
+							<value>camionista</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/ocupacao-militar-label')" />
+							<value>militar</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/ocupacao-mineiro-label')" />
+							<value>mineiro</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/ocupacao-trab_sexo-label')" />
+							<value>trab_sexo</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/ocupacao-trab_saude-label')" />
+							<value>trab_saude</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/ocupacao-educacao-label')" />
+							<value>educacao</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/ocupacao-estudante-label')" />
+							<value>estudante</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/ocupacao-informal-label')" />
+							<value>informal</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/ocupacao-domestica-label')" />
+							<value>domestica</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/ocupacao-policia-label')" />
+							<value>policia</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/ocupacao-campones-label')" />
+							<value>campones</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/ocupacao-recluso-label')" />
+							<value>recluso</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/ocupacao-outro-label')" />
+							<value>outro</value>
+						</item>
+					</select1>
+					<input  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/ocupacao_outro">
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/ocupacao_outro-label')" />
+					</input>
+					<input  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/nome_empresa">
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/nome_empresa-label')" />
+					</input>
+					<select1  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/grau_de_parentesco">
+						<label ref="jr:itext('grau_de_parentesco-label')" />
+						<alert ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/grau_de_parentesco-constraintMsg')" />
+						<item>
+							<label ref="jr:itext('grau_de_parentesco-esposo-label')" />
+							<value>esposo</value>
+						</item>
+						<item>
+							<label ref="jr:itext('grau_de_parentesco-filho-label')" />
+							<value>filho</value>
+						</item>
+						<item>
+							<label ref="jr:itext('grau_de_parentesco-namorado-label')" />
+							<value>namorado</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/grau_de_parentesco-pai-label')" />
+							<value>pai</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/grau_de_parentesco-sobrinho-label')" />
+							<value>sobrinho</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/grau_de_parentesco-irmao-label')" />
+							<value>irmao</value>
+						</item>
+						<item>
+							<label ref="jr:itext('grau_de_parentesco-outro-label')" />
+							<value>outro</value>
+						</item>
+					</select1>
+					<select1  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/parceiro_fora_da_casa_perguntar">
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/parceiro_fora_da_casa_perguntar-label')" />
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/parceiro_fora_da_casa_perguntar-sim-label')" />
+							<value>sim</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/parceiro_fora_da_casa_perguntar-nao-label')" />
+							<value>nao</value>
+						</item>
+					</select1>
+					<group  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/sexual_partner_info">
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/sexual_partner_info-label')" />
+						<input  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/sexual_partner_info/num_parceiros_fora_casa">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/sexual_partner_info/num_parceiros_fora_casa-label')" />
+							<hint ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/sexual_partner_info/num_parceiros_fora_casa-hint')" />
+						</input>
+						<trigger  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/sexual_partner_info/register_info_sexual_lbl" appearance="minimal">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/sexual_partner_info/register_info_sexual_lbl-label')" />
+						</trigger>
+					</group>
+					<input  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/parceiro_fora_da_casa_endereco">
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/parceiro_fora_da_casa_endereco-label')" />
+					</input>
+					<input  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/outro_grau_de_parentesco">
+						<label ref="jr:itext('outro_grau_de_parentesco-label')" />
+					</input>
+					<select1  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/tem_numero_de_telefone">
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/tem_numero_de_telefone-label')" />
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/tem_numero_de_telefone-sim-label')" />
+							<value>sim</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/tem_numero_de_telefone-nao-label')" />
+							<value>nao</value>
+						</item>
+					</select1>
+					<input  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/telefone" appearance="numeric">
+						<label ref="jr:itext('telefone-label')" />
+						<alert ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/telefone-constraintMsg')" />
+					</input>
+					<select1  ref="/data/consentimento_sim/registro_de_conviventes/patient_information/consentimento_menor_15_anos">
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/consentimento_menor_15_anos-label')" />
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/consentimento_menor_15_anos-sim-label')" />
+							<value>sim</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/patient_information/consentimento_menor_15_anos-nao-label')" />
+							<value>nao</value>
+						</item>
+					</select1>
+				</group>
+				<group  ref="/data/consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member">
+					<label ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member-label')" />
+					<select1  ref="/data/consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes">
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-label')" />
+						<hint ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-hint')" />
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-0-label')" />
+							<value>0</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-1-label')" />
+							<value>1</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-2-label')" />
+							<value>2</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-3-label')" />
+							<value>3</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-4-label')" />
+							<value>4</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-5-label')" />
+							<value>5</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-6-label')" />
+							<value>6</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-7-label')" />
+							<value>7</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-8-label')" />
+							<value>8</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-9-label')" />
+							<value>9</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-10-label')" />
+							<value>10</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-11-label')" />
+							<value>11</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-12-label')" />
+							<value>12</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-13-label')" />
+							<value>13</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-14-label')" />
+							<value>14</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-15-label')" />
+							<value>15</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-16-label')" />
+							<value>16</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-17-label')" />
+							<value>17</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-18-label')" />
+							<value>18</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-19-label')" />
+							<value>19</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes-20-label')" />
+							<value>20</value>
+						</item>
+					</select1>
+					<input  ref="/data/consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/num_parceiros">
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/num_parceiros-label')" />
+					</input>
+					<input  ref="/data/consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes_under5">
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes_under5-label')" />
+					</input>
+					<input  ref="/data/consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes_5_to_14">
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/numero_conviventes_5_to_14-label')" />
+					</input>
+					<group  ref="/data/consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/filhos_fora_hh">
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/filhos_fora_hh-label')" />
+						<select1  ref="/data/consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/filhos_fora_hh/children_living_outside_the_hh">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/filhos_fora_hh/children_living_outside_the_hh-label')" />
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/filhos_fora_hh/children_living_outside_the_hh-yes-label')" />
+								<value>yes</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/filhos_fora_hh/children_living_outside_the_hh-no-label')" />
+								<value>no</value>
+							</item>
+						</select1>
+						<input  ref="/data/consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/filhos_fora_hh/number_of_children_living_outside_the_house">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/filhos_fora_hh/number_of_children_living_outside_the_house-label')" />
+						</input>
+						<trigger  ref="/data/consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/filhos_fora_hh/lbl_counsel" appearance="minimal">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/sexual_partner_or_community_member/filhos_fora_hh/lbl_counsel-label')" />
+						</trigger>
+					</group>
+				</group>
+				<select1  ref="/data/consentimento_sim/registro_de_conviventes/o_paciente__sexualmente_activo">
+					<label ref="jr:itext('consentimento_sim/registro_de_conviventes/o_paciente__sexualmente_activo-label')" />
+					<item>
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/o_paciente__sexualmente_activo-sim-label')" />
+						<value>sim</value>
+					</item>
+					<item>
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/o_paciente__sexualmente_activo-no-label')" />
+						<value>no</value>
+					</item>
+				</select1>
+				<select  ref="/data/consentimento_sim/registro_de_conviventes/tipo_de_sexo">
+					<label ref="jr:itext('consentimento_sim/registro_de_conviventes/tipo_de_sexo-label')" />
+					<item>
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/tipo_de_sexo-anal-label')" />
+						<value>anal</value>
+					</item>
+					<item>
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/tipo_de_sexo-oral-label')" />
+						<value>oral</value>
+					</item>
+					<item>
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/tipo_de_sexo-vaginal-label')" />
+						<value>vaginal</value>
+					</item>
+				</select>
+				<select1  ref="/data/consentimento_sim/registro_de_conviventes/relacoes_mesmo_sexo">
+					<label ref="jr:itext('consentimento_sim/registro_de_conviventes/relacoes_mesmo_sexo-label')" />
+					<item>
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/relacoes_mesmo_sexo-sim-label')" />
+						<value>sim</value>
+					</item>
+					<item>
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/relacoes_mesmo_sexo-no-label')" />
+						<value>no</value>
+					</item>
+				</select1>
+				<select1  ref="/data/consentimento_sim/registro_de_conviventes/o_paciente_tem_mais_de_um_parceiro_sexual">
+					<label ref="jr:itext('consentimento_sim/registro_de_conviventes/o_paciente_tem_mais_de_um_parceiro_sexual-label')" />
+					<item>
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/o_paciente_tem_mais_de_um_parceiro_sexual-sim-label')" />
+						<value>sim</value>
+					</item>
+					<item>
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/o_paciente_tem_mais_de_um_parceiro_sexual-no-label')" />
+						<value>no</value>
+					</item>
+				</select1>
+				<select1  ref="/data/consentimento_sim/registro_de_conviventes/alguma_vez_foi_solicitado_a_ter_relaes_sexuais_com_algum_em_troca_de_dinhei">
+					<label ref="jr:itext('consentimento_sim/registro_de_conviventes/alguma_vez_foi_solicitado_a_ter_relaes_sexuais_com_algum_em_troca_de_dinhei-label')" />
+					<item>
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/alguma_vez_foi_solicitado_a_ter_relaes_sexuais_com_algum_em_troca_de_dinhei-sim-label')" />
+						<value>sim</value>
+					</item>
+					<item>
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/alguma_vez_foi_solicitado_a_ter_relaes_sexuais_com_algum_em_troca_de_dinhei-no-label')" />
+						<value>no</value>
+					</item>
+				</select1>
+				<select1  ref="/data/consentimento_sim/registro_de_conviventes/consome_bebidas_alcolicas">
+					<label ref="jr:itext('consentimento_sim/registro_de_conviventes/consome_bebidas_alcolicas-label')" />
+					<item>
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/consome_bebidas_alcolicas-sim-label')" />
+						<value>sim</value>
+					</item>
+					<item>
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/consome_bebidas_alcolicas-nao-label')" />
+						<value>nao</value>
+					</item>
+				</select1>
+				<input  ref="/data/consentimento_sim/registro_de_conviventes/que_tipo_costuma_consumir">
+					<label ref="jr:itext('consentimento_sim/registro_de_conviventes/que_tipo_costuma_consumir-label')" />
+				</input>
+				<select1  ref="/data/consentimento_sim/registro_de_conviventes/consome_outras_drogas">
+					<label ref="jr:itext('consentimento_sim/registro_de_conviventes/consome_outras_drogas-label')" />
+					<item>
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/consome_outras_drogas-sim-label')" />
+						<value>sim</value>
+					</item>
+					<item>
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/consome_outras_drogas-nao-label')" />
+						<value>nao</value>
+					</item>
+				</select1>
+				<input  ref="/data/consentimento_sim/registro_de_conviventes/frequencia_drogas">
+					<label ref="jr:itext('consentimento_sim/registro_de_conviventes/frequencia_drogas-label')" />
+				</input>
+				<group  ref="/data/consentimento_sim/registro_de_conviventes/testagem_para_adultos">
+					<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_para_adultos-label')" />
+					<select  ref="/data/consentimento_sim/registro_de_conviventes/testagem_para_adultos/indique_os_factores_de_risco_que_o_paciente_apresenta">
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_para_adultos/indique_os_factores_de_risco_que_o_paciente_apresenta-label')" />
+						<alert ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_para_adultos/indique_os_factores_de_risco_que_o_paciente_apresenta-constraintMsg')" />
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_para_adultos/indique_os_factores_de_risco_que_o_paciente_apresenta-nenhum-label')" />
+							<value>nenhum</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_para_adultos/indique_os_factores_de_risco_que_o_paciente_apresenta-esteve_internado_nos_ultimos_6_meses-label')" />
+							<value>esteve_internado_nos_ultimos_6_meses</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_para_adultos/indique_os_factores_de_risco_que_o_paciente_apresenta-parceiro_de_PVHIV-label')" />
+							<value>parceiro_de_PVHIV</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_para_adultos/indique_os_factores_de_risco_que_o_paciente_apresenta-o_paciente_usa_preservativo_durante_as_relaes_sexuai-label')" />
+							<value>o_paciente_usa_preservativo_durante_as_relaes_sexuai</value>
+						</item>
+					</select>
+					<select  ref="/data/consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas">
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-label')" />
+						<alert ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-constraintMsg')" />
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-nenhum-label')" />
+							<value>nenhum</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-sinais_e_sintomas_respiratorios-label')" />
+							<value>sinais_e_sintomas_respiratorios</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-corrimento_ou_feridas_genitais-label')" />
+							<value>corrimento_ou_feridas_genitais</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-inchaco-label')" />
+							<value>inchaco</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-perda_de_peso-label')" />
+							<value>perda_de_peso</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-diarreia-label')" />
+							<value>diarreia</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-febre-label')" />
+							<value>febre</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-dificuldades_comer-label')" />
+							<value>dificuldades_comer</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-problema_pele-label')" />
+							<value>problema_pele</value>
+						</item>
+						<item>
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_para_adultos/sintomas-outro-label')" />
+							<value>outro</value>
+						</item>
+					</select>
+					<input  ref="/data/consentimento_sim/registro_de_conviventes/testagem_para_adultos/outro">
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_para_adultos/outro-label')" />
+					</input>
+					<trigger  ref="/data/consentimento_sim/registro_de_conviventes/testagem_para_adultos/este__um_adulto_em_risco_e_deve_ser_testado" appearance="minimal">
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_para_adultos/este__um_adulto_em_risco_e_deve_ser_testado-label')" />
+					</trigger>
+				</group>
+				<group  ref="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population">
+					<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population-label')" />
+					<group  ref="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens">
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens-label')" />
+						<select1  ref="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/produto_lubrificacao">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/produto_lubrificacao-label')" />
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/produto_lubrificacao-sim-label')" />
+								<value>sim</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/produto_lubrificacao-nao-label')" />
+								<value>nao</value>
+							</item>
+						</select1>
+						<input  ref="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/tipo_lubricador">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/tipo_lubricador-label')" />
+						</input>
+						<select1  ref="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/sabe_sobre_HIV">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/sabe_sobre_HIV-label')" />
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/sabe_sobre_HIV-sim-label')" />
+								<value>sim</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/sabe_sobre_HIV-no-label')" />
+								<value>no</value>
+							</item>
+						</select1>
+						<select1  ref="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/sabe_prevenir">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/sabe_prevenir-label')" />
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/sabe_prevenir-sim-label')" />
+								<value>sim</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/sabe_prevenir-nao-label')" />
+								<value>nao</value>
+							</item>
+						</select1>
+						<select1  ref="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/acredita_HIV">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/acredita_HIV-label')" />
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/acredita_HIV-sim-label')" />
+								<value>sim</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/acredita_HIV-nao-label')" />
+								<value>nao</value>
+							</item>
+						</select1>
+						<select1  ref="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/disieases">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/disieases-label')" />
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/disieases-sim-label')" />
+								<value>sim</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/disieases-nao-label')" />
+								<value>nao</value>
+							</item>
+						</select1>
+						<select1  ref="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/procurou_tratamento">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/procurou_tratamento-label')" />
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/procurou_tratamento-sim_en-label')" />
+								<value>sim_en</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/procurou_tratamento-no_en-label')" />
+								<value>no_en</value>
+							</item>
+						</select1>
+						<trigger  ref="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/este_peciente_est_em_risco_e_deve_ser_testado_pois_apresenta_factores_de_ho" appearance="minimal">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/homens_que_fazem_sexo_com_homens/este_peciente_est_em_risco_e_deve_ser_testado_pois_apresenta_factores_de_ho-label')" />
+						</trigger>
+					</group>
+					<group  ref="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46">
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46-label')" />
+						<input  ref="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/txt_reaction">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/txt_reaction-label')" />
+						</input>
+						<select1  ref="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/ja_ouviu_falar_de_its_hiv">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/ja_ouviu_falar_de_its_hiv-label')" />
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/ja_ouviu_falar_de_its_hiv-sim-label')" />
+								<value>sim</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/ja_ouviu_falar_de_its_hiv-no-label')" />
+								<value>no</value>
+							</item>
+						</select1>
+						<select1  ref="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/sabe_como_se_prevenir_para_no_contrair">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/sabe_como_se_prevenir_para_no_contrair-label')" />
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/sabe_como_se_prevenir_para_no_contrair-sim-label')" />
+								<value>sim</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/sabe_como_se_prevenir_para_no_contrair-no-label')" />
+								<value>no</value>
+							</item>
+						</select1>
+						<select1  ref="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/usa_o_preservativo_com_os_clientes_e_tambm_com_seu_parceiro">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/usa_o_preservativo_com_os_clientes_e_tambm_com_seu_parceiro-label')" />
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/usa_o_preservativo_com_os_clientes_e_tambm_com_seu_parceiro-sim-label')" />
+								<value>sim</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/usa_o_preservativo_com_os_clientes_e_tambm_com_seu_parceiro-no-label')" />
+								<value>no</value>
+							</item>
+						</select1>
+						<select1  ref="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/usa_em_todas_as_practicas_sexuais">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/usa_em_todas_as_practicas_sexuais-label')" />
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/usa_em_todas_as_practicas_sexuais-sim-label')" />
+								<value>sim</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/usa_em_todas_as_practicas_sexuais-nao-label')" />
+								<value>nao</value>
+							</item>
+						</select1>
+						<select1  ref="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/produto_lubrificacao">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/produto_lubrificacao-label')" />
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/produto_lubrificacao-sim-label')" />
+								<value>sim</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/produto_lubrificacao-nao-label')" />
+								<value>nao</value>
+							</item>
+						</select1>
+						<input  ref="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/tipo_lubricador">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/tipo_lubricador-label')" />
+						</input>
+						<select  ref="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/onde_tem_praticado_sua_actividade_como_trabalhadora">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/onde_tem_praticado_sua_actividade_como_trabalhadora-label')" />
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/onde_tem_praticado_sua_actividade_como_trabalhadora-rua-label')" />
+								<value>rua</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/onde_tem_praticado_sua_actividade_como_trabalhadora-barracas-label')" />
+								<value>barracas</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/onde_tem_praticado_sua_actividade_como_trabalhadora-casa-label')" />
+								<value>casa</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/onde_tem_praticado_sua_actividade_como_trabalhadora-hotel-label')" />
+								<value>hotel</value>
+							</item>
+						</select>
+						<trigger  ref="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/esta_paciente__trabalhadora_de_sexo_e_deve_ser_testada" appearance="minimal">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/question46/esta_paciente__trabalhadora_de_sexo_e_deve_ser_testada-label')" />
+						</trigger>
+					</group>
+					<group  ref="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas">
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas-label')" />
+						<input  ref="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/relation_after_drugs">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/relation_after_drugs-label')" />
+						</input>
+						<select1  ref="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/usa_preservativo_durante_as_suas_relacoes_sxuais">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/usa_preservativo_durante_as_suas_relacoes_sxuais-label')" />
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/usa_preservativo_durante_as_suas_relacoes_sxuais-sim-label')" />
+								<value>sim</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/usa_preservativo_durante_as_suas_relacoes_sxuais-nao-label')" />
+								<value>nao</value>
+							</item>
+						</select1>
+						<select1  ref="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/usa_drogas_injectaveis">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/usa_drogas_injectaveis-label')" />
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/usa_drogas_injectaveis-sim-label')" />
+								<value>sim</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/usa_drogas_injectaveis-nao-label')" />
+								<value>nao</value>
+							</item>
+						</select1>
+						<input  ref="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/com_que_frequencia_usa_estas_drogas">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/com_que_frequencia_usa_estas_drogas-label')" />
+						</input>
+						<select1  ref="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/j_partilhou_agulhas_ou_seringas">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/j_partilhou_agulhas_ou_seringas-label')" />
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/j_partilhou_agulhas_ou_seringas-sim-label')" />
+								<value>sim</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/j_partilhou_agulhas_ou_seringas-nao-label')" />
+								<value>nao</value>
+							</item>
+						</select1>
+						<select1  ref="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/acha_que_alguem_que_usa_drogas_injectaveis_corre_risco_de_contrair_o_hiv">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/acha_que_alguem_que_usa_drogas_injectaveis_corre_risco_de_contrair_o_hiv-label')" />
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/acha_que_alguem_que_usa_drogas_injectaveis_corre_risco_de_contrair_o_hiv-sim-label')" />
+								<value>sim</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/acha_que_alguem_que_usa_drogas_injectaveis_corre_risco_de_contrair_o_hiv-nao-label')" />
+								<value>nao</value>
+							</item>
+						</select1>
+						<trigger  ref="/data/consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/este_paciente_faz_o_uso_de_drogas_e_deve" appearance="minimal">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/testagem_hiv_para_key_population/testagem_para_pessoas_que_usam_e_injetam_drogas/este_paciente_faz_o_uso_de_drogas_e_deve-label')" />
+						</trigger>
+					</group>
+				</group>
+				<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido">
+					<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido-label')" />
+					<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment">
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment-label')" />
+						<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18-label')" />
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/mae_viva_presente">
+								<label ref="jr:itext('testagem_HIV/hiv_mostrar_apenas_menos_18/amamentacao-label')" />
+								<item>
+									<label ref="jr:itext('testagem_HIV/hiv_mostrar_apenas_menos_18/amamentacao-sim-label')" />
+									<value>sim</value>
+								</item>
+								<item>
+									<label ref="jr:itext('testagem_HIV/hiv_mostrar_apenas_menos_18/amamentacao-nao-label')" />
+									<value>nao</value>
+								</item>
+							</select1>
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/documentation">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/documentation-label')" />
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/documentation-sim-label')" />
+									<value>sim</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/documentation-nao-label')" />
+									<value>nao</value>
+								</item>
+							</select1>
+							<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/pedir_cartao" appearance="minimal">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/pedir_cartao-label')" />
+							</trigger>
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/seroestado_conhecido">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/seroestado_conhecido-label')" />
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/seroestado_conhecido-sim-label')" />
+									<value>sim</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/seroestado_conhecido-nao-label')" />
+									<value>nao</value>
+								</item>
+							</select1>
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/seroestado_da_mae">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/seroestado_da_mae-label')" />
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/seroestado_da_mae-positivo-label')" />
+									<value>positivo</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/seroestado_da_mae-negativo-label')" />
+									<value>negativo</value>
+								</item>
+							</select1>
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/crianca_em_seguimento">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/crianca_em_seguimento-label')" />
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/crianca_em_seguimento-sim-label')" />
+									<value>sim</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/crianca_em_seguimento-nao-label')" />
+									<value>nao</value>
+								</item>
+							</select1>
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/internada_ultimos_6meses">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/internada_ultimos_6meses-label')" />
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/internada_ultimos_6meses-sim-label')" />
+									<value>sim</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/internada_ultimos_6meses-no-label')" />
+									<value>no</value>
+								</item>
+							</select1>
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/lesao_ultimos_6meses">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/lesao_ultimos_6meses-label')" />
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/lesao_ultimos_6meses-sim-label')" />
+									<value>sim</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/lesao_ultimos_6meses-nao-label')" />
+									<value>nao</value>
+								</item>
+							</select1>
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/severe_health_issues">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/severe_health_issues-label')" />
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/severe_health_issues-sim-label')" />
+									<value>sim</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_crianca_maior_de_18/severe_health_issues-no-label')" />
+									<value>no</value>
+								</item>
+							</select1>
+						</group>
+						<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos-label')" />
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/mae_viva_presente">
+								<label ref="jr:itext('testagem_HIV/hiv_mostrar_apenas_menos_18/amamentacao-label')" />
+								<item>
+									<label ref="jr:itext('testagem_HIV/hiv_mostrar_apenas_menos_18/amamentacao-sim-label')" />
+									<value>sim</value>
+								</item>
+								<item>
+									<label ref="jr:itext('testagem_HIV/hiv_mostrar_apenas_menos_18/amamentacao-nao-label')" />
+									<value>nao</value>
+								</item>
+							</select1>
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/hospitalised_6months">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/hospitalised_6months-label')" />
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/hospitalised_6months-sim-label')" />
+									<value>sim</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/hospitalised_6months-no-label')" />
+									<value>no</value>
+								</item>
+							</select1>
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_teve_uma_leso_extensa_que_no_melhora_com_o_tratamento">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_teve_uma_leso_extensa_que_no_melhora_com_o_tratamento-label')" />
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_teve_uma_leso_extensa_que_no_melhora_com_o_tratamento-sim-label')" />
+									<value>sim</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_teve_uma_leso_extensa_que_no_melhora_com_o_tratamento-no-label')" />
+									<value>no</value>
+								</item>
+							</select1>
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/nos_ultimos_3_meses_teve_algum_problema_de_saude_persistente_como_perda_de_">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/nos_ultimos_3_meses_teve_algum_problema_de_saude_persistente_como_perda_de_-label')" />
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/nos_ultimos_3_meses_teve_algum_problema_de_saude_persistente_como_perda_de_-sim-label')" />
+									<value>sim</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/nos_ultimos_3_meses_teve_algum_problema_de_saude_persistente_como_perda_de_-no-label')" />
+									<value>no</value>
+								</item>
+							</select1>
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_tem_corrimento">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_tem_corrimento-label')" />
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_tem_corrimento-sim-label')" />
+									<value>sim</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_tem_corrimento-no-label')" />
+									<value>no</value>
+								</item>
+							</select1>
+							<select  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_tem_um_dos_seguintes_problemas">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_tem_um_dos_seguintes_problemas-label')" />
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_tem_um_dos_seguintes_problemas-corrimento_vaginal-label')" />
+									<value>corrimento_vaginal</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_tem_um_dos_seguintes_problemas-corrimento_uretral-label')" />
+									<value>corrimento_uretral</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/o_paciente_tem_um_dos_seguintes_problemas-ulcera_genital-label')" />
+									<value>ulcera_genital</value>
+								</item>
+							</select>
+							<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/este_adolescente_est_em_risco_e_deve_ser_testado" appearance="minimal">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/testagem_para_hiv_de_adolescente_10-18_anos/este_adolescente_est_em_risco_e_deve_ser_testado-label')" />
+							</trigger>
+						</group>
+						<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions-label')" />
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testado_hiv_vez">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testado_hiv_vez-label')" />
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testado_hiv_vez-sim-label')" />
+									<value>sim</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testado_hiv_vez-nao-label')" />
+									<value>nao</value>
+								</item>
+							</select1>
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/fez_pcr">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/fez_pcr-label')" />
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/fez_pcr-sim-label')" />
+									<value>sim</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/fez_pcr-não-label')" />
+									<value>não</value>
+								</item>
+							</select1>
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/resultado_previo_hiv">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/resultado_previo_hiv-label')" />
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/resultado_previo_hiv-positivo-label')" />
+									<value>positivo</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/resultado_previo_hiv-negativo-label')" />
+									<value>negativo</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/resultado_previo_hiv-indeterminado-label')" />
+									<value>indeterminado</value>
+								</item>
+							</select1>
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/child_still_breastfeeding">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/child_still_breastfeeding-label')" />
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/child_still_breastfeeding-yes-label')" />
+									<value>yes</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/child_still_breastfeeding-no-label')" />
+									<value>no</value>
+								</item>
+							</select1>
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/mai_parou_amamentar">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/mai_parou_amamentar-label')" />
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/mai_parou_amamentar-sim-label')" />
+									<value>sim</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/mai_parou_amamentar-nao-label')" />
+									<value>nao</value>
+								</item>
+							</select1>
+							<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/child_risk_evaluated" appearance="minimal">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/child_risk_evaluated-label')" />
+							</trigger>
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/tem_nid">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/tem_nid-label')" />
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/tem_nid-sim-label')" />
+									<value>sim</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/tem_nid-nao-label')" />
+									<value>nao</value>
+								</item>
+							</select1>
+							<input  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/nid">
+								<label ref="jr:itext('nid-label')" />
+								<alert ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/nid-constraintMsg')" />
+							</input>
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/testado_por_hiv_recente">
+								<label ref="jr:itext('testado_por_hiv_recente-label')" />
+								<item>
+									<label ref="jr:itext('testado_por_hiv_recente-sim-label')" />
+									<value>sim</value>
+								</item>
+								<item>
+									<label ref="jr:itext('testado_por_hiv_recente-nao-label')" />
+									<value>nao</value>
+								</item>
+							</select1>
+							<input  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/data_ultimo_teste_hiv">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/data_ultimo_teste_hiv-label')" />
+							</input>
+							<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/restagem_3_meses" appearance="minimal">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/restagem_3_meses-label')" />
+							</trigger>
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/em_tratamento_hiv">
+								<label ref="jr:itext('em_tratamento_hiv-label')" />
+								<item>
+									<label ref="jr:itext('em_tratamento_hiv-sim-label')" />
+									<value>sim</value>
+								</item>
+								<item>
+									<label ref="jr:itext('em_tratamento_hiv-nao-label')" />
+									<value>nao</value>
+								</item>
+							</select1>
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/em_seguimento_ccr">
+								<label ref="jr:itext('em_tratamento_hiv-label2')" />
+								<item>
+									<label ref="jr:itext('em_tratamento_hiv-sim-label2')" />
+									<value>sim</value>
+								</item>
+								<item>
+									<label ref="jr:itext('em_tratamento_hiv-nao-label2')" />
+									<value>nao</value>
+								</item>
+							</select1>
+							<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/lbl_no_test" appearance="minimal">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/lbl_no_test-label')" />
+							</trigger>
+							<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/contact_doesnt_require_test" appearance="minimal">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/contact_doesnt_require_test-label')" />
+							</trigger>
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/test_patient_anyway">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/test_patient_anyway-label')" />
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/test_patient_anyway-yes-label')" />
+									<value>yes</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/test_patient_anyway-nao-label')" />
+									<value>nao</value>
+								</item>
+							</select1>
+							<input  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/reason_to_test_hiv">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/reason_to_test_hiv-label')" />
+							</input>
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/querer_testar">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/querer_testar-label')" />
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/querer_testar-sim-label')" />
+									<value>sim</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/querer_testar-nao-label')" />
+									<value>nao</value>
+								</item>
+							</select1>
+							<select  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/si_nao">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/si_nao-label')" />
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/si_nao-nao_tem_interesse-label')" />
+									<value>nao_tem_interesse</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/si_nao-teme_resultado-label')" />
+									<value>teme_resultado</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/si_nao-ja_sabe_diagnostico-label')" />
+									<value>ja_sabe_diagnostico</value>
+								</item>
+							</select>
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/activista_capacitado_testagem">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/activista_capacitado_testagem-label')" />
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/activista_capacitado_testagem-sim-label')" />
+									<value>sim</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/activista_capacitado_testagem-no-label')" />
+									<value>no</value>
+								</item>
+							</select1>
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/referir_para_teste">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/referir_para_teste-label')" />
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/referir_para_teste-1-label')" />
+									<value>1</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/patient_questions/referir_para_teste-0-label')" />
+									<value>0</value>
+								</item>
+							</select1>
+						</group>
+						<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/outcomes">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/outcomes-label')" />
+							<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/outcomes/referir_e_aconselhar" appearance="minimal">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/outcomes/referir_e_aconselhar-label')" />
+							</trigger>
+							<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/outcomes/referir_crianca_ccr" appearance="minimal">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/outcomes/referir_crianca_ccr-label')" />
+							</trigger>
+							<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/outcomes/aconselhado_adesao" appearance="minimal">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/outcomes/aconselhado_adesao-label')" />
+							</trigger>
+							<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/outcomes/aconselhado_saude_infantil" appearance="minimal">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/outcomes/aconselhado_saude_infantil-label')" />
+							</trigger>
+							<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/outcomes/aconselhado_negativo" appearance="minimal">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/pre-test_assessment/outcomes/aconselhado_negativo-label')" />
+							</trigger>
+						</group>
+					</group>
+					<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV">
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV-label')" />
+						<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos-label')" />
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/ver_os_pasos_test1">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/ver_os_pasos_test1-label')" />
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/ver_os_pasos_test1-sim-label')" />
+									<value>sim</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/ver_os_pasos_test1-nao-label')" />
+									<value>nao</value>
+								</item>
+							</select1>
+							<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_1">
+								<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1-label')" />
+								<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_1/preparacao">
+									<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/preparacao-label')" />
+									<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_1/preparacao/reunir_itens" appearance="minimal">
+										<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/preparacao/reunir_itens-label')" />
+									</trigger>
+									<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_1/preparacao/tira_teste" appearance="minimal">
+										<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/preparacao/tira_teste-label')" />
+									</trigger>
+									<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_1/preparacao/rotule_cartao" appearance="minimal">
+										<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/preparacao/rotule_cartao-label')" />
+									</trigger>
+									<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_1/preparacao/remover_cobertura" appearance="minimal">
+										<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/preparacao/remover_cobertura-label')" />
+									</trigger>
+								</group>
+								<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_1/colhendo_amostra">
+									<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/colhendo_amostra-label')" />
+									<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_1/colhendo_amostra/colhar_amostra" appearance="minimal">
+										<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/colhendo_amostra/colhar_amostra-label')" />
+									</trigger>
+								</group>
+								<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_1/aplicando_amostra">
+									<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/aplicando_amostra-label')" />
+									<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_1/aplicando_amostra/aplicar_amostra" appearance="minimal">
+										<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/aplicando_amostra/aplicar_amostra-label')" />
+									</trigger>
+									<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_1/aplicando_amostra/sangue_total" appearance="minimal">
+										<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/aplicando_amostra/sangue_total-label')" />
+									</trigger>
+								</group>
+								<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_1/obtener_resultados">
+									<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/obtener_resultados-label')" />
+									<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_1/obtener_resultados/tempo_resultados" appearance="minimal">
+										<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/obtener_resultados/tempo_resultados-label')" />
+									</trigger>
+									<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_1/obtener_resultados/registrar_resultados" appearance="minimal">
+										<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/obtener_resultados/registrar_resultados-label')" />
+									</trigger>
+								</group>
+								<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_1/interpretacao_teste" appearance="minimal">
+									<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/interpretacao_teste-label')" />
+								</trigger>
+							</group>
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_teste_rapido_determine">
+								<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/resultado_teste_rapido_determine-label')" />
+								<item>
+									<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/resultado_teste_rapido_determine-positivo-label')" />
+									<value>reativo</value>
+								</item>
+								<item>
+									<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/resultado_teste_rapido_determine-negativo-label')" />
+									<value>nao_reativo</value>
+								</item>
+							</select1>
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/Quer_ver_os_pasos">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/Quer_ver_os_pasos-label')" />
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/Quer_ver_os_pasos-sim-label')" />
+									<value>sim</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/Quer_ver_os_pasos-nao-label')" />
+									<value>nao</value>
+								</item>
+							</select1>
+							<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_2">
+								<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2-label')" />
+								<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_2/unigold_preparacao">
+									<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/unigold_preparacao-label')" />
+									<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_2/unigold_preparacao/unigold_reunir_itens" appearance="minimal">
+										<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/unigold_preparacao/unigold_reunir_itens-label')" />
+									</trigger>
+								</group>
+								<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_2/unigold_dispositivo_embalagem" appearance="minimal">
+									<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/unigold_preparacao/unigold_dispositivo_embalagem-label')" />
+								</trigger>
+								<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_2/unigold_colhendo_amostra">
+									<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/unigold_colhendo_amostra-label')" />
+									<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_2/unigold_colhendo_amostra/unigold_colhar_amostra" appearance="minimal">
+										<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/unigold_colhendo_amostra/unigold_colhar_amostra-label')" />
+									</trigger>
+								</group>
+								<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_2/unigold_aplicando_amostra">
+									<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/unigold_aplicando_amostra-label')" />
+									<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_2/unigold_aplicando_amostra/unigold_aplicar_amostra" appearance="minimal">
+										<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/unigold_aplicando_amostra/unigold_aplicar_amostra-label')" />
+									</trigger>
+									<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_2/unigold_aplicando_amostra/unigold_sangue_total" appearance="minimal">
+										<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/unigold_aplicando_amostra/unigold_sangue_total-label')" />
+									</trigger>
+								</group>
+								<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_2/obtener_resultados">
+									<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/obtener_resultados-label')" />
+									<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_2/obtener_resultados/tempo_resultados" appearance="minimal">
+										<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/obtener_resultados/tempo_resultados-label')" />
+									</trigger>
+									<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_2/obtener_resultados/registrar_resultados" appearance="minimal">
+										<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/obtener_resultados/registrar_resultados-label')" />
+									</trigger>
+								</group>
+								<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/teste_2/interpretacao_teste" appearance="minimal">
+									<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/interpretacao_teste-label')" />
+								</trigger>
+							</group>
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_teste_rapido_unigold">
+								<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/resultado_teste_rapido_unigold-label')" />
+								<item>
+									<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/resultado_teste_rapido_unigold-postivo-label')" />
+									<value>reativo</value>
+								</item>
+								<item>
+									<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/resultado_teste_rapido_unigold-negativo-label')" />
+									<value>nao_reativo</value>
+								</item>
+							</select1>
+							<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_final" appearance="field-list">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_final-label')" />
+								<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_final/display_resultado_do_teste_rapido" appearance="minimal">
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_final/display_resultado_do_teste_rapido-label')" />
+								</trigger>
+								<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_final/resultado_indeterminado_repetir" appearance="minimal">
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos/resultado_final/resultado_indeterminado_repetir-label')" />
+								</trigger>
+							</group>
+						</group>
+						<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2-label')" />
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/ver_os_pasos_test1">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/ver_os_pasos_test1-label')" />
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/ver_os_pasos_test1-sim-label')" />
+									<value>sim</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/ver_os_pasos_test1-nao-label')" />
+									<value>nao</value>
+								</item>
+							</select1>
+							<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_1">
+								<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1-label')" />
+								<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_1/preparacao">
+									<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/preparacao-label')" />
+									<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_1/preparacao/reunir_itens" appearance="minimal">
+										<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/preparacao/reunir_itens-label')" />
+									</trigger>
+									<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_1/preparacao/tira_teste" appearance="minimal">
+										<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/preparacao/tira_teste-label')" />
+									</trigger>
+									<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_1/preparacao/rotule_cartao" appearance="minimal">
+										<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/preparacao/rotule_cartao-label')" />
+									</trigger>
+									<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_1/preparacao/remover_cobertura" appearance="minimal">
+										<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/preparacao/remover_cobertura-label')" />
+									</trigger>
+								</group>
+								<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_1/colhendo_amostra">
+									<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/colhendo_amostra-label')" />
+									<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_1/colhendo_amostra/colhar_amostra" appearance="minimal">
+										<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/colhendo_amostra/colhar_amostra-label')" />
+									</trigger>
+								</group>
+								<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_1/aplicando_amostra">
+									<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/aplicando_amostra-label')" />
+									<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_1/aplicando_amostra/aplicar_amostra" appearance="minimal">
+										<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/aplicando_amostra/aplicar_amostra-label')" />
+									</trigger>
+									<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_1/aplicando_amostra/sangue_total" appearance="minimal">
+										<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/aplicando_amostra/sangue_total-label')" />
+									</trigger>
+								</group>
+								<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_1/obtener_resultados">
+									<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/obtener_resultados-label')" />
+									<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_1/obtener_resultados/tempo_resultados" appearance="minimal">
+										<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/obtener_resultados/tempo_resultados-label')" />
+									</trigger>
+									<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_1/obtener_resultados/registrar_resultados" appearance="minimal">
+										<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/obtener_resultados/registrar_resultados-label')" />
+									</trigger>
+								</group>
+								<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_1/interpretacao_teste" appearance="minimal">
+									<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_1/interpretacao_teste-label')" />
+								</trigger>
+							</group>
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_teste_rapido_determine">
+								<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/resultado_teste_rapido_determine-label')" />
+								<item>
+									<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/resultado_teste_rapido_determine-positivo-label')" />
+									<value>reativo</value>
+								</item>
+								<item>
+									<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/resultado_teste_rapido_determine-negativo-label')" />
+									<value>nao_reativo</value>
+								</item>
+							</select1>
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/Quer_ver_os_pasos">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/Quer_ver_os_pasos-label')" />
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/Quer_ver_os_pasos-sim-label')" />
+									<value>sim</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/Quer_ver_os_pasos-nao-label')" />
+									<value>nao</value>
+								</item>
+							</select1>
+							<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_2">
+								<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2-label')" />
+								<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_2/unigold_preparacao">
+									<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/unigold_preparacao-label')" />
+									<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_2/unigold_preparacao/unigold_reunir_itens" appearance="minimal">
+										<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/unigold_preparacao/unigold_reunir_itens-label')" />
+									</trigger>
+								</group>
+								<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_2/unigold_dispositivo_embalagem" appearance="minimal">
+									<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/unigold_preparacao/unigold_dispositivo_embalagem-label')" />
+								</trigger>
+								<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_2/unigold_colhendo_amostra">
+									<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/unigold_colhendo_amostra-label')" />
+									<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_2/unigold_colhendo_amostra/unigold_colhar_amostra" appearance="minimal">
+										<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/unigold_colhendo_amostra/unigold_colhar_amostra-label')" />
+									</trigger>
+								</group>
+								<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_2/unigold_aplicando_amostra">
+									<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/unigold_aplicando_amostra-label')" />
+									<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_2/unigold_aplicando_amostra/unigold_aplicar_amostra" appearance="minimal">
+										<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/unigold_aplicando_amostra/unigold_aplicar_amostra-label')" />
+									</trigger>
+									<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_2/unigold_aplicando_amostra/unigold_sangue_total" appearance="minimal">
+										<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/unigold_aplicando_amostra/unigold_sangue_total-label')" />
+									</trigger>
+								</group>
+								<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_2/obtener_resultados">
+									<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/obtener_resultados-label')" />
+									<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_2/obtener_resultados/tempo_resultados" appearance="minimal">
+										<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/obtener_resultados/tempo_resultados-label')" />
+									</trigger>
+									<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_2/obtener_resultados/registrar_resultados" appearance="minimal">
+										<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/obtener_resultados/registrar_resultados-label')" />
+									</trigger>
+								</group>
+								<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/teste_2/interpretacao_teste" appearance="minimal">
+									<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/teste_2/interpretacao_teste-label')" />
+								</trigger>
+							</group>
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_teste_rapido_unigold">
+								<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/resultado_teste_rapido_unigold-label')" />
+								<item>
+									<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/resultado_teste_rapido_unigold-postivo-label')" />
+									<value>reativo</value>
+								</item>
+								<item>
+									<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/resultado_teste_rapido_unigold-negativo-label')" />
+									<value>nao_reativo</value>
+								</item>
+							</select1>
+							<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_final" appearance="field-list">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_final-label')" />
+								<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_final/display_resultado_do_teste_rapido" appearance="minimal">
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_final/display_resultado_do_teste_rapido-label')" />
+								</trigger>
+								<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/testagem_hiv_pasos2/resultado_final/indeterminado_segunda" appearance="minimal">
+									<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/question7-label')" />
+								</trigger>
+							</group>
+						</group>
+						<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/couseling">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/couseling-label')" />
+							<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/couseling/aconselhamento_pos" appearance="minimal">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/couseling/aconselhamento_pos-label')" />
+							</trigger>
+						</group>
+						<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used-label')" />
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_determine">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_determine-label')" />
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_determine-corecto-label')" />
+									<value>corecto</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_determine-nao_corecto-label')" />
+									<value>nao_corecto</value>
+								</item>
+							</select1>
+							<input  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_determine_coregir">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_determine_coregir-label')" />
+								<alert ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_determine_coregir-constraintMsg')" />
+							</input>
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_unigold">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_unigold-label')" />
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_unigold-corecto-label')" />
+									<value>corecto</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_unigold-nao_corecto-label')" />
+									<value>nao_corecto</value>
+								</item>
+							</select1>
+							<input  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_unigold_coregir">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_unigold_coregir-label')" />
+								<alert ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/tests_used/numero_testes_unigold_coregir-constraintMsg')" />
+							</input>
+						</group>
+						<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/referencia">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/referencia-label')" />
+							<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/referencia/resultado_negativo_referral" appearance="minimal">
+								<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/resultado_negativo_referral-label')" />
+							</trigger>
+							<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/referencia/referir_adulto" appearance="minimal">
+								<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/copy-1-of-resultado_positivo_referral_teste_vih-label')" />
+							</trigger>
+							<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/referencia/referir_crianca" appearance="minimal">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/referencia/referir_crianca-label')" />
+							</trigger>
+							<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/referencia/referir_mae_crianca" appearance="minimal">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/referencia/referir_mae_crianca-label')" />
+							</trigger>
+							<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/referencia/pos_seguimento" appearance="minimal">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/referencia/pos_seguimento-label')" />
+							</trigger>
+							<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/referencia/neg_crianca_testado" appearance="minimal">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/referencia/neg_crianca_testado-label')" />
+							</trigger>
+						</group>
+						<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership-label')" />
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/chw_testagem">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/chw_testagem-label')" />
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/chw_testagem-sim-label')" />
+									<value>sim</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/chw_testagem-nao-label')" />
+									<value>nao</value>
+								</item>
+							</select1>
+							<input  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/activista_fez_testagem_hiv">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/activista_fez_testagem_hiv-label')" />
+							</input>
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/tem_numero_de_telefone">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/tem_numero_de_telefone-label')" />
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/tem_numero_de_telefone-sim-label')" />
+									<value>sim</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/tem_numero_de_telefone-nao-label')" />
+									<value>nao</value>
+								</item>
+							</select1>
+							<input  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/telefone" appearance="numeric">
+								<label ref="jr:itext('telefone-label')" />
+								<alert ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/testagem_HIV/test_ownership/telefone-constraintMsg')" />
+							</input>
+						</group>
+					</group>
+					<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb">
+						<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb-label')" />
+						<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/rastreio_tb_display" appearance="minimal">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/rastreio_tb_display-label')" />
+						</trigger>
+						<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/antes_de_comenar_o_rastreio_lembre-se_d_en" appearance="minimal">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/antes_de_comenar_o_rastreio_lembre-se_d_en-label')" />
+						</trigger>
+						<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/ja_em_tratamento">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/ja_em_tratamento-label')" />
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/ja_em_tratamento-sim-label')" />
+								<value>sim</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/ja_em_tratamento-nao-label')" />
+								<value>nao</value>
+							</item>
+						</select1>
+						<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/verificar_adesao" appearance="minimal">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/verificar_adesao-label')" />
+						</trigger>
+						<input  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/nit">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/nit-label')" />
+							<alert ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/nit-constraintMsg')" />
+						</input>
+						<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/contacto_ultimo_ano">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/contacto_ultimo_ano-label')" />
+							<alert ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/contacto_ultimo_ano-constraintMsg')" />
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/contacto_ultimo_ano-sim-label')" />
+								<value>sim</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/contacto_ultimo_ano-nao-label')" />
+								<value>nao</value>
+							</item>
+						</select1>
+						<select  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15-label')" />
+							<alert ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15-constraintMsg')" />
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15-nenhum-label')" />
+								<value>nenhum</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15-tem_tosse-label')" />
+								<value>tem_tosse</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15-febre_2_semanas-label')" />
+								<value>febre_2_semanas</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15-perda_de_peso-label')" />
+								<value>perda_de_peso</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15-Tem_falta_de_vontade_de_brincar-label')" />
+								<value>Tem_falta_de_vontade_de_brincar</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15-Tem_caroço_no_pescoço_que_não_doi-label')" />
+								<value>Tem_caroço_no_pescoço_que_não_doi</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15-nao_responde_aos_suplementos-label')" />
+								<value>nao_responde_aos_suplementos</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_menos_15-pneumonia_neonatal-label')" />
+								<value>pneumonia_neonatal</value>
+							</item>
+						</select>
+						<select  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-label')" />
+							<alert ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-constraintMsg')" />
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-nenhum-label')" />
+								<value>nenhum</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-tem_tosse-label')" />
+								<value>tem_tosse</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-sangue-label')" />
+								<value>sangue</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-febre_2_semanas-label')" />
+								<value>febre_2_semanas</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-perda_de_peso-label')" />
+								<value>perda_de_peso</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-transpira-label')" />
+								<value>transpira</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-Tem_caroço_no_pescoço_que_não_doi-label')" />
+								<value>Tem_caroço_no_pescoço_que_não_doi</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-cansado-label')" />
+								<value>cansado</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-diarreia-label')" />
+								<value>diarreia</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/sintomas_mas_15-fam_tb-label')" />
+								<value>fam_tb</value>
+							</item>
+						</select>
+						<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details-label')" />
+							<input  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/cough">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/cough-label')" />
+							</input>
+							<input  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/cough_with_blood">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/cough_with_blood-label')" />
+							</input>
+							<input  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/fever">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/fever-label')" />
+							</input>
+							<input  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/lost_weight">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/lost_weight-label')" />
+							</input>
+							<input  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/fatigue">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/fatigue-label')" />
+							</input>
+							<input  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/night_sweating">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/night_sweating-label')" />
+							</input>
+							<input  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/diarrhea">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/symptoms_details/diarrhea-label')" />
+							</input>
+						</group>
+						<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_screening_result" appearance="field-list">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_screening_result-label')" />
+							<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_screening_result/referido_rastreio_tb" appearance="minimal">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_screening_result/referido_rastreio_tb-label')" />
+							</trigger>
+							<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_screening_result/lbl_refer_exposed_child_tb" appearance="minimal">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_screening_result/lbl_refer_exposed_child_tb-label')" />
+							</trigger>
+							<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_screening_result/hiv_exposed" appearance="minimal">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_screening_result/hiv_exposed-label')" />
+							</trigger>
+							<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_screening_result/lbl_tb_symptoms" appearance="minimal">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_screening_result/lbl_tb_symptoms-label')" />
+							</trigger>
+						</group>
+						<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/referido_rastreio_tb" appearance="field-list">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/referido_rastreio_tb-label')" />
+							<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/referido_rastreio_tb/instruccoes_frascos" appearance="minimal">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/referido_rastreio_tb/instruccoes_frascos-label')" />
+							</trigger>
+							<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/referido_rastreio_tb/instruccoes">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/referido_rastreio_tb/instruccoes-label')" />
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/referido_rastreio_tb/instruccoes-sim-label')" />
+									<value>sim</value>
+								</item>
+								<item>
+									<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/referido_rastreio_tb/instruccoes-nao-label')" />
+									<value>nao</value>
+								</item>
+							</select1>
+						</group>
+						<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/escarro">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/escarro-label')" />
+							<trigger  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/escarro/question9" appearance="minimal">
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/escarro/question9-label')" />
+							</trigger>
+						</group>
+						<select1  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/patient_received_container">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/patient_received_container-label')" />
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/patient_received_container-yes-label')" />
+								<value>yes</value>
+							</item>
+							<item>
+								<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/patient_received_container-no-label')" />
+								<value>no</value>
+							</item>
+						</select1>
+						<input  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/not_received_container">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/not_received_container-label')" />
+						</input>
+						<group  ref="/data/consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties">
+							<label ref="jr:itext('consentimento_sim/registro_de_conviventes/teste_consentido/rastreio_tb/tb_properties-label')" />
+						</group>
+					</group>
+				</group>
+			</group>
+		</group>
+		<group  ref="/data/referrals">
+			<label ref="jr:itext('referrals-label')" />
+			<group  ref="/data/referrals/required_referrals">
+				<label ref="jr:itext('referrals/required_referrals-label')" />
+				<group  ref="/data/referrals/required_referrals/list_required_referrals" appearance="field-list">
+					<label ref="jr:itext('referrals/required_referrals/list_required_referrals-label')" />
+					<trigger  ref="/data/referrals/required_referrals/list_required_referrals/referir_paciente" appearance="minimal">
+						<label ref="jr:itext('referrals/required_referrals/list_required_referrals/referir_paciente-label')" />
+					</trigger>
+					<trigger  ref="/data/referrals/required_referrals/list_required_referrals/lbl_hiv_indeterminate" appearance="minimal">
+						<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18_2/question7-label')" />
+					</trigger>
+					<trigger  ref="/data/referrals/required_referrals/list_required_referrals/lbl_new_pregnancy" appearance="minimal">
+						<label ref="jr:itext('referrals/required_referrals/list_required_referrals/lbl_new_pregnancy-label')" />
+					</trigger>
+					<trigger  ref="/data/referrals/required_referrals/list_required_referrals/lbl_new_breastfeeding" appearance="minimal">
+						<label ref="jr:itext('referrals/required_referrals/list_required_referrals/lbl_new_breastfeeding-label')" />
+					</trigger>
+					<trigger  ref="/data/referrals/required_referrals/list_required_referrals/lbl_tb_hiv_positive" appearance="minimal">
+						<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/copy-1-of-resultado_positivo_referral_teste_vih-label')" />
+					</trigger>
+					<trigger  ref="/data/referrals/required_referrals/list_required_referrals/lbl_refer_for_ccr" appearance="minimal">
+						<label ref="jr:itext('referrals/required_referrals/list_required_referrals/lbl_refer_for_ccr-label')" />
+					</trigger>
+					<trigger  ref="/data/referrals/required_referrals/list_required_referrals/lbl_refer_child_pos_tb_screening" appearance="minimal">
+						<label ref="jr:itext('referrals/required_referrals/list_required_referrals/lbl_refer_child_pos_tb_screening-label')" />
+					</trigger>
+					<trigger  ref="/data/referrals/required_referrals/list_required_referrals/pacinete_para_testar_na_unidade_sanitria" appearance="minimal">
+						<label ref="jr:itext('referrals/required_referrals/list_required_referrals/pacinete_para_testar_na_unidade_sanitria-label')" />
+					</trigger>
+					<trigger  ref="/data/referrals/required_referrals/list_required_referrals/lbl_iniciar_tarv" appearance="minimal">
+						<label ref="jr:itext('referrals/required_referrals/list_required_referrals/lbl_iniciar_tarv-label')" />
+					</trigger>
+					<trigger  ref="/data/referrals/required_referrals/list_required_referrals/resultado_negativo_referral" appearance="minimal">
+						<label ref="jr:itext('registro_de_conviventes/testagem_HIV/copy-1-of-hiv_mostrar_apenas_mais_18-1/resultado_negativo_referral-label')" />
+					</trigger>
+					<trigger  ref="/data/referrals/required_referrals/list_required_referrals/pos_seguimento" appearance="minimal">
+						<label ref="jr:itext('referrals/required_referrals/list_required_referrals/pos_seguimento-label')" />
+					</trigger>
+					<trigger  ref="/data/referrals/required_referrals/list_required_referrals/neg_crianca_testado" appearance="minimal">
+						<label ref="jr:itext('referrals/required_referrals/list_required_referrals/neg_crianca_testado-label')" />
+					</trigger>
+					<trigger  ref="/data/referrals/required_referrals/list_required_referrals/lbl_tb_positive" appearance="minimal">
+						<label ref="jr:itext('referrals/required_referrals/list_required_referrals/lbl_tb_positive-label')" />
+					</trigger>
+					<trigger  ref="/data/referrals/required_referrals/list_required_referrals/lbl_refer_hiv_for_tpi" appearance="minimal">
+						<label ref="jr:itext('referrals/required_referrals/list_required_referrals/lbl_refer_hiv_for_tpi-label')" />
+					</trigger>
+					<trigger  ref="/data/referrals/required_referrals/list_required_referrals/lbl_refer_exposed_child_tb" appearance="minimal">
+						<label ref="jr:itext('referrals/required_referrals/list_required_referrals/lbl_refer_exposed_child_tb-label')" />
+					</trigger>
+					<trigger  ref="/data/referrals/required_referrals/list_required_referrals/hiv_exposed" appearance="minimal">
+						<label ref="jr:itext('referrals/required_referrals/list_required_referrals/hiv_exposed-label')" />
+					</trigger>
+					<trigger  ref="/data/referrals/required_referrals/list_required_referrals/lbl_tb_symptoms" appearance="minimal">
+						<label ref="jr:itext('referrals/required_referrals/list_required_referrals/lbl_tb_symptoms-label')" />
+					</trigger>
+				</group>
+				<select1  ref="/data/referrals/required_referrals/fez_referencia">
+					<label ref="jr:itext('referrals/required_referrals/fez_referencia-label')" />
+					<item>
+						<label ref="jr:itext('referrals/required_referrals/fez_referencia-sim-label')" />
+						<value>sim</value>
+					</item>
+					<item>
+						<label ref="jr:itext('referrals/required_referrals/fez_referencia-nao-label')" />
+						<value>nao</value>
+					</item>
+				</select1>
+				<select1  ref="/data/referrals/required_referrals/does_patients_name_accepts_to_receive_care_at_chw_hf_name">
+					<label ref="jr:itext('referrals/required_referrals/does_patients_name_accepts_to_receive_care_at_chw_hf_name-label')" />
+					<item>
+						<label ref="jr:itext('referrals/required_referrals/does_patients_name_accepts_to_receive_care_at_chw_hf_name-1-label')" />
+						<value>1</value>
+					</item>
+					<item>
+						<label ref="jr:itext('referrals/required_referrals/does_patients_name_accepts_to_receive_care_at_chw_hf_name-0-label')" />
+						<value>0</value>
+					</item>
+				</select1>
+				<group  ref="/data/referrals/required_referrals/preferred_health_facility_grp">
+					<label ref="jr:itext('referrals/required_referrals/preferred_health_facility_grp-label')" />
+					<select1  ref="/data/referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province" appearance="combobox fuzzy">
+						<label ref="jr:itext('referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-label')" />
+						<item>
+							<label ref="jr:itext('referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-maputo_cidade-label')" />
+							<value>maputo_cidade</value>
+						</item>
+						<item>
+							<label ref="jr:itext('referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-maputo_provincia-label')" />
+							<value>maputo_provincia</value>
+						</item>
+						<item>
+							<label ref="jr:itext('referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-gaza-label')" />
+							<value>gaza</value>
+						</item>
+						<item>
+							<label ref="jr:itext('referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-inhambane-label')" />
+							<value>inhambane</value>
+						</item>
+						<item>
+							<label ref="jr:itext('referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-niassa-label')" />
+							<value>niassa</value>
+						</item>
+						<item>
+							<label ref="jr:itext('referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-manica-label')" />
+							<value>manica</value>
+						</item>
+						<item>
+							<label ref="jr:itext('referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-sofala-label')" />
+							<value>sofala</value>
+						</item>
+						<item>
+							<label ref="jr:itext('referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-zambezia-label')" />
+							<value>zambezia</value>
+						</item>
+						<item>
+							<label ref="jr:itext('referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-nampula-label')" />
+							<value>nampula</value>
+						</item>
+						<item>
+							<label ref="jr:itext('referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province-cabo_delgado-label')" />
+							<value>cabo_delgado</value>
+						</item>
+					</select1>
+					<select1  ref="/data/referrals/required_referrals/preferred_health_facility_grp/hf_health_facility">
+						<label ref="jr:itext('referrals/required_referrals/preferred_health_facility_grp/hf_health_facility-label')" />
+						<itemset nodeset="instance('health_facility')/health_facility_list/health_facility[/data/referrals/required_referrals/preferred_health_facility_grp/hf_to_refer_province = province]" >
+							<label ref="name" />
+							<value ref="code" />
+						</itemset>
+					</select1>
+					<trigger  ref="/data/referrals/required_referrals/preferred_health_facility_grp/lbl_transfer_to_current_chw_partner" appearance="minimal">
+						<label ref="jr:itext('referrals/required_referrals/preferred_health_facility_grp/lbl_transfer_to_current_chw_partner-label')" />
+					</trigger>
+					<select1  ref="/data/referrals/required_referrals/preferred_health_facility_grp/select_partner">
+						<label ref="jr:itext('referrals/required_referrals/preferred_health_facility_grp/select_partner-label')" />
+						<itemset nodeset="instance('locations')/locations/location[@type = 'partner'][contains(/data/referrals/required_referrals/preferred_health_facility_grp/hf_selected_partner_ids, @id)]" >
+							<label ref="name" />
+							<value ref="@id" />
+						</itemset>
+					</select1>
+					<trigger  ref="/data/referrals/required_referrals/preferred_health_facility_grp/lbl_no_partner_in_hf" appearance="minimal">
+						<label ref="jr:itext('referrals/required_referrals/preferred_health_facility_grp/lbl_no_partner_in_hf-label')" />
+					</trigger>
+				</group>
+				<select1  ref="/data/referrals/required_referrals/consentimento_busca_activa">
+					<label ref="jr:itext('referrals/required_referrals/consentimento_busca_activa-label')" />
+					<item>
+						<label ref="jr:itext('referrals/required_referrals/consentimento_busca_activa-sim-label')" />
+						<value>sim</value>
+					</item>
+					<item>
+						<label ref="jr:itext('referrals/required_referrals/consentimento_busca_activa-nao-label')" />
+						<value>nao</value>
+					</item>
+				</select1>
+				<trigger  ref="/data/referrals/required_referrals/intentar_convencer" appearance="minimal">
+					<label ref="jr:itext('referrals/required_referrals/intentar_convencer-label')" />
+				</trigger>
+				<group  ref="/data/referrals/required_referrals/test">
+					<label ref="jr:itext('referrals/required_referrals/test-label')" />
+					<input  ref="/data/referrals/required_referrals/test/test_data_de_referencia">
+						<label ref="jr:itext('referrals/required_referrals/test/test_data_de_referencia-label')" />
+					</input>
+					<input  ref="/data/referrals/required_referrals/test/test_data_proxima_visita">
+						<label ref="jr:itext('referrals/required_referrals/test/test_data_proxima_visita-label')" />
+					</input>
+				</group>
+			</group>
+			<group  ref="/data/referrals/no_referrals">
+				<label ref="jr:itext('referrals/no_referrals-label')" />
+				<select  ref="/data/referrals/no_referrals/outras_referencias">
+					<label ref="jr:itext('referrals/no_referrals/outras_referencias-label')" />
+					<item>
+						<label ref="jr:itext('referrals/no_referrals/outras_referencias-nunhum-label')" />
+						<value>nunhum</value>
+					</item>
+					<item>
+						<label ref="jr:itext('referrals/no_referrals/outras_referencias-hipertensao-label')" />
+						<value>hipertensao</value>
+					</item>
+					<item>
+						<label ref="jr:itext('referrals/no_referrals/outras_referencias-infeccao_de_transmission_sexual-label')" />
+						<value>infeccao_de_transmission_sexual</value>
+					</item>
+					<item>
+						<label ref="jr:itext('referrals/no_referrals/outras_referencias-consulta_pre_natal-label')" />
+						<value>consulta_pre_natal</value>
+					</item>
+					<item>
+						<label ref="jr:itext('referrals/no_referrals/outras_referencias-malaria-label')" />
+						<value>malaria</value>
+					</item>
+					<item>
+						<label ref="jr:itext('referrals/no_referrals/outras_referencias-epilepsia-label')" />
+						<value>epilepsia</value>
+					</item>
+					<item>
+						<label ref="jr:itext('referrals/no_referrals/outras_referencias-doencas_de_pele-label')" />
+						<value>doencas_de_pele</value>
+					</item>
+					<item>
+						<label ref="jr:itext('referrals/no_referrals/outras_referencias-diarreia-label')" />
+						<value>diarreia</value>
+					</item>
+					<item>
+						<label ref="jr:itext('referrals/no_referrals/outras_referencias-circuncisao_masculina-label')" />
+						<value>circuncisao_masculina</value>
+					</item>
+					<item>
+						<label ref="jr:itext('referrals/no_referrals/outras_referencias-ptv-label')" />
+						<value>ptv</value>
+					</item>
+					<item>
+						<label ref="jr:itext('referrals/no_referrals/outras_referencias-violenca_sexual-label')" />
+						<value>violenca_sexual</value>
+					</item>
+					<item>
+						<label ref="jr:itext('referrals/no_referrals/outras_referencias-violencia-label')" />
+						<value>violencia</value>
+					</item>
+					<item>
+						<label ref="jr:itext('referrals/no_referrals/outras_referencias-grupo_de_apoio-label')" />
+						<value>grupo_de_apoio</value>
+					</item>
+					<item>
+						<label ref="jr:itext('referrals/no_referrals/outras_referencias-despite_cancro_uterino-label')" />
+						<value>despite_cancro_uterino</value>
+					</item>
+					<item>
+						<label ref="jr:itext('referrals/no_referrals/outras_referencias-despiste_cancro_de_prostata-label')" />
+						<value>despiste_cancro_de_prostata</value>
+					</item>
+					<item>
+						<label ref="jr:itext('referrals/no_referrals/outras_referencias-outra-label')" />
+						<value>outra</value>
+					</item>
+				</select>
+				<input  ref="/data/referrals/no_referrals/outra_doenca">
+					<label ref="jr:itext('referrals/no_referrals/outra_doenca-label')" />
+				</input>
+			</group>
+		</group>
+		<select1  ref="/data/contacts_registration_concent">
+			<label ref="jr:itext('contacts_registration_concent-label')" />
+			<item>
+				<label ref="jr:itext('contacts_registration_concent-yes-label')" />
+				<value>yes</value>
+			</item>
+			<item>
+				<label ref="jr:itext('contacts_registration_concent-no-label')" />
+				<value>no</value>
+			</item>
+		</select1>
+		<select1  ref="/data/register_conviventes_during_visit">
+			<label ref="jr:itext('register_conviventes_during_visit-label')" />
+			<item>
+				<label ref="jr:itext('register_conviventes_during_visit-sim-label')" />
+				<value>sim</value>
+			</item>
+			<item>
+				<label ref="jr:itext('register_conviventes_during_visit-nao-label')" />
+				<value>nao</value>
+			</item>
+		</select1>
+		<group  ref="/data/hh_reg" appearance="field-list">
+			<label ref="jr:itext('hh_reg-label')" />
+			<select1  ref="/data/hh_reg/mais_conviventes">
+				<label ref="jr:itext('hh_reg/mais_conviventes-label')" />
+				<item>
+					<label ref="jr:itext('hh_reg/mais_conviventes-sim-label')" />
+					<value>sim</value>
+				</item>
+				<item>
+					<label ref="jr:itext('hh_reg/mais_conviventes-nao-label')" />
+					<value>nao</value>
+				</item>
+			</select1>
+			<select1  ref="/data/hh_reg/confirmar_registo_conviventes_completo">
+				<label ref="jr:itext('hh_reg/confirmar_registo_conviventes_completo-label')" />
+				<item>
+					<label ref="jr:itext('hh_reg/confirmar_registo_conviventes_completo-ok-label')" />
+					<value>ok</value>
+				</item>
+			</select1>
+		</group>
+		<trigger  ref="/data/display_new_convivente" appearance="minimal">
+			<label ref="jr:itext('display_new_convivente-label')" />
+		</trigger>
+		<group  ref="/data/data">
+			<label ref="jr:itext('data-label')" />
+			<group  ref="/data/data/referencia">
+				<label ref="jr:itext('data/referencia-label')" />
+			</group>
+			<group  ref="/data/data/geral">
+				<label ref="jr:itext('data/geral-label')" />
+			</group>
+			<group  ref="/data/data/busca_activa">
+				<label ref="jr:itext('data/busca_activa-label')" />
+			</group>
+		</group>
+		<group  ref="/data/casa">
+			<label ref="jr:itext('casa-label')" />
+			<group  ref="/data/casa/conviventes">
+				<label ref="jr:itext('casa/conviventes-label')" />
+			</group>
+			<group  ref="/data/casa/testagem">
+				<label ref="jr:itext('casa/testagem-label')" />
+			</group>
+			<group  ref="/data/casa/index">
+				<label ref="jr:itext('casa/index-label')" />
+			</group>
+		</group>
+		<group  ref="/data/indicators_v4">
+			<label ref="jr:itext('indicators_v4-label')" />
+		</group>
+		<group  ref="/data/calendario">
+			<label ref="jr:itext('calendario-label')" />
+		</group>
+		<group  ref="/data/convivente_cascade" />
+	</h:body>
+</h:html>


### PR DESCRIPTION
Ticket Reference:
https://dimagi-dev.atlassian.net/browse/HI-572

Will implemented an algorithm to find the shortest cycle in dependency evaluation, but the directional of the graph was implemented backwards

IE: For a calculation
velocity = distance / time

it would create the dependency edge set
distance -> velocity
time -> velocity

rather than
velocity -> time
velocity -> distance

which was making the algorithm mistakenly miss the cycle and error out.

Also ensured that cyclical references are reported specifically as a parse error, which was not unified on the current reporting path. We can end up detecting them in two places.