### PR TITLE
Fix Fractional Time Comparisons with DST

### DIFF
--- a/src/main/java/org/javarosa/core/model/utils/DateUtils.java
+++ b/src/main/java/org/javarosa/core/model/utils/DateUtils.java
@@ -32,8 +32,10 @@ public class DateUtils {
     private static TimezoneProvider tzProvider = new TimezoneProvider();
 
     public static final long HOUR_IN_MS = TimeUnit.HOURS.toMillis(1);
-    public static final long DAY_IN_MS = TimeUnit.DAYS.toMillis(1);;
+    public static final long DAY_IN_MS = TimeUnit.DAYS.toMillis(1);
+
     private static final Date EPOCH_DATE = getDate(1970, 1, 1);
+
     private final static long EPOCH_TIME = roundDate(EPOCH_DATE).getTime();
 
     public static class CalendarStrings {
@@ -835,7 +837,11 @@ public class DateUtils {
 
 
     public static Double fractionalDaysSinceEpoch(Date a) {
-        return new Double((a.getTime() - EPOCH_DATE.getTime()) / (double)DAY_IN_MS);
+        //Even though EPOCH_DATE uses the device timezone, calendar Daylight savings time adjustments
+        //are based on the instance of evaluation (the epoch), not today, so we need to manually
+        //correct for any drift in the offsets
+        long timeZoneAdjust = (a.getTimezoneOffset() - EPOCH_DATE.getTimezoneOffset()) * 60* 1000;
+        return new Double(((a.getTime() - EPOCH_DATE.getTime()) - timeZoneAdjust) / (double)DAY_IN_MS);
     }
 
     /**


### PR DESCRIPTION
When using the fractional date (`double(date())`) evaluation [introduced here](https://github.com/dimagi/commcare-core/commit/e0d29f5e04ce62110de8788ea5054ba1637e5b64), the system relies on the 'default' timezone being the same between the date presented for comparison and the `EPOCH_DATE`.

Currently, this results in an issue when the default TimeZone is DST aware for its locale, and the current DST offset for the current instance is different from the DST offset in the TimeZone on the date of the epoch. For instance, the offset for the "Eastern Time" timezone August 20, 2020 is UTC-04:00, but the offset for the "Eastern Time" timezone on the date of the epoch on January 1, 1970 was UTC-05:00. 

It's not obvious to me whether this has ~always been an issue which simply hasn't come up, or whether changes to the thoroughness of TimeZones on Android has introduced the disparity. 

This change explicitly factors in the offsets being introduced by the associated `Date` objects, regardless of why those offsets were introduced, so it should be a safe no-op in any situation  where the default TimeZone has consistent offsets for both the current instant and for the epoch instant. 