### PR TITLE
Captive Portal Redirect Exception Handling

### DIFF
--- a/src/main/java/org/commcare/core/network/CaptivePortalRedirectException.java
+++ b/src/main/java/org/commcare/core/network/CaptivePortalRedirectException.java
@@ -1,0 +1,18 @@
+package org.commcare.core.network;
+
+import java.io.IOException;
+
+/**
+ * Exception wrapper which communicates that an exception is the result of the current network
+ * being behind a captive portal which
+ *
+ * @author Clayton Sims (csims@dimagi.com)
+ */
+
+public class CaptivePortalRedirectException extends IOException {
+    public CaptivePortalRedirectException(IOException sourceException) {
+        super("The current network is not connected to the internet. You may need to log in from " +
+                "a web browser");
+        this.initCause(sourceException);
+    }
+}

--- a/src/main/java/org/commcare/core/network/CaptivePortalRedirectException.java
+++ b/src/main/java/org/commcare/core/network/CaptivePortalRedirectException.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 
 /**
  * Exception wrapper which communicates that an exception is the result of the current network
- * being behind a captive portal which
+ * being behind a captive portal which is redirecting traffic
  *
  * @author Clayton Sims (csims@dimagi.com)
  */


### PR DESCRIPTION
@ShivamPokhriyal 

This code provides a super simple entry point for adding code which detects a captive portal and will ensure that the code is executed at the most effective time in a request cycle based on our HTTP traffic. 

This will ensure that the ultimate downstream IO Exception from a request which fails due to a captive portal is semantically typed for easy handling