### PR TITLE
Fixes bulk case parser to not overwrite same case blocks in a single Form

### DIFF
--- a/src/main/java/org/commcare/xml/bulk/BulkProcessingCaseXmlParser.java
+++ b/src/main/java/org/commcare/xml/bulk/BulkProcessingCaseXmlParser.java
@@ -91,6 +91,7 @@ public abstract class BulkProcessingCaseXmlParser extends BulkElementParser<Case
 
             try {
                 writeLog.put(caseForBlock.getCaseId(), caseForBlock);
+                currentOperatingSet.put(caseForBlock.getCaseId(), caseForBlock);
             } catch (SerializationLimitationException e) {
                 throw new InvalidStructureException("One of the property values for the case named '" +
                         caseForBlock.getName() + "' is too large (by " + e.percentOversized +


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/MOB-120

When there is a form containing the save to case question causing the form to have 2 case blocks, the later case block overwrites the earlier case block from the form.  

Bulk parser currently does do a lookup in `currentOperatingSet` to see if a case already exists but any cases we create during a form parsing doesn't really make it to `currentOperatingSet`. This PR changes that to write any cases we are creating or updating in `currentOperatingSet`. 

This bug is only there for BulkCaseXmlParser and not CaseXmlParser since CaseXmlParser directly looks up the case DB before creating a case. 