### PR TITLE
Modify fuzzy search to match strings with a perfect prefix

### DIFF
--- a/src/main/java/org/commcare/cases/util/StringUtils.java
+++ b/src/main/java/org/commcare/cases/util/StringUtils.java
@@ -78,6 +78,12 @@ public class StringUtils {
         //starts being used (this is probably not necessary, and
         //basically only makes sure that "at" doesn't match "or" or similar
         if (source.length() > 3) {
+            // Makes sure that we're only matching strings with distanceThreshold as
+            // the maximum difference in length, otherwise LevenshteinDistance may return a
+            // distance more than distanceThreshold even if the prefix matches perfectly.
+            if (target.length() > source.length() + distanceThreshold) {
+                target = target.substring(0, source.length() + distanceThreshold);
+            }
             int distance = LevenshteinDistance(source, target);
             //tweakable parameter: edit distance past string length disparity
             if (distance <= distanceThreshold) {

--- a/src/test/java/org/commcare/util/reference/test/FuzzySearchTest.java
+++ b/src/test/java/org/commcare/util/reference/test/FuzzySearchTest.java
@@ -1,0 +1,34 @@
+package org.commcare.util.reference.test;
+
+import org.commcare.cases.util.StringUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author $|-|!˅@M
+ */
+public class FuzzySearchTest {
+
+    @Test
+    public void testFuzzySearch() {
+        // Our current implementation allows a maximum difference of 2 between strings to be matched.
+
+        Assert.assertTrue(StringUtils.fuzzyMatch("Rama", "Rmaa").first);
+        Assert.assertTrue(StringUtils.fuzzyMatch("Mehrotras", "Mehrotra").first);
+        Assert.assertTrue(StringUtils.fuzzyMatch("Clayton", "Cyton").first);
+        Assert.assertTrue(StringUtils.fuzzyMatch("Test", "Tasty").first);
+
+        // false since Rama and Rmaa has a difference of 3 characters 'a', 'm' and ','
+        Assert.assertFalse(StringUtils.fuzzyMatch("Rama", "Rmaa,").first);
+
+        // true since we check Mehr with Mehrot,
+        Assert.assertTrue(StringUtils.fuzzyMatch("Mehr", "Mehrotra").first);
+
+        // false since to check fuzzy search source must have atleast 4 characters.
+        Assert.assertFalse(StringUtils.fuzzyMatch("Meh", "Mehrotra").first);
+
+        // false even though we have an exact substring match,
+        // Cuz fuzzy search starts checking from 0th location.
+        Assert.assertFalse(StringUtils.fuzzyMatch("Test", "CrazyTest").first);
+    }
+}


### PR DESCRIPTION
Product Note:- Change Fuzzy Search algo to match perfect prefixes even if they differ with the original string by more than 2 characters. 