### PR TITLE
Adds back removal of all upgrade table entries when clearing upgrade on failures

### DIFF
--- a/src/main/java/org/commcare/resources/model/ResourceTable.java
+++ b/src/main/java/org/commcare/resources/model/ResourceTable.java
@@ -872,14 +872,13 @@ public class ResourceTable {
     // Clears all resources in the table
     public void clearAll(CommCarePlatform platform) {
         clearByStatus(platform, RESOURCE_STATUS_ALL_RESOURCES);
-        storage.removeAll();
     }
 
     /**
      * Clears any resources with a given resource status and also try very hard to remove any files installed
      * by it. This is important for rolling back botched upgrades without leaving their files around.
      *
-     * @param platform CommCare platform
+     * @param platform       CommCare platform
      * @param resourceStatus Only resources with this status will get cleared
      */
     private void clearByStatus(CommCarePlatform platform, int resourceStatus) {
@@ -900,6 +899,8 @@ public class ResourceTable {
         if (count > 0) {
             Logger.log(LogTypes.TYPE_RESOURCES, "Cleaned up " + count + " records from table");
         }
+
+        storage.removeAll();
     }
 
     protected void cleanup() {

--- a/src/main/java/org/commcare/resources/model/ResourceTable.java
+++ b/src/main/java/org/commcare/resources/model/ResourceTable.java
@@ -864,24 +864,26 @@ public class ResourceTable {
     }
 
 
-    // Clears resources with status RESOURCE_STATUS_UPGRADE in the table
+    // Uninstalls resources with status RESOURCE_STATUS_UPGRADE in the table and wipe the complete table
     public void clearUpgrade(CommCarePlatform platform) {
-        clearByStatus(platform, Resource.RESOURCE_STATUS_UPGRADE);
+        uninstallResourcesForStatus(platform, Resource.RESOURCE_STATUS_UPGRADE);
+        storage.removeAll();
     }
 
-    // Clears all resources in the table
+    // Clears all resources in the table and wipe the complete table
     public void clearAll(CommCarePlatform platform) {
-        clearByStatus(platform, RESOURCE_STATUS_ALL_RESOURCES);
+        uninstallResourcesForStatus(platform, RESOURCE_STATUS_ALL_RESOURCES);
+        storage.removeAll();
     }
 
     /**
-     * Clears any resources with a given resource status and also try very hard to remove any files installed
+     * Uninstalls any resources with a given resource status and also try very hard to remove any files installed
      * by it. This is important for rolling back botched upgrades without leaving their files around.
      *
      * @param platform       CommCare platform
      * @param resourceStatus Only resources with this status will get cleared
      */
-    private void clearByStatus(CommCarePlatform platform, int resourceStatus) {
+    private void uninstallResourcesForStatus(CommCarePlatform platform, int resourceStatus) {
         cleanup();
         Stack<Resource> s = this.getResourceStack();
         int count = 0;
@@ -897,10 +899,8 @@ public class ResourceTable {
             }
         }
         if (count > 0) {
-            Logger.log(LogTypes.TYPE_RESOURCES, "Cleaned up " + count + " records from table");
+            Logger.log(LogTypes.TYPE_RESOURCES, "Uninstalled " + count + " records from table");
         }
-
-        storage.removeAll();
     }
 
     protected void cleanup() {


### PR DESCRIPTION
This was introduced in the [Recovery Measures PR](https://github.com/dimagi/commcare-core/pull/803). Before this PR, we had a `ResourceTable.clear` function which we were using to clear the upgrade table on failures or when an update gets staled. The Recovery measure PR refactored this `clear` to  be called `clearUpgrade` and utilize internal method `clearByStatus`. During this refactoring I mistakenly dropped `storage.removeAll` from the code path which will today result in update table not getting cleared by this function. 

This happened because of me getting confused by [the git diff](https://github.com/dimagi/commcare-core/pull/803/commits/892d642425519e31ee18f671078d05f7ec4df95c) which made it seem like my commit added the `storage.removeAll` statement when it was already there leading me to believe that I added that statement by mistake and hence removing it in a later commit in that PR. 

Also this bug has now been there in both 2.45 and 2.46 and I can't really comprehend any visible repercussions of this issue. We call `clear` after update failures or as a result of staged update getting stale. Though we also have another method `ResourceTable.destroy` that does clears the udpate table today and gets [called when an stages update has gone stale](https://github.com/dimagi/commcare-android/blob/master/app/src/org/commcare/engine/resource/AndroidResourceManager.java#L111) and also [when we have a new update available on top of the staged update](https://github.com/dimagi/commcare-android/blob/master/app/src/org/commcare/engine/resource/AndroidResourceManager.java#L141).  

I think we will need to make this fix available in next LTS release we do since LTS currenly also doesn't have this bug and risks are substantially higher with ICDS. Though I am not really sure if we should do a hotfix for it on 2.46 and wondering if you have any thoughts on that. 






