### PR TITLE
Add Locale Arg Parameters for <text> implementation

### DIFF
--- a/src/main/java/org/commcare/suite/model/Text.java
+++ b/src/main/java/org/commcare/suite/model/Text.java
@@ -364,8 +364,9 @@ public class Text implements Externalizable, DetailTemplate, XPathAnalyzable {
             keys.add(key);
         }
 
-        //We presume all of the keys here are numbers and that they are in order (implicit in
-        //the data model), this prevents the need to do a bunch of type coercion.
+        //This code uses a hacky shortcut to need to prevent type coercing the keys into integers,
+        //and just sorts them alphanumerically, which will fail if there are more than 10 keys.
+        //This check should keep us honest should we ever need to fix that.
         if(keys.size() > 10) {
             throw new RuntimeException("Too many arguments - Text params only support 10");
         }

--- a/src/main/java/org/commcare/suite/model/Text.java
+++ b/src/main/java/org/commcare/suite/model/Text.java
@@ -29,10 +29,8 @@ import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Vector;
-import java.util.concurrent.Callable;
 
 import io.reactivex.Single;
-import io.reactivex.functions.*;
 
 /**
  * <p>Text objects are a model for holding strings which
@@ -342,24 +340,11 @@ public class Text implements Externalizable, DetailTemplate, XPathAnalyzable {
             return new String[0];
         }
 
-        List<String> keys = new ArrayList<>();
-        for(String key : arguments.keySet()) {
-            if(key.equals("id")) {
-                continue;
-            }
-            keys.add(key);
-        }
+        List<String> keys = getOrderedKeys(arguments);
 
         if(keys.size() == 0) {
             return new String[0];
         }
-
-
-        if(keys.size() > 10) {
-            throw new RuntimeException("Too many arguments - Text params only support 10");
-        }
-
-        Collections.sort(keys, (s1, s2) -> s1.compareTo(s2));
 
         String[] parameters = new String[keys.size()];
         for(int i = 0; i < keys.size(); ++i) {
@@ -367,6 +352,26 @@ public class Text implements Externalizable, DetailTemplate, XPathAnalyzable {
         }
 
         return parameters;
+    }
+
+    private List<String> getOrderedKeys(Hashtable<String, Text> arguments) {
+        List<String> keys = new ArrayList<>();
+
+        for(String key : arguments.keySet()) {
+            if(key.equals("id")) {
+                continue;
+            }
+            keys.add(key);
+        }
+
+        //We presume all of the keys here are numbers and that they are in order (implicit in
+        //the data model), this prevents the need to do a bunch of type coercion.
+        if(keys.size() > 10) {
+            throw new RuntimeException("Too many arguments - Text params only support 10");
+        }
+
+        Collections.sort(keys, (s1, s2) -> s1.compareTo(s2));
+        return keys;
     }
 
     @Override

--- a/src/main/java/org/commcare/xml/TextParser.java
+++ b/src/main/java/org/commcare/xml/TextParser.java
@@ -96,15 +96,34 @@ public class TextParser extends ElementParser<Text> {
     private Text parseLocale() throws InvalidStructureException, IOException, XmlPullParserException {
         checkNode("locale");
         String id = parser.getAttributeValue(null, "id");
-        if (id != null) {
-            return Text.LocaleText(id);
-        } else {
+
+        Hashtable<String, Text> arguments = new Hashtable<>();
+
+
+        if (id == null) {
             //Get ID Node, throw exception if there isn't a tag
             getNextTagInBlock("locale");
             checkNode("id");
             Text idText = new TextParser(parser).parseBody();
-            return Text.LocaleText(idText);
+
+            arguments.put("id", idText);
         }
+
+
+        int count = 0;
+        while (nextTagInBlock("locale")) {
+            checkNode("argument");
+            Text argumentText = new TextParser(parser).parseBody();
+
+            arguments.put(String.valueOf(count), argumentText);
+            count++;
+        }
+        if(id == null) {
+            return Text.LocaleText(arguments);
+        } else {
+            return Text.LocaleText(id, arguments);
+        }
+
     }
 
     private Text parseXPath() throws InvalidStructureException, IOException, XmlPullParserException {

--- a/src/test/java/org/commcare/backend/model/AppConfiguredTextTests.java
+++ b/src/test/java/org/commcare/backend/model/AppConfiguredTextTests.java
@@ -1,24 +1,20 @@
 package org.commcare.backend.model;
 
-import org.commcare.backend.session.test.SessionStackTests;
 import org.commcare.backend.suite.model.test.EmptyAppElementsTests;
 import org.commcare.modern.session.SessionWrapper;
-import org.commcare.session.SessionFrame;
 import org.commcare.suite.model.MenuDisplayable;
 import org.commcare.suite.model.MenuLoader;
 import org.commcare.test.utilities.MockApp;
 import org.javarosa.core.model.condition.EvaluationContext;
-import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.services.locale.Localization;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Tests navigating through a CommCareSession (setting datum values and commands, using stepBack(),
- * etc.) for a sample app
+ * Tests for <text/> elements as they are used live in the suite file structure
  *
- * @author amstone
+ * @author ctsims
  */
 public class AppConfiguredTextTests {
 

--- a/src/test/java/org/commcare/backend/model/AppConfiguredTextTests.java
+++ b/src/test/java/org/commcare/backend/model/AppConfiguredTextTests.java
@@ -66,7 +66,7 @@ public class AppConfiguredTextTests {
     }
 
     @Test
-    public void testLocaliationIdParam() {
+    public void testLocalizationIdParam() {
         Localization.setLocale("en");
         MenuDisplayable display = getDisplayable("test4");
         EvaluationContext evaluationContext = session.getEvaluationContext("test4");

--- a/src/test/java/org/commcare/backend/model/AppConfiguredTextTests.java
+++ b/src/test/java/org/commcare/backend/model/AppConfiguredTextTests.java
@@ -1,0 +1,126 @@
+package org.commcare.backend.model;
+
+import org.commcare.backend.session.test.SessionStackTests;
+import org.commcare.backend.suite.model.test.EmptyAppElementsTests;
+import org.commcare.modern.session.SessionWrapper;
+import org.commcare.session.SessionFrame;
+import org.commcare.suite.model.MenuDisplayable;
+import org.commcare.suite.model.MenuLoader;
+import org.commcare.test.utilities.MockApp;
+import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.model.instance.ExternalDataInstance;
+import org.javarosa.core.services.locale.Localization;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests navigating through a CommCareSession (setting datum values and commands, using stepBack(),
+ * etc.) for a sample app
+ *
+ * @author amstone
+ */
+public class AppConfiguredTextTests {
+
+    private MockApp mApp;
+    private SessionWrapper session;
+
+    @Before
+    public void setUp() throws Exception {
+        mApp = new MockApp("/app_for_text_tests/");
+        session = mApp.getSession();
+        Localization.setDefaultLocale("default");
+    }
+
+    @Test
+    public void testBasicText() {
+
+        MenuDisplayable display = getDisplayable("test1");
+
+        EvaluationContext evaluationContext = session.getEvaluationContext("test1");
+
+        Assert.assertEquals("RAWTEXT", display.getDisplayText(evaluationContext));
+    }
+
+    @Test
+    public void testLocalizedTextBehavior() {
+        Localization.setLocale("en");
+        MenuDisplayable display = getDisplayable("test2");
+        EvaluationContext evaluationContext = session.getEvaluationContext("test2");
+
+        Assert.assertEquals("EnglishString", display.getDisplayText(evaluationContext));
+
+        Localization.setLocale("hin");
+
+        Assert.assertEquals("DefaultString", display.getDisplayText(evaluationContext));
+    }
+
+    @Test
+    public void testLocalizationParams() {
+        Localization.setLocale("en");
+        MenuDisplayable display = getDisplayable("test3");
+        EvaluationContext evaluationContext = session.getEvaluationContext("test3");
+
+        Assert.assertEquals("ValueArgument", display.getDisplayText(evaluationContext));
+
+        Localization.setLocale("hin");
+
+        Assert.assertEquals("ArgumentValue", display.getDisplayText(evaluationContext));
+
+    }
+
+    @Test
+    public void testLocaliationIdParam() {
+        Localization.setLocale("en");
+        MenuDisplayable display = getDisplayable("test4");
+        EvaluationContext evaluationContext = session.getEvaluationContext("test4");
+
+        Assert.assertEquals("Message1", display.getDisplayText(evaluationContext));
+
+        Localization.setLocale("hin");
+
+        Assert.assertEquals("Message2", display.getDisplayText(evaluationContext));
+
+    }
+
+    @Test
+    public void testMultipleArgs() {
+        Localization.setLocale("en");
+        MenuDisplayable display = getDisplayable("test5");
+        EvaluationContext evaluationContext = session.getEvaluationContext("test5");
+
+        Assert.assertEquals("OneThreeTwo", display.getDisplayText(evaluationContext));
+
+        Localization.setLocale("hin");
+
+        Assert.assertEquals("TwoOneThree", display.getDisplayText(evaluationContext));
+
+    }
+    @Test
+    public void testMultipleArgsAndId() {
+        Localization.setLocale("en");
+        MenuDisplayable display = getDisplayable("test6");
+        EvaluationContext evaluationContext = session.getEvaluationContext("test6");
+
+        Assert.assertEquals("OneThreeTwo", display.getDisplayText(evaluationContext));
+
+        Localization.setLocale("hin");
+
+        Assert.assertEquals("TwoOneThree", display.getDisplayText(evaluationContext));
+
+    }
+
+    private MenuDisplayable getDisplayable(String commandId) {
+        MenuLoader menuLoader = new MenuLoader(session.getPlatform(), session, "root",
+                new EmptyAppElementsTests.TestLogger(), false, false);
+
+        for(MenuDisplayable displayable : menuLoader.getMenus()) {
+            if(displayable.getCommandID().equals(commandId)) {
+                return displayable;
+            }
+        }
+        throw new RuntimeException("No Command " + commandId + " found in test harness");
+    }
+
+
+}

--- a/src/test/java/org/commcare/backend/model/TextTests.java
+++ b/src/test/java/org/commcare/backend/model/TextTests.java
@@ -1,6 +1,7 @@
 package org.commcare.backend.model;
 
 import org.commcare.suite.model.Text;
+import org.commcare.xml.TextParser;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xpath.XPathException;
@@ -32,5 +33,4 @@ public class TextTests {
             Assert.fail("XPath failure in text run did not fail fast");
         }
     }
-
 }

--- a/src/test/java/org/commcare/backend/model/TextTests.java
+++ b/src/test/java/org/commcare/backend/model/TextTests.java
@@ -1,9 +1,7 @@
 package org.commcare.backend.model;
 
 import org.commcare.suite.model.Text;
-import org.commcare.xml.TextParser;
 import org.javarosa.core.model.condition.EvaluationContext;
-import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xpath.XPathException;
 import org.junit.Assert;
 import org.junit.Test;

--- a/src/test/resources/app_for_text_tests/default/app_strings.txt
+++ b/src/test/resources/app_for_text_tests/default/app_strings.txt
@@ -1,0 +1,7 @@
+display.string=DefaultString
+unused=unused
+witharg=Value${0}
+msg_in_lang=msg1
+msg1=Message1
+msg2=Message2
+multiarg=${0}${2}${1}

--- a/src/test/resources/app_for_text_tests/en/app_strings.txt
+++ b/src/test/resources/app_for_text_tests/en/app_strings.txt
@@ -1,0 +1,3 @@
+display.string=EnglishString
+unused=unused
+msg_in_lang=msg1

--- a/src/test/resources/app_for_text_tests/hin/app_strings.txt
+++ b/src/test/resources/app_for_text_tests/hin/app_strings.txt
@@ -1,0 +1,4 @@
+unused=unused
+witharg=${0}Value
+msg_in_lang=msg2
+multiarg=${1}${0}${2}

--- a/src/test/resources/app_for_text_tests/modules-0/forms-0.xml
+++ b/src/test/resources/app_for_text_tests/modules-0/forms-0.xml
@@ -1,0 +1,38 @@
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Registration Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/176924C1-4A88-4E5F-B7FD-F1AC499C1DC8" uiVersion="1" version="15" name="Registration Form">
+					<enter_text/>
+					<select_one/>
+				<case xmlns="http://commcarehq.org/case/transaction/v2" case_id="" date_modified="" user_id=""><create><case_name/><owner_id/><case_type>case</case_type></create></case><orx:meta xmlns:cc="http://commcarehq.org/xforms"><orx:deviceID/><orx:timeStart/><orx:timeEnd/><orx:username/><orx:userID/><orx:instanceID/><cc:appVersion/></orx:meta></data>
+			</instance><instance id="commcaresession" src="jr://instance/session"/>
+			<instance src="jr://fixture/item-list:City" id="City"/>
+			<bind nodeset="/data/enter_text" type="xsd:string" required="true()"/>
+			<bind nodeset="/data/select_one"/>
+			<itext>
+				<translation lang="en" default="">
+					<text id="enter_text-label">
+						<value>Enter text</value>
+					</text>
+					<text id="select_one-label">
+						<value>Select one</value>
+					</text>
+				</translation>
+			</itext>
+		<bind calculate="/data/meta/timeEnd" nodeset="/data/case/@date_modified" type="xsd:dateTime"/><bind calculate="/data/meta/userID" nodeset="/data/case/@user_id"/><setvalue event="xforms-ready" ref="/data/case/@case_id" value="instance('commcaresession')/session/data/case_id_new_case_0"/><bind calculate="/data/enter_text" nodeset="/data/case/create/case_name"/><bind calculate="/data/meta/userID" nodeset="/data/case/create/owner_id"/><setvalue event="xforms-ready" ref="/data/meta/deviceID" value="instance('commcaresession')/session/context/deviceid"/><setvalue event="xforms-ready" ref="/data/meta/timeStart" value="now()"/><bind nodeset="/data/meta/timeStart" type="xsd:dateTime"/><setvalue event="xforms-revalidate" ref="/data/meta/timeEnd" value="now()"/><bind nodeset="/data/meta/timeEnd" type="xsd:dateTime"/><setvalue event="xforms-ready" ref="/data/meta/username" value="instance('commcaresession')/session/context/username"/><setvalue event="xforms-ready" ref="/data/meta/userID" value="instance('commcaresession')/session/context/userid"/><setvalue event="xforms-ready" ref="/data/meta/instanceID" value="uuid()"/><setvalue event="xforms-ready" ref="/data/meta/appVersion" value="instance('commcaresession')/session/context/appversion"/></model>
+	</h:head>
+	<h:body>
+		<input ref="/data/enter_text">
+			<label ref="jr:itext('enter_text-label')"/>
+		</input>
+		<select1 ref="/data/select_one">
+			<label ref="jr:itext('select_one-label')"/>
+			<itemset nodeset="instance('City')/City_list/City">
+				<label ref="city"/>
+				<value ref="id"/>
+			</itemset>
+		</select1>
+	</h:body>
+</h:html>

--- a/src/test/resources/app_for_text_tests/modules-1/forms-0.xml
+++ b/src/test/resources/app_for_text_tests/modules-1/forms-0.xml
@@ -1,0 +1,29 @@
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum" vellum:ignore="richText">
+	<h:head>
+		<h:title>Followup Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/A07B61A8-850A-4E4F-BCB5-B4B9D288C6E7" uiVersion="1" version="15" name="Followup Form">
+					<enter_text/>
+					<current_case_name/>
+				<case xmlns="http://commcarehq.org/case/transaction/v2" case_id="" date_modified="" user_id=""/><orx:meta xmlns:cc="http://commcarehq.org/xforms"><orx:deviceID/><orx:timeStart/><orx:timeEnd/><orx:username/><orx:userID/><orx:instanceID/><cc:appVersion/></orx:meta></data>
+			</instance>
+			<instance src="jr://instance/casedb" id="casedb"/>
+			<instance src="jr://instance/session" id="commcaresession"/>
+			<bind nodeset="/data/enter_text" type="xsd:string"/>
+			<bind nodeset="/data/current_case_name" calculate="instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id]/case_name"/>
+			<itext>
+				<translation lang="en" default="">
+					<text id="enter_text-label">
+						<value>Enter text</value>
+					</text>
+				</translation>
+			</itext>
+		<bind calculate="/data/meta/timeEnd" nodeset="/data/case/@date_modified" type="xsd:dateTime"/><bind calculate="/data/meta/userID" nodeset="/data/case/@user_id"/><bind calculate="instance('commcaresession')/session/data/case_id" nodeset="/data/case/@case_id"/><setvalue event="xforms-ready" ref="/data/meta/deviceID" value="instance('commcaresession')/session/context/deviceid"/><setvalue event="xforms-ready" ref="/data/meta/timeStart" value="now()"/><bind nodeset="/data/meta/timeStart" type="xsd:dateTime"/><setvalue event="xforms-revalidate" ref="/data/meta/timeEnd" value="now()"/><bind nodeset="/data/meta/timeEnd" type="xsd:dateTime"/><setvalue event="xforms-ready" ref="/data/meta/username" value="instance('commcaresession')/session/context/username"/><setvalue event="xforms-ready" ref="/data/meta/userID" value="instance('commcaresession')/session/context/userid"/><setvalue event="xforms-ready" ref="/data/meta/instanceID" value="uuid()"/><setvalue event="xforms-ready" ref="/data/meta/appVersion" value="instance('commcaresession')/session/context/appversion"/></model>
+	</h:head>
+	<h:body>
+		<input ref="/data/enter_text">
+			<label ref="jr:itext('enter_text-label')"/>
+		</input>
+	</h:body>
+</h:html>

--- a/src/test/resources/app_for_text_tests/profile.ccpr
+++ b/src/test/resources/app_for_text_tests/profile.ccpr
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<profile version="1"
+         requiredMajor="2"
+         requiredMinor="22"
+         uniqueid="id"
+         update=""
+         name="trivial_test_resources"
+         descriptor="Profile">
+
+
+    <suite><resource id="suite" version="1">
+            <location authority="local">./suite.xml</location>
+    </resource></suite>
+</profile>

--- a/src/test/resources/app_for_text_tests/suite.xml
+++ b/src/test/resources/app_for_text_tests/suite.xml
@@ -1,0 +1,113 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<suite version="16" descriptor="Suite File">
+  <xform>
+    <resource id="a9fe250f809487b4457c783d604764a2e5276dd7" version="15" descriptor="Form: (Module Menu 1) - Registration Form">
+      <location authority="local">./modules-0/forms-0.xml</location>
+      <location authority="remote">./modules-0/forms-0.xml</location>
+    </resource>
+  </xform>
+  <xform>
+    <resource id="ee2be993c2f7bd0b99ecc101f0d4b85087e080ad" version="15" descriptor="Form: (Module Menu 2) - Followup Form">
+      <location authority="local">./modules-1/forms-0.xml</location>
+      <location authority="remote">./modules-1/forms-0.xml</location>
+    </resource>
+  </xform>
+
+  <locale language="default">
+    <resource id="app_default_strings" version="330" descriptor="Translations: Default Language">
+      <location authority="local">./default/app_strings.txt</location>
+      <location authority="remote">./default/app_strings.txt</location>
+    </resource>
+  </locale>
+  <locale language="en">
+    <resource id="app_en_strings" version="330" descriptor="Translations: English">
+      <location authority="local">./en/app_strings.txt</location>
+      <location authority="remote">./en/app_strings.txt</location>
+    </resource>
+  </locale>
+
+  <locale language="hin">
+    <resource id="app_hin_strings" version="330" descriptor="Translations: Hindi">
+      <location authority="local">./hin/app_strings.txt</location>
+      <location authority="remote">./hin/app_strings.txt</location>
+    </resource>
+  </locale>
+
+  <entry>
+    <form>Raw Text Evaluation</form>
+    <command id="test1">
+      <text>RAWTEXT</text>
+    </command>
+  </entry>
+
+  <entry>
+    <form>test2</form>
+    <command id="test2">
+      <text>
+        <locale id="display.string"/>
+      </text>
+    </command>
+  </entry>
+
+  <entry>
+    <form>test3</form>
+    <command id="test3">
+      <text>
+        <locale id="witharg">
+          <argument>Argument</argument>
+        </locale>
+      </text>
+    </command>
+  </entry>
+
+  <entry>
+    <form>test4</form>
+    <command id="test4">
+      <text>
+        <locale>
+          <id>
+            <locale id="msg_in_lang"/>
+          </id>
+        </locale>
+      </text>
+    </command>
+  </entry>
+
+  <entry>
+  <form>test5</form>
+  <command id="test5">
+    <text>
+      <locale id="multiarg">
+        <argument>One</argument>
+        <argument>Two</argument>
+        <argument>Three</argument>
+      </locale>
+    </text>
+  </command>
+</entry>
+  <entry>
+    <form>test6</form>
+    <command id="test6">
+      <text>
+        <locale>
+          <id>multiarg</id>
+          <argument>One</argument>
+          <argument>Two</argument>
+          <argument>Three</argument>
+        </locale>
+      </text>
+    </command>
+  </entry>
+
+  <menu id="root">
+    <text>
+      Root Menu, test cases should appear below
+    </text>
+    <command id="test1"/>
+    <command id="test2"/>
+    <command id="test3"/>
+    <command id="test4"/>
+    <command id="test5"/>
+    <command id="test6"/>
+  </menu>
+</suite>

--- a/src/test/resources/app_for_text_tests/user_restore.xml
+++ b/src/test/resources/app_for_text_tests/user_restore.xml
@@ -1,0 +1,21 @@
+<OpenRosaResponse>
+	<message nature="ota_restore_success">Successfully restored account test!</message>
+	<Sync xmlns="http://commcarehq.org/sync">
+		<restore_id>sync_token</restore_id>
+	</Sync>
+	<Registration xmlns="http://openrosa.org/user/registration">
+		<username>test</username>
+		<password>sha1$60441$53cf77c2ac3608a944db96af177a6dfe1579e4ba</password>
+		<uuid>test_uuid</uuid>
+		<date>2012-04-30</date>
+	</Registration>
+	<case case_id="case_one"
+		date_modified="2014-08-04T21:09:07.000000Z" user_id="test_uuid"
+		xmlns="http://commcarehq.org/case/transaction/v2">
+		<create>
+			<case_type>case</case_type>
+			<case_name>A Case</case_name>
+			<owner_id>test_uuid</owner_id>
+		</create>
+	</case>
+</OpenRosaResponse>


### PR DESCRIPTION
The `<text>` element [specification for the suite](https://github.com/dimagi/commcare-core/wiki/Suite20#text) and app config layer specifies the ability to insert `<argument>` parameters as usually supported by text (like "There are ${0} results of ${1}"), but apparently that was never implemented.

Additionally, there were almost no unit tests for the core functioning of the `<text>` system, so I added some which parse through a sample app to make sure they are maximally realistic.