### PR TITLE
Refactoring for root level atrribute lookup support for Indexed Fixtures

### DIFF
--- a/src/main/java/org/commcare/cases/instance/IndexedFixtureInstanceTreeElement.java
+++ b/src/main/java/org/commcare/cases/instance/IndexedFixtureInstanceTreeElement.java
@@ -19,7 +19,7 @@ import java.util.Hashtable;
  *
  * @author Phillip Mates (pmates@dimagi.com)
  */
-public class IndexedFixtureInstanceTreeElement
+public abstract class IndexedFixtureInstanceTreeElement
         extends StorageInstanceTreeElement<StorageIndexedTreeElementModel, IndexedFixtureChildElement> {
 
     private Hashtable<XPathPathExpr, String> storageIndexMap = null;
@@ -32,19 +32,6 @@ public class IndexedFixtureInstanceTreeElement
         super(instanceRoot, storage, indexedFixtureIdentifier.getFixtureBase(), indexedFixtureIdentifier.getFixtureChild());
         attrHolder = indexedFixtureIdentifier.getRootAttributes();
         cacheKey = indexedFixtureIdentifier.getFixtureBase() + "|" + indexedFixtureIdentifier.getFixtureChild();
-    }
-
-    public static IndexedFixtureInstanceTreeElement get(UserSandbox sandbox,
-                                                        String instanceName,
-                                                        InstanceBase instanceBase) {
-        IndexedFixtureIdentifier indexedFixtureIdentifier = sandbox.getIndexedFixtureIdentifier(instanceName);
-        if (indexedFixtureIdentifier == null) {
-            return null;
-        } else {
-            IStorageUtilityIndexed<StorageIndexedTreeElementModel> storage =
-                    sandbox.getIndexedFixtureStorage(instanceName);
-            return new IndexedFixtureInstanceTreeElement(instanceBase, storage, indexedFixtureIdentifier);
-        }
     }
 
     @Override
@@ -73,8 +60,38 @@ public class IndexedFixtureInstanceTreeElement
         return storageIndexMap;
     }
 
+    @Override
+    public int getAttributeCount() {
+        return loadAttributes().getAttributeCount();
+    }
+
+
+    @Override
+    public String getAttributeNamespace(int index) {
+        return loadAttributes().getAttributeNamespace(index);
+    }
+
+    @Override
+    public String getAttributeName(int index) {
+        return loadAttributes().getAttributeName(index);
+    }
+
+    @Override
+    public String getAttributeValue(int index) {
+        return loadAttributes().getAttributeValue(index);
+    }
+
+    @Override
+    public AbstractTreeElement getAttribute(String namespace, String name) {
+        TreeElement attr = loadAttributes().getAttribute(namespace, name);
+        attr.setParent(this);
+        return attr;
+    }
+
     public String getStorageCacheName() {
         return cacheKey;
     }
+
+    protected abstract TreeElement loadAttributes();
 
 }

--- a/src/main/java/org/commcare/core/process/CommCareInstanceInitializer.java
+++ b/src/main/java/org/commcare/core/process/CommCareInstanceInitializer.java
@@ -109,16 +109,7 @@ public class CommCareInstanceInitializer extends InstanceInitializationFactory {
 
 
     protected AbstractTreeElement setupFixtureData(ExternalDataInstance instance) {
-        AbstractTreeElement indexedFixture = IndexedFixtureInstanceTreeElement.get(
-                mSandbox,
-                getRefId(instance.getReference()),
-                instance.getBase());
-
-        if (indexedFixture != null) {
-            return indexedFixture;
-        } else {
-            return loadFixtureRoot(instance, instance.getReference());
-        }
+        return loadFixtureRoot(instance, instance.getReference());
     }
 
     protected static String getRefId(String reference) {

--- a/src/main/java/org/commcare/modern/database/IndexedFixturePathsConstants.java
+++ b/src/main/java/org/commcare/modern/database/IndexedFixturePathsConstants.java
@@ -29,4 +29,12 @@ public class IndexedFixturePathsConstants {
                     " (" + INDEXED_FIXTURE_PATHS_COL_NAME + " UNIQUE" +
                     ", " + INDEXED_FIXTURE_PATHS_COL_BASE +
                     ", " + INDEXED_FIXTURE_PATHS_COL_CHILD + ");";
+
+    public final static String INDEXED_FIXTURE_PATHS_TABLE_SELECT_STMT =
+            "SELECT " +
+                    IndexedFixturePathsConstants.INDEXED_FIXTURE_PATHS_COL_BASE + ", " +
+                    IndexedFixturePathsConstants.INDEXED_FIXTURE_PATHS_COL_CHILD  + ", " +
+                    IndexedFixturePathsConstants.INDEXED_FIXTURE_PATHS_COL_ATTRIBUTES  +
+                    " FROM " + IndexedFixturePathsConstants.INDEXED_FIXTURE_PATHS_TABLE +
+                    " WHERE " + IndexedFixturePathsConstants.INDEXED_FIXTURE_PATHS_COL_NAME + " = ?;";
 }

--- a/src/main/java/org/commcare/modern/database/TableBuilder.java
+++ b/src/main/java/org/commcare/modern/database/TableBuilder.java
@@ -177,7 +177,7 @@ public class TableBuilder {
 
         stringBuilder.append(");");
 
-        return new Pair<String, List<Object>>(stringBuilder.toString(), params);
+        return new Pair<>(stringBuilder.toString(), params);
     }
 
     public static String scrubName(String input) {


### PR DESCRIPTION
Makes IndexedFixtureInstanceTreeElement abstract and removes the instance initialization logic from here making CommCare clients responsible to handle it. 