### PR TITLE
Interrupt triggers for indexing ops

### DIFF
--- a/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
+++ b/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
@@ -527,6 +527,9 @@ public class EvaluationContext {
     }
 
     public AbstractTreeElement resolveReference(TreeReference qualifiedRef) {
+        if(Thread.interrupted()) {
+            throw new RequestAbandonedException();
+        }
         DataInstance instance = this.getMainInstance();
         if (qualifiedRef.getInstanceName() != null &&
                 (instance == null || instance.getInstanceId() == null || !instance.getInstanceId().equals(qualifiedRef.getInstanceName()))) {

--- a/src/main/java/org/javarosa/xpath/expr/XPathExpression.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathExpression.java
@@ -1,6 +1,7 @@
 package org.javarosa.xpath.expr;
 
 import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.model.condition.RequestAbandonedException;
 import org.javarosa.core.model.condition.pivot.UnpivotableExpressionException;
 import org.javarosa.core.model.instance.AbstractTreeElement;
 import org.javarosa.core.model.instance.DataInstance;
@@ -31,6 +32,9 @@ public abstract class XPathExpression extends InFormCacheableExpr implements Ext
      */
     public Object eval(DataInstance model, EvaluationContext evalContext) {
         evalContext.openTrace(this);
+        if(Thread.interrupted()) {
+            throw new RequestAbandonedException();
+        }
 
         Object value;
         boolean fromCache = false;


### PR DESCRIPTION
Various things (ASync badge calcuations, formplayer ops, etc) rely on being able to interrupt long running processes and let them fault out through an abandoned request.

This makes sure that a couple of the very commonly hit points in "hang-prone" operations check for thread interruption and respond appropriately. These are just heuristic based on running stack traces, so I expect them to catch a large % of real-world hangs.