### PR TITLE
Offline restore installer error handling

### DIFF
--- a/src/main/java/org/commcare/resources/model/ResourceTable.java
+++ b/src/main/java/org/commcare/resources/model/ResourceTable.java
@@ -1162,7 +1162,7 @@ public class ResourceTable {
             }
 
             if (cancellationChecker != null && cancellationChecker.wasInstallCancelled()) {
-                break;
+                new InstallCancelledException("Resource recovery was cancelled");
             }
         }
         return true;

--- a/src/main/java/org/commcare/resources/model/installers/OfflineUserRestoreInstaller.java
+++ b/src/main/java/org/commcare/resources/model/installers/OfflineUserRestoreInstaller.java
@@ -53,7 +53,7 @@ public class OfflineUserRestoreInstaller extends CacheInstaller<OfflineUserResto
                 table.commit(r, Resource.RESOURCE_STATUS_UPGRADE);
             }
             cacheLocation = offlineUserRestore.getID();
-        } catch (IOException | XmlPullParserException | InvalidStructureException e) {
+        } catch (IOException | XmlPullParserException | InvalidStructureException | InvalidReferenceException e) {
             throw new UnresolvedResourceException(r, e.getMessage());
         }
         return true;

--- a/src/main/java/org/commcare/suite/model/OfflineUserRestore.java
+++ b/src/main/java/org/commcare/suite/model/OfflineUserRestore.java
@@ -45,14 +45,14 @@ public class OfflineUserRestore implements Persistable {
 
     public OfflineUserRestore(String reference)
             throws UnfullfilledRequirementsException, IOException, InvalidStructureException,
-            XmlPullParserException {
+            XmlPullParserException, InvalidReferenceException {
         this.reference = reference;
         checkThatRestoreIsValidAndSetUsername();
     }
 
     public static OfflineUserRestore buildInMemoryUserRestore(InputStream restoreStream)
             throws UnfullfilledRequirementsException, IOException, InvalidStructureException,
-            XmlPullParserException {
+            XmlPullParserException, InvalidReferenceException {
 
         OfflineUserRestore offlineUserRestore = new OfflineUserRestore();
         byte[] restoreBytes = StreamsUtil.inputStreamToByteArray(restoreStream);
@@ -62,7 +62,7 @@ public class OfflineUserRestore implements Persistable {
         return offlineUserRestore;
     }
 
-    public InputStream getRestoreStream() {
+    public InputStream getRestoreStream() throws IOException, InvalidReferenceException {
         if (reference != null) {
             // user restore xml was installed to a file
             return getStreamFromReference();
@@ -80,13 +80,9 @@ public class OfflineUserRestore implements Persistable {
         }
     }
 
-    private InputStream getStreamFromReference() {
-        try {
+    private InputStream getStreamFromReference() throws InvalidReferenceException, IOException {
             Reference local = ReferenceManager.instance().DeriveReference(reference);
             return local.getStream();
-        } catch (IOException | InvalidReferenceException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     public String getReference() {
@@ -126,7 +122,7 @@ public class OfflineUserRestore implements Persistable {
 
     private void checkThatRestoreIsValidAndSetUsername()
             throws UnfullfilledRequirementsException, IOException, InvalidStructureException,
-            XmlPullParserException {
+            XmlPullParserException, InvalidReferenceException {
 
         TransactionParserFactory factory = parser -> {
             String name = parser.getName();


### PR DESCRIPTION
removes the `RuntimeException` exception wrapper for OfflineUserRestore install to properly catch these exceptions at a higher level. 