### PR TITLE
fixes the comparison for minimal version to check for minor equality

### DIFF
--- a/src/main/java/org/commcare/xml/ProfileParser.java
+++ b/src/main/java/org/commcare/xml/ProfileParser.java
@@ -141,7 +141,7 @@ public class ProfileParser extends ElementParser<Profile> {
             }
 
             //For the minimal version, anything greater than the profile's version is valid
-            if (this.instance.getMinimalVersion() < minimal) {
+            if (this.instance.getMinorVersion() == minor &&  this.instance.getMinimalVersion() < minimal) {
                 throw new UnfullfilledRequirementsException(
                         "Minimal Version Mismatch (Required: " + minimal + " | Available: " +
                                 this.instance.getMinimalVersion() + ")",


### PR DESCRIPTION
Fixes a bug in [PR](https://github.com/dimagi/commcare-core/pull/907) where app targeting 2.49.2 would be incompatible on 2.50.1 