### PR TITLE
255 chars limit on case name, type, owner_id and external_id 

### DIFF
--- a/src/main/java/org/commcare/xml/CaseXmlParser.java
+++ b/src/main/java/org/commcare/xml/CaseXmlParser.java
@@ -217,19 +217,19 @@ public class CaseXmlParser extends TransactionParser<Case> {
     private void checkForMaxLength(Case caseForBlock) throws InvalidStructureException {
         if (caseForBlock.getTypeId().length() > 255) {
             throw new InvalidStructureException(
-                    "Invalid <case_type>, value must be 256 characters or less",
+                    "Invalid <case_type>, value must be 255 characters or less",
                     parser);
         } else if (caseForBlock.getUserId().length() > 255) {
             throw new InvalidStructureException(
-                    "Invalid <owner_id>, value must be 256 characters or less",
+                    "Invalid <owner_id>, value must be 255 characters or less",
                     parser);
         } else if (caseForBlock.getName().length() > 255) {
             throw new InvalidStructureException(
-                    "Invalid <case_name>, value must be 256 characters or less",
+                    "Invalid <case_name>, value must be 255 characters or less",
                     parser);
         } else if (caseForBlock.getExternalId()!=null && caseForBlock.getExternalId().length() > 255) {
             throw new InvalidStructureException(
-                    "Invalid <external_id>, value must be 256 characters or less",
+                    "Invalid <external_id>, value must be 255 characters or less",
                     parser);
         }
     }

--- a/src/main/java/org/commcare/xml/CaseXmlParser.java
+++ b/src/main/java/org/commcare/xml/CaseXmlParser.java
@@ -217,19 +217,19 @@ public class CaseXmlParser extends TransactionParser<Case> {
     private void checkForMaxLength(Case caseForBlock) throws InvalidStructureException {
         if (caseForBlock.getTypeId().length() > 255) {
             throw new InvalidStructureException(
-                    "case_type is longer than 255 chars for case with ID: " + caseForBlock.getCaseId() + " and case_type " + caseForBlock.getTypeId(),
+                    "Invalid <case_type>, value must be 256 characters or less",
                     parser);
         } else if (caseForBlock.getUserId().length() > 255) {
             throw new InvalidStructureException(
-                    "owner_id is longer than 255 chars for case with ID: " + caseForBlock.getCaseId() + " and owner_id " + caseForBlock.getUserId(),
+                    "Invalid <owner_id>, value must be 256 characters or less",
                     parser);
         } else if (caseForBlock.getName().length() > 255) {
             throw new InvalidStructureException(
-                    "case_name is longer than 255 chars for case with ID: " + caseForBlock.getCaseId() + " and case_name " + caseForBlock.getName(),
+                    "Invalid <case_name>, value must be 256 characters or less",
                     parser);
         } else if (caseForBlock.getExternalId()!=null && caseForBlock.getExternalId().length() > 255) {
             throw new InvalidStructureException(
-                    "external_id is longer than 255 chars for case with ID: " + caseForBlock.getCaseId() + " and external_id " + caseForBlock.getExternalId(),
+                    "Invalid <external_id>, value must be 256 characters or less",
                     parser);
         }
     }

--- a/src/main/java/org/commcare/xml/CaseXmlParser.java
+++ b/src/main/java/org/commcare/xml/CaseXmlParser.java
@@ -175,6 +175,8 @@ public class CaseXmlParser extends TransactionParser<Case> {
             throw new InvalidStructureException("One of [user_id, owner_id] is missing for case <create> with ID: " + caseId, parser);
         }
 
+        checkForMaxLength(caseForBlock);
+
         return caseForBlock;
     }
 
@@ -208,6 +210,27 @@ public class CaseXmlParser extends TransactionParser<Case> {
                     caseForBlock.setProperty(key, value);
                     break;
             }
+        }
+        checkForMaxLength(caseForBlock);
+    }
+
+    private void checkForMaxLength(Case caseForBlock) throws InvalidStructureException {
+        if (caseForBlock.getTypeId().length() > 255) {
+            throw new InvalidStructureException(
+                    "case_type is longer than 255 chars for case with ID: " + caseForBlock.getCaseId() + " and case_type " + caseForBlock.getTypeId(),
+                    parser);
+        } else if (caseForBlock.getUserId().length() > 255) {
+            throw new InvalidStructureException(
+                    "owner_id is longer than 255 chars for case with ID: " + caseForBlock.getCaseId() + " and owner_id " + caseForBlock.getUserId(),
+                    parser);
+        } else if (caseForBlock.getName().length() > 255) {
+            throw new InvalidStructureException(
+                    "case_name is longer than 255 chars for case with ID: " + caseForBlock.getCaseId() + " and case_name " + caseForBlock.getName(),
+                    parser);
+        } else if (caseForBlock.getExternalId()!=null && caseForBlock.getExternalId().length() > 255) {
+            throw new InvalidStructureException(
+                    "external_id is longer than 255 chars for case with ID: " + caseForBlock.getCaseId() + " and external_id " + caseForBlock.getExternalId(),
+                    parser);
         }
     }
 

--- a/src/main/java/org/commcare/xml/CaseXmlParser.java
+++ b/src/main/java/org/commcare/xml/CaseXmlParser.java
@@ -6,6 +6,7 @@ import org.commcare.data.xml.TransactionParser;
 import org.javarosa.core.model.utils.DateUtils;
 import org.javarosa.core.services.storage.IStorageUtilityIndexed;
 import org.javarosa.core.util.externalizable.SerializationLimitationException;
+import org.javarosa.xml.util.InvalidCasePropertyLengthException;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.ActionableInvalidStructureException;
 import org.kxml2.io.KXmlParser;
@@ -216,21 +217,13 @@ public class CaseXmlParser extends TransactionParser<Case> {
 
     private void checkForMaxLength(Case caseForBlock) throws InvalidStructureException {
         if (caseForBlock.getTypeId().length() > 255) {
-            throw new InvalidStructureException(
-                    "Invalid <case_type>, value must be 255 characters or less",
-                    parser);
+            throw new InvalidCasePropertyLengthException("case_type");
         } else if (caseForBlock.getUserId().length() > 255) {
-            throw new InvalidStructureException(
-                    "Invalid <owner_id>, value must be 255 characters or less",
-                    parser);
+            throw new InvalidCasePropertyLengthException("owner_id");
         } else if (caseForBlock.getName().length() > 255) {
-            throw new InvalidStructureException(
-                    "Invalid <case_name>, value must be 255 characters or less",
-                    parser);
+            throw new InvalidCasePropertyLengthException("case_name");
         } else if (caseForBlock.getExternalId()!=null && caseForBlock.getExternalId().length() > 255) {
-            throw new InvalidStructureException(
-                    "Invalid <external_id>, value must be 255 characters or less",
-                    parser);
+            throw new InvalidCasePropertyLengthException("external_id");
         }
     }
 

--- a/src/main/java/org/javarosa/xml/util/InvalidCasePropertyLengthException.java
+++ b/src/main/java/org/javarosa/xml/util/InvalidCasePropertyLengthException.java
@@ -1,0 +1,15 @@
+package org.javarosa.xml.util;
+
+public class InvalidCasePropertyLengthException extends InvalidStructureException {
+
+    private final String caseProperty;
+
+    public InvalidCasePropertyLengthException(String caseProperty) {
+        super("Invalid <" + caseProperty + ">, value must be 255 characters or less");
+        this.caseProperty = caseProperty;
+    }
+
+    public String getCaseProperty() {
+        return caseProperty;
+    }
+}

--- a/src/test/java/org/commcare/cases/test/BadCaseXMLTests.java
+++ b/src/test/java/org/commcare/cases/test/BadCaseXMLTests.java
@@ -53,6 +53,16 @@ public class BadCaseXMLTests {
     }
 
     @Test(expected = InvalidStructureException.class)
+    public void testMaxLength() throws Exception {
+        try {
+            config.parseIntoSandbox(this.getClass().getResourceAsStream("/case_parse/case_create_broken_length.xml"), sandbox, true);
+        }finally {
+            //Make sure that we didn't make a case entry for the bad case though
+            Assert.assertEquals("Case XML with no id should not have created a case record", sandbox.getCaseStorage().getNumRecords(), 0);
+        }
+    }
+
+    @Test(expected = InvalidStructureException.class)
     public void testBadCaseIndexOp() throws Exception {
         try {
             config.parseIntoSandbox(this.getClass().getResourceAsStream("/case_parse/broken_self_index.xml"), sandbox, true);

--- a/src/test/resources/case_parse/case_create_broken_length.xml
+++ b/src/test/resources/case_parse/case_create_broken_length.xml
@@ -1,0 +1,22 @@
+<OpenRosaResponse>
+	<message nature="ota_restore_success">Successfully restored account test!</message>
+	<Sync xmlns="http://commcarehq.org/sync">
+		<restore_id>sync_token_a</restore_id>
+	</Sync>
+	<Registration xmlns="http://openrosa.org/user/registration">
+		<username>test</username>
+		<password>sha1$60441$53cf77c2ac3608a944db96af177a6dfe1579e4ba</password>
+		<uuid>test_example</uuid>
+		<date>2012-04-30</date>
+	</Registration>
+	
+	<case case_id=""
+		date_modified="2014-08-04T21:09:07.000000Z" user_id="test_example"
+		xmlns="http://commcarehq.org/case/transaction/v2">
+		<create>
+			<case_type>retain_test</case_type>
+			<case_name>This is a random test which is greater than the max limit specified for the case name property aka 255 chars. case transactions with case_name of size greater than 255 chars should result in InvalidStructureException. This is a greater than 255 character string demostrating this failure.</case_name>
+			<owner_id>test_example</owner_id>
+		</create>
+	</case>
+</OpenRosaResponse>


### PR DESCRIPTION
Adds 255 chars limit on case_name, case_type, owner_id and external_id to be in sync with [HQ limitations](https://github.com/dimagi/commcare-hq/blob/f7b136fb44787e5fdacde7dce5c922880e9a01c8/corehq/form_processor/backends/sql/update_strategy.py#L54-L60) and fail fast on mobile itself. 

Product Note: Throws an error on saving a form with any of case_name, case_type, owner_id and external_id for a case is greater than 255 chars in length. 