### PR TITLE
Throws FNF in case resource reference don't exist

### DIFF
--- a/src/main/java/org/javarosa/core/reference/ResourceReference.java
+++ b/src/main/java/org/javarosa/core/reference/ResourceReference.java
@@ -1,5 +1,6 @@
 package org.javarosa.core.reference;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -43,7 +44,7 @@ public class ResourceReference implements Reference {
     public InputStream getStream() throws IOException {
         InputStream is = System.class.getResourceAsStream(URI);
         if (is == null) {
-            throw new IOException("File not found when opening resource as stream");
+            throw new FileNotFoundException("File not found when opening resource as stream");
         }
         return is;
     }


### PR DESCRIPTION
In case a resource reference don't exit, android code results in a `UnreliableResourceException` while it should really be `UnresolvedResourceException` (Missing Files). To correct for it this PR Explicitly throws a FNF instead of `IOException` in case a resource reference don't exist to be caught [as a FNF here](https://github.com/dimagi/commcare-android/blob/master/app/src/org/commcare/android/resource/installers/FileSystemInstaller.java#L91) and results in a URE downstream. 

Required in 2.48 as it corrects a test failure in [this android PR](https://github.com/dimagi/commcare-android/pull/2244)