### PR TITLE
Improve performance for queries against missing case properties

### DIFF
--- a/src/main/java/org/javarosa/core/model/instance/DataInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/DataInstance.java
@@ -118,7 +118,7 @@ public abstract class DataInstance<T extends AbstractTreeElement<T>> implements 
             }
             if (mult == TreeReference.INDEX_UNBOUND) {
                 int inferredMultiplicity = node.getChildMultiplicity(name);
-                if (inferredMultiplicity == 1 || inferredMultiplicity ==0) {
+                if (inferredMultiplicity == 1 || inferredMultiplicity == 0) {
                     mult = 0;
                 } else {
                     // reference is not unambiguous

--- a/src/main/java/org/javarosa/core/model/instance/DataInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/DataInstance.java
@@ -117,7 +117,8 @@ public abstract class DataInstance<T extends AbstractTreeElement<T>> implements 
                 continue;
             }
             if (mult == TreeReference.INDEX_UNBOUND) {
-                if (node.getChildMultiplicity(name) == 1) {
+                int inferredMultiplicity = node.getChildMultiplicity(name);
+                if (inferredMultiplicity == 1 || inferredMultiplicity ==0) {
                     mult = 0;
                 } else {
                     // reference is not unambiguous

--- a/src/main/java/org/javarosa/xpath/XPathLazyNodeset.java
+++ b/src/main/java/org/javarosa/xpath/XPathLazyNodeset.java
@@ -103,7 +103,7 @@ public class XPathLazyNodeset extends XPathNodeset {
                 //figure out if we can roll that in easily. For now the catch handles it
                 return XPathPathExpr.getRefValue(instance, ec, unExpandedRef);
             } catch (XPathException xpe) {
-                //This isn't really a best effort attempt, so if we can, see if evaluating cleany works.
+                //This isn't really a best effort attempt, so if we can, see if evaluating cleanly works.
                 performEvaluation();
                 return super.unpack();
             }

--- a/src/test/java/org/commcare/cases/test/CaseXPathQueryTest.java
+++ b/src/test/java/org/commcare/cases/test/CaseXPathQueryTest.java
@@ -82,6 +82,9 @@ public class CaseXPathQueryTest {
         Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(ec,
                 "instance('casedb')/casedb/case[@case_id = 'case_one']/doesnt_exist", ""));
 
+        Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(ec,
+                "instance('casedb')/casedb/case[1]/doesnt_exist", ""));
+
         CaseTestUtils.xpathEvalAndAssert(ec,
                 "count(instance('casedb')/casedb/case[@case_id = 'case_one'][not(doesnt_exist = '')])", 0.0);
 

--- a/src/test/java/org/commcare/cases/test/CaseXPathQueryTest.java
+++ b/src/test/java/org/commcare/cases/test/CaseXPathQueryTest.java
@@ -73,7 +73,7 @@ public class CaseXPathQueryTest {
     }
 
     @Test
-    public void caseQueryWithBadPath() throws Exception {
+    public void caseQueryWithNoProperty() throws Exception {
         config.parseIntoSandbox(
                 this.getClass().getResourceAsStream("/case_query_testing.xml"), sandbox);
         EvaluationContext ec = MockDataUtils.buildContextWithInstance(sandbox, "casedb",
@@ -81,6 +81,12 @@ public class CaseXPathQueryTest {
 
         Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(ec,
                 "instance('casedb')/casedb/case[@case_id = 'case_one']/doesnt_exist", ""));
+
+        CaseTestUtils.xpathEvalAndAssert(ec,
+                "count(instance('casedb')/casedb/case[@case_id = 'case_one'][not(doesnt_exist = '')])", 0.0);
+
+        CaseTestUtils.xpathEvalAndAssert(ec,
+                "count(instance('casedb')/casedb/case[1][not(doesnt_exist = '')])", 0.0);
     }
 
     @Test

--- a/src/test/java/org/commcare/cases/test/CaseXPathQueryTest.java
+++ b/src/test/java/org/commcare/cases/test/CaseXPathQueryTest.java
@@ -90,6 +90,9 @@ public class CaseXPathQueryTest {
 
         CaseTestUtils.xpathEvalAndAssert(ec,
                 "count(instance('casedb')/casedb/case[1][not(doesnt_exist = '')])", 0.0);
+
+        CaseTestUtils.xpathEvalAndAssert(ec,
+                "count(instance('casedb')/casedb/case[1][doesnt_exist = 'nomatch'])", 0.0);
     }
 
     @Test

--- a/src/test/java/org/commcare/fixtures/test/FixtureQueryTest.java
+++ b/src/test/java/org/commcare/fixtures/test/FixtureQueryTest.java
@@ -7,6 +7,7 @@ import org.commcare.util.mocks.MockUserDataSandbox;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
+import org.javarosa.xpath.XPathTypeMismatchException;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 import org.junit.Before;
 import org.junit.Test;
@@ -35,5 +36,23 @@ public class FixtureQueryTest {
                 MockDataUtils.buildContextWithInstance(sandbox, "commtrack:products", CaseTestUtils.FIXTURE_INSTANCE_PRODUCT);
         CaseTestUtils.xpathEvalAndAssert(ec, "count(instance('commtrack:products')/products/product[@heterogenous_attribute = 'present'])", 2.0);
         CaseTestUtils.xpathEvalAndAssert(ec, "instance('commtrack:products')/products/@last_sync", "2018-07-27T12:54:11.987997+00:00");
+    }
+
+    @Test(expected = XPathTypeMismatchException.class)
+    public void queryMissingLookups() throws XPathSyntaxException, UnfullfilledRequirementsException, XmlPullParserException, IOException, InvalidStructureException {
+        ParseUtils.parseIntoSandbox(this.getClass().getResourceAsStream("/fixture_create.xml"), sandbox);
+
+        EvaluationContext ec =
+                MockDataUtils.buildContextWithInstance(sandbox, "commtrack:products", CaseTestUtils.FIXTURE_INSTANCE_PRODUCT);
+        CaseTestUtils.xpathEvalAndAssert(ec, "instance('commtrack:products')/products/product[@heterogenous_attribute = 'present']/missing_reference", "");
+    }
+
+    @Test(expected = XPathTypeMismatchException.class)
+    public void queryMissingPredicate() throws XPathSyntaxException, UnfullfilledRequirementsException, XmlPullParserException, IOException, InvalidStructureException {
+        ParseUtils.parseIntoSandbox(this.getClass().getResourceAsStream("/fixture_create.xml"), sandbox);
+
+        EvaluationContext ec =
+                MockDataUtils.buildContextWithInstance(sandbox, "commtrack:products", CaseTestUtils.FIXTURE_INSTANCE_PRODUCT);
+        CaseTestUtils.xpathEvalAndAssert(ec, "instance('commtrack:products')/products/product[@heterogenous_attribute = 'present'][missing_reference='test']", "");
     }
 }


### PR DESCRIPTION
Previously, request patterns which referred to case properties which may or may have existed, like

```
instance('casedb')/casedb/case[3]/my_property = 'value'
```

had an awkward resolution path when the `my_property` case property is not set. Those requests would fail to take advantage of a [core optimization](https://github.com/dimagi/commcare-core/blob/master/src/main/java/org/javarosa/xpath/XPathLazyNodeset.java#L104) which allowed much, much faster resolution for 'normal' references which don't use xpath predicates. 

This change lets the normal "Go look up a node" process correctly identify the "shadow" elements which represent a case property that doesn't exist, and returns that virtual node. That prevents the system from creating, throwing, and catching an XPathTypeException potentially tens-of-thousands of times during request evaluation. Since that XPathTypeException requires gaining a lock on a static type, this also will potentially reduce concurrency issues when multiple such requests are running simultaneously.

This PR does change the resolution behavior of CommCare slightly. It will result in `count()` or other queries which depend on an element existing or not (rather than its value) "seeing" the virtual element more, since a real treeelement is created to represent it. This was true before as well, but in many fewer circumstances. That change still needs a bit more scrutiny before this can be included safely.
