### PR TITLE
Remove catching all exceptions while localizing text

### DIFF
--- a/src/main/java/org/javarosa/form/api/FormEntryPrompt.java
+++ b/src/main/java/org/javarosa/form/api/FormEntryPrompt.java
@@ -315,6 +315,7 @@ public class FormEntryPrompt extends FormEntryCaption {
     /**
      * Helper for getHintText, getHelpText, getConstraintText. Tries to localize text form textID,
      * falls back to innerText if not available.
+     * It may throw XPathException.
      */
     private String localizeText(QuestionString mQuestionString) {
 
@@ -331,9 +332,6 @@ public class FormEntryPrompt extends FormEntryCaption {
             //use fallback
         } catch (UnregisteredLocaleException ule) {
             System.err.println("Warning: No Locale set yet (while attempting to localizeText())");
-        } catch (Exception e) {
-            Logger.exception("FormEntryPrompt.localizeText", e);
-            e.printStackTrace();
         }
 
         return fallbackText;


### PR DESCRIPTION
This PR will remove catching all the exception in the localizeText method so that we can handle it outside and show appropriate error message to user when some exception occurs.

cross-request: https://github.com/dimagi/commcare-android/pull/2159