### PR TITLE
Skips case deletion in case the case has already been deleted

### DIFF
--- a/src/main/java/org/commcare/cases/util/CasePurgeFilter.java
+++ b/src/main/java/org/commcare/cases/util/CasePurgeFilter.java
@@ -111,10 +111,10 @@ public class CasePurgeFilter extends EntityFilter<Case> {
      *
      * The Index of each node is its case id guid
      * The Node element for the guide consists of an integer array [STATUS_FLAGS, storageid]
-     *         storageid is the id of the row of the case in the provided storage
-     *         STATUS_FLAGS is a bitmasked integer. It should be initialized with any of STATUS_OWNED,
-     *              STATUS_OPEN, and/or STATUS_RELEVANT as applies to the node (A node starts as relevant
-     *              if it is OWNED and it is OPEN)
+     * storageid is the id of the row of the case in the provided storage
+     * STATUS_FLAGS is a bitmasked integer. It should be initialized with any of STATUS_OWNED,
+     * STATUS_OPEN, and/or STATUS_RELEVANT as applies to the node (A node starts as relevant
+     * if it is OWNED and it is OPEN)
      *
      * The Edge string is the 'type' of index from the originating case to the target case(ie: parent, or extension)
      */
@@ -242,8 +242,8 @@ public class CasePurgeFilter extends EntityFilter<Case> {
      *                             meets this criteria.
      */
     private static void propagateMarkToDAG(DAG<String, int[], String> dag, boolean walkFromSourceToSink,
-                                    int maskCondition, int markToApply, String relationship,
-                                    boolean requireOpenDestination) {
+                                           int maskCondition, int markToApply, String relationship,
+                                           boolean requireOpenDestination) {
         Stack<String> toProcess = walkFromSourceToSink ? dag.getSources() : dag.getSinks();
         while (!toProcess.isEmpty()) {
             // current node
@@ -255,7 +255,7 @@ public class CasePurgeFilter extends EntityFilter<Case> {
 
             for (Edge<String, String> edge : edgeSet) {
                 if (caseStatusIs(node[0], maskCondition) && (relationship == null || edge.e.equals(relationship))) {
-                    if(!requireOpenDestination || caseStatusIs(dag.getNode(edge.i)[0], STATUS_OPEN)) {
+                    if (!requireOpenDestination || caseStatusIs(dag.getNode(edge.i)[0], STATUS_OPEN)) {
                         dag.getNode(edge.i)[0] |= markToApply;
                     }
                 }
@@ -331,9 +331,11 @@ public class CasePurgeFilter extends EntityFilter<Case> {
 
         // Once all edges to/from this node have been removed, delete the node itself from the
         // DAG, and add it to the list of cases to be purged
-        int storageIdOfRemovedNode = internalCaseDAG.removeNode(indexOfRemovedNode)[1];
-        idsToRemove.addElement(new Integer(storageIdOfRemovedNode));
-        casesRemovedDueToMissingCases.addElement(indexOfRemovedNode);
+        if (casesRemovedDueToMissingCases.indexOf(indexOfRemovedNode) == -1) {
+            int storageIdOfRemovedNode = internalCaseDAG.removeNode(indexOfRemovedNode)[1];
+            idsToRemove.addElement(new Integer(storageIdOfRemovedNode));
+            casesRemovedDueToMissingCases.addElement(indexOfRemovedNode);
+        }
     }
 
     // For use in tests


### PR DESCRIPTION
Sentry: https://sentry.io/organizations/dimagi/issues/989338130/?project=142105&referrer=slack
Jira: https://dimagi-dev.atlassian.net/browse/MOB-116

It seems like when purging the cases, if somehow a case appears in the list of to be deleted cases twice, mobile tries to delete that case twice and encounters a Null Pointer exception in the process because of that case being already deleted.

In this particular case mobile is trying to delete the case https://www.commcarehq.org/a/broad-nigeria/reports/case_data/76f90a6d-8c97-4c39-8bf2-713ce2daa272/#related since the parent of this(caseid: 157127a9-9782-4cbe-a5ad-0daf494f4461) has been deleted. Though this case also has an extension case https://www.commcarehq.org/a/broad-nigeria/reports/case_data/8b9da4db-4808-4015-97b7-900b43b44d06/ with the common parent which causes "76f90a6d-8c97-4c39-8bf2-713ce2daa272" to appear twice in the list for to be deleted cases. 

