### PR TITLE
Index-of Expression

### DIFF
--- a/src/main/java/org/javarosa/xpath/expr/FunctionUtils.java
+++ b/src/main/java/org/javarosa/xpath/expr/FunctionUtils.java
@@ -2,6 +2,7 @@ package org.javarosa.xpath.expr;
 
 import org.javarosa.core.model.utils.DateUtils;
 import org.javarosa.core.util.CacheTable;
+import org.javarosa.core.util.DataUtil;
 import org.javarosa.core.util.MathUtils;
 import org.javarosa.xpath.IExprDataType;
 import org.javarosa.xpath.XPathNodeset;
@@ -85,6 +86,7 @@ public class FunctionUtils {
         funcList.put(XPathSortByFunc.NAME, XPathSortByFunc.class);
         funcList.put(XPathDistinctValuesFunc.NAME, XPathDistinctValuesFunc.class);
         funcList.put(XPathSleepFunc.NAME, XPathSleepFunc.class);
+        funcList.put(XPathIndexOfFunc.NAME, XPathIndexOfFunc.class);
     }
 
     private static final CacheTable<String, Double> mDoubleParseCache = new CacheTable<>();
@@ -436,6 +438,25 @@ public class FunctionUtils {
             return s.toUpperCase();
         }
         return s.toLowerCase();
+    }
+
+
+    /**
+     * @return A sequence representation of the input, whether the input is
+     * a nodeset (which will be dereferenced and evaluated), an existing sequence,
+     * or a string representation of a sequence (space separated list of strings)
+     */
+    public static Object[] getSequence(Object input) {
+        Object[] argList;
+        if (input instanceof XPathNodeset) {
+            argList = ((XPathNodeset)input).toArgList();
+        } else if (input instanceof Object[]) {
+            argList = (Object[])input;
+        } else {
+            String selection = (String)FunctionUtils.unpack(input);
+            argList = DataUtil.splitOnSpaces(selection);
+        }
+        return argList;
     }
 
     /**

--- a/src/main/java/org/javarosa/xpath/expr/XPathDistinctValuesFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathDistinctValuesFunc.java
@@ -2,6 +2,7 @@ package org.javarosa.xpath.expr;
 
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.DataInstance;
+import org.javarosa.core.util.DataUtil;
 import org.javarosa.xpath.XPathNodeset;
 import org.javarosa.xpath.XPathTypeMismatchException;
 import org.javarosa.xpath.parser.XPathSyntaxException;
@@ -37,19 +38,12 @@ public class XPathDistinctValuesFunc extends XPathFuncExpr {
 
     @Override
     public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
-        if (!(evaluatedArgs[0] instanceof XPathNodeset)) {
-            throw new XPathTypeMismatchException("distinct-values requires a nodeset input, instead, argument" +
-                    " is " + evaluatedArgs);
-        }
-        XPathNodeset input = (XPathNodeset)evaluatedArgs[0];
-        Object[] list = input.toArgList();
+        Object[] argList = FunctionUtils.getSequence(evaluatedArgs[0]);
+
         HashSet<String> returnSet = new LinkedHashSet<>();
-        for (Object o : list) {
+        for (Object o : argList) {
             returnSet.add(FunctionUtils.toString(o));
         }
         return returnSet.toArray();
     }
-
-
-
 }

--- a/src/main/java/org/javarosa/xpath/expr/XPathIndexOfFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathIndexOfFunc.java
@@ -1,0 +1,49 @@
+package org.javarosa.xpath.expr;
+
+import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.model.instance.DataInstance;
+import org.javarosa.core.util.DataUtil;
+import org.javarosa.xpath.XPathNodeset;
+import org.javarosa.xpath.XPathTypeMismatchException;
+import org.javarosa.xpath.parser.XPathSyntaxException;
+
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+
+/**
+ * Identifies the numerical index of the provided argument into the provided sequence, if
+ * it is a member of the sequence. If not, an empty result is returned.
+ *
+ * Created by ctsims on 04/24/2020
+ */
+
+public class XPathIndexOfFunc extends XPathFuncExpr {
+    public static final String NAME = "index-of";
+    // one or more arguments
+    private static final int EXPECTED_ARG_COUNT = 2;
+
+    public XPathIndexOfFunc() {
+        name = NAME;
+        expectedArgCount = EXPECTED_ARG_COUNT;
+    }
+
+    public XPathIndexOfFunc(XPathExpression[] args) throws XPathSyntaxException {
+        super(NAME, args, EXPECTED_ARG_COUNT, true);
+    }
+
+    @Override
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
+        Object[] argList = FunctionUtils.getSequence(evaluatedArgs[0]);
+        String indexedItem = FunctionUtils.toString(evaluatedArgs[1]);
+
+        for(int i = 0 ; i < argList.length ; ++i) {
+            if(argList[i].equals(indexedItem)) {
+                return i;
+            }
+        }
+        return "";
+    }
+
+
+
+}

--- a/src/main/java/org/javarosa/xpath/parser/ast/ASTNodeFunctionCall.java
+++ b/src/main/java/org/javarosa/xpath/parser/ast/ASTNodeFunctionCall.java
@@ -173,6 +173,8 @@ public class ASTNodeFunctionCall extends ASTNode {
                 return new XPathDistinctValuesFunc(args);
             case "sleep":
                 return new XPathSleepFunc(args);
+            case "index-of":
+                return new XPathIndexOfFunc(args);
             default:
                 return new XPathCustomRuntimeFunc(name, args);
         }

--- a/src/test/java/org/javarosa/xpath/expr/test/XPathFuncExprTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/test/XPathFuncExprTest.java
@@ -48,7 +48,6 @@ public class XPathFuncExprTest {
         FormInstance instance = ExprEvalUtils.loadInstance("/test_xpathpathexpr.xml");
         ExprEvalUtils.testEval("join(' ', /data/places/country/state)", instance, null, "Utah Montana");
         ExprEvalUtils.testEval("join-chunked('-', 5, /data/places/country/state)", instance, null, "UtahM-ontan-a");
-
     }
 
         @Test
@@ -84,6 +83,19 @@ public class XPathFuncExprTest {
         ExprEvalUtils.testEval("join(' ', distinct-values(/data/places/country/language))", instance, null, "English Spanish");
 
         ExprEvalUtils.testEval("join(' ', distinct-values(/data/places/country[language = 'French']/@id))", instance, null, "");
+
+        ExprEvalUtils.testEval("join(' ', distinct-values('a b c a b d'))", instance, null, "a b c d");
+    }
+
+    @Test
+    public void testIndexOf() {
+        FormInstance instance = ExprEvalUtils.loadInstance("/xpath/test_distinct.xml");
+
+        ExprEvalUtils.testEval("index-of(/data/places/country/@id, 'ca')", instance, null, 1);
+        ExprEvalUtils.testEval("index-of('ma ks ca', 'ca')", instance, null, 2);
+        ExprEvalUtils.testEval("index-of(distinct-values(/data/places/country/@continent), 'na')", instance, null, 0);
+
+        ExprEvalUtils.testEval("index-of(/data/places/country/@id, 'NOTHING')", instance, null, "");
     }
 
     @Test


### PR DESCRIPTION
Implements the [index-of](http://www.xqueryfunctions.com/xq/fn_index-of.html) expression for availability in XPath.

Also makes sure that `distinct-values` works with raw nodesets **or** de-referenced sequences, aligning with the semantics of the `join()` function