### PR TITLE
Fix incorrect redirect log message

### DIFF
--- a/src/main/java/org/commcare/core/network/CommCareNetworkServiceGenerator.java
+++ b/src/main/java/org/commcare/core/network/CommCareNetworkServiceGenerator.java
@@ -42,7 +42,7 @@ public class CommCareNetworkServiceGenerator {
         if (response.code() == 301) {
             String newUrl = response.header("Location");
             if (!isValidRedirect(request.url(), HttpUrl.parse(newUrl))) {
-                Logger.log(LogTypes.TYPE_WARNING_NETWORK, "Invalid redirect from " + request.url().toString() + " to " + response.request().url().toString());
+                Logger.log(LogTypes.TYPE_WARNING_NETWORK, "Invalid redirect from " + request.url().toString() + " to " + newUrl);
                 throw new IOException("Invalid redirect from secure server to insecure server");
             }
         }


### PR DESCRIPTION
We are incorrectly logging failed HTTPS redirects and echoing the same urls back

Sample Error:
```
Invalid redirect from https://www.businessweek.com/innovate/next/archives/2009/09/im_a_pc_and_imc.html to https://www.businessweek.com/innovate/next/archives/2009/09/im_a_pc_and_imc.html
```

This fixes the log error so we can see the failed redirect directly.