### PR TITLE
Adds and Parses buildProfileId for Profile

### DIFF
--- a/src/main/java/org/commcare/suite/model/Profile.java
+++ b/src/main/java/org/commcare/suite/model/Profile.java
@@ -30,7 +30,6 @@ public class Profile implements Persistable {
 
     public static final String STORAGE_KEY = "PROFILE";
     public static final String FEATURE_REVIEW = "checkoff";
-    public static final String FEATURE_USERS = "users";
 
     private int recordId = -1;
     private int version;
@@ -41,6 +40,7 @@ public class Profile implements Persistable {
 
     private String uniqueId;
     private String displayName;
+    private String buildProfileId;
 
     /**
      * Indicates if this was generated from an old version of the profile file, before fields
@@ -66,16 +66,16 @@ public class Profile implements Persistable {
      *                is obsoleted by it.
      */
     public Profile(int version, String authRef, String uniqueId, String displayName,
-                   boolean fromOld) {
+                   boolean fromOld, String buildProfileId) {
         this.version = version;
         this.authRef = authRef;
         this.uniqueId = uniqueId;
         this.displayName = displayName;
+        this.buildProfileId = buildProfileId;
         this.fromOld = fromOld;
         properties = new Vector<>();
         roots = new Vector<>();
         featureStatus = new Hashtable<>();
-
         //turn on default features
         featureStatus.put("users", true);
     }
@@ -106,6 +106,13 @@ public class Profile implements Persistable {
 	public String getDisplayName() {
 	    return this.displayName;
 	}
+
+    /**
+     * @return the buildProfileId for this particular app profile
+     */
+    public String getBuildProfileId() {
+        return buildProfileId;
+    }
 
     /**
      * @return if this object was generated from an old version of the profile.ccpr file
@@ -208,6 +215,7 @@ public class Profile implements Persistable {
         properties = (Vector<PropertySetter>)ExtUtil.read(in, new ExtWrapList(PropertySetter.class), pf);
         roots = (Vector<RootTranslator>)ExtUtil.read(in, new ExtWrapList(RootTranslator.class), pf);
         featureStatus = (Hashtable<String, Boolean>)ExtUtil.read(in, new ExtWrapMap(String.class, Boolean.class), pf);
+        buildProfileId = ExtUtil.readString(in);
     }
 
     @Override
@@ -222,5 +230,6 @@ public class Profile implements Persistable {
         ExtUtil.write(out, new ExtWrapList(properties));
         ExtUtil.write(out, new ExtWrapList(roots));
         ExtUtil.write(out, new ExtWrapMap(featureStatus));
+        ExtUtil.writeString(out, buildProfileId);
     }
 }

--- a/src/main/java/org/commcare/xml/ProfileParser.java
+++ b/src/main/java/org/commcare/xml/ProfileParser.java
@@ -145,6 +145,11 @@ public class ProfileParser extends ElementParser<Profile> {
             displayName = "";
         }
 
+        // defaults to empty string instead of null
+        if(buildProfileId == null){
+            buildProfileId = "";
+        }
+
         return new Profile(version, authRef, uniqueId, displayName, fromOld, buildProfileId);
     }
 

--- a/src/main/java/org/commcare/xml/ProfileParser.java
+++ b/src/main/java/org/commcare/xml/ProfileParser.java
@@ -89,6 +89,7 @@ public class ProfileParser extends ElementParser<Profile> {
         String sMinor = parser.getAttributeValue(null, "requiredMinor");
         String uniqueId = parser.getAttributeValue(null, "uniqueid");
         String displayName = parser.getAttributeValue(null, "name");
+        String buildProfileId = parser.getAttributeValue(null, "buildProfileID");
 
         int major = -1;
         int minor = -1;
@@ -144,7 +145,7 @@ public class ProfileParser extends ElementParser<Profile> {
             displayName = "";
         }
 
-        return new Profile(version, authRef, uniqueId, displayName, fromOld);
+        return new Profile(version, authRef, uniqueId, displayName, fromOld, buildProfileId);
     }
 
     private void parseProperty(Profile profile) {


### PR DESCRIPTION
Parses `buildProfileId` present in `profile` file as  - 

````
<profile version="226"
         update="http://192.168.20.109/a/mkangia-domain/apps/download/e0a3716cec574efdb3055e8391f071f2/media_profile.ccpr?latest=true&amp;profile=1bda6672420745a8837eaf03f6d0532d"
         requiredMajor="2"
         requiredMinor="44"
         uniqueid="2588b449b7eae879341d44f33b015389"
         name="MK-Application"
         descriptor="Profile File"
         buildProfileID="1bda6672420745a8837eaf03f6d0532d">
````

cross-request: https://github.com/dimagi/commcare-android/pull/2291