### PR TITLE
Fix integer -> double typing

### DIFF
--- a/src/main/java/org/javarosa/xpath/expr/XPathIndexOfFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathIndexOfFunc.java
@@ -38,7 +38,7 @@ public class XPathIndexOfFunc extends XPathFuncExpr {
 
         for(int i = 0 ; i < argList.length ; ++i) {
             if(argList[i].equals(indexedItem)) {
-                return i;
+                return new Double(i);
             }
         }
         return "";

--- a/src/test/java/org/javarosa/xpath/expr/test/XPathFuncExprTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/test/XPathFuncExprTest.java
@@ -91,9 +91,9 @@ public class XPathFuncExprTest {
     public void testIndexOf() {
         FormInstance instance = ExprEvalUtils.loadInstance("/xpath/test_distinct.xml");
 
-        ExprEvalUtils.testEval("index-of(/data/places/country/@id, 'ca')", instance, null, 1);
-        ExprEvalUtils.testEval("index-of('ma ks ca', 'ca')", instance, null, 2);
-        ExprEvalUtils.testEval("index-of(distinct-values(/data/places/country/@continent), 'na')", instance, null, 0);
+        ExprEvalUtils.testEval("index-of(/data/places/country/@id, 'ca')", instance, null, 1.0);
+        ExprEvalUtils.testEval("index-of('ma ks ca', 'ca')", instance, null, 2.0);
+        ExprEvalUtils.testEval("index-of(distinct-values(/data/places/country/@continent), 'na')", instance, null, 0.0);
 
         ExprEvalUtils.testEval("index-of(/data/places/country/@id, 'NOTHING')", instance, null, "");
     }


### PR DESCRIPTION
Fixes the return type for the index-of function to use double typing (the xpath engine doesn't register Integer references)