### PR TITLE
Catch bad Index relationship transactions

### DIFF
--- a/src/main/java/org/commcare/xml/CaseXmlParser.java
+++ b/src/main/java/org/commcare/xml/CaseXmlParser.java
@@ -226,6 +226,8 @@ public class CaseXmlParser extends TransactionParser<Case> {
             String relationship = parser.getAttributeValue(null, "relationship");
             if (relationship == null) {
                 relationship = CaseIndex.RELATIONSHIP_CHILD;
+            } else if ("".equals(relationship)) {
+                throw new InvalidStructureException("Invalid Case Transaction: Attempt to create '' relationship type", parser);
             }
 
             String value = parser.nextText().trim();

--- a/src/main/java/org/commcare/xml/bulk/BulkProcessingCaseXmlParser.java
+++ b/src/main/java/org/commcare/xml/bulk/BulkProcessingCaseXmlParser.java
@@ -243,6 +243,12 @@ public abstract class BulkProcessingCaseXmlParser extends BulkElementParser<Case
             if (value.equals("")) {
                 value = null;
             }
+
+            if ("".equals(relationship)) {
+                throw new InvalidStructureException(String.format("Invalid Case Transaction for Case[%s]: Attempt to add a '' relationship type to entity[%s]", caseId, value));
+            }
+
+
             //Process blank inputs in the same manner as data fields (IE: Remove the underlying model)
             if (value == null) {
                 if (caseForBlock.removeIndex(indexName)) {

--- a/src/test/java/org/commcare/cases/test/BadCaseXMLTests.java
+++ b/src/test/java/org/commcare/cases/test/BadCaseXMLTests.java
@@ -1,5 +1,7 @@
 package org.commcare.cases.test;
 
+import org.commcare.cases.model.Case;
+import org.commcare.cases.model.CaseIndex;
 import org.commcare.core.parse.ParseUtils;
 import org.commcare.test.utilities.TestProfileConfiguration;
 import org.commcare.util.mocks.MockDataUtils;
@@ -57,6 +59,16 @@ public class BadCaseXMLTests {
         }finally {
             //Make sure that we didn't make a case entry for the bad case though
             Assert.assertEquals("Case XML with invalid index not have created a case record", sandbox.getCaseStorage().getNumRecords(), 0);
+        }
+    }
+
+    @Test(expected = InvalidStructureException.class)
+    public void testEmptyRelationship() throws Exception {
+        try {
+            config.parseIntoSandbox(this.getClass().getResourceAsStream("/case_parse/empty_relationship.xml"), sandbox, true);
+        }finally {
+            //Make sure that we didn't make a case entry for the bad case though
+            Assert.assertNotEquals("Case XML with invalid index not have created a case record", sandbox.getCaseStorage().getNumRecords(), 2);
         }
     }
 }

--- a/src/test/resources/case_parse/empty_relationship.xml
+++ b/src/test/resources/case_parse/empty_relationship.xml
@@ -1,0 +1,35 @@
+<OpenRosaResponse>
+	<message nature="ota_restore_success">Successfully restored account test!</message>
+	<Sync xmlns="http://commcarehq.org/sync">
+		<restore_id>sync_token_a</restore_id>
+	</Sync>
+	<Registration xmlns="http://openrosa.org/user/registration">
+		<username>test</username>
+		<password>sha1$60441$53cf77c2ac3608a944db96af177a6dfe1579e4ba</password>
+		<uuid>test_example</uuid>
+		<date>2012-04-30</date>
+	</Registration>
+	
+	<case case_id="valid_case_id"
+		date_modified="2014-08-04T21:09:07.000000Z" user_id="test_example"
+		xmlns="http://commcarehq.org/case/transaction/v2">
+		<create>
+			<case_type>retain_test</case_type>
+			<case_name>case</case_name>
+			<owner_id>test_example</owner_id>
+		</create>
+	</case>
+	<case case_id="second_case_id"
+		date_modified="2014-08-04T21:09:07.000000Z" user_id="test_example"
+		xmlns="http://commcarehq.org/case/transaction/v2">
+		<create>
+			<case_type>retain_test</case_type>
+			<case_name>case</case_name>
+			<owner_id>test_example</owner_id>
+		</create>
+		<index>
+			<broken case_type="retain_test" relationship="">valid_case_id</broken>
+		</index>
+	</case>
+
+</OpenRosaResponse>


### PR DESCRIPTION
Simon noted that HQ was getting bad transactions

`<n0:parent case_type="household" relationship="">`

This change will ensure those bad transactions are caught at parse time and ensure that we fail fast before they are committed.