### PR TITLE
Fix npe in getting case property length

### DIFF
--- a/src/main/java/org/commcare/xml/CaseXmlParser.java
+++ b/src/main/java/org/commcare/xml/CaseXmlParser.java
@@ -216,15 +216,22 @@ public class CaseXmlParser extends TransactionParser<Case> {
     }
 
     private void checkForMaxLength(Case caseForBlock) throws InvalidStructureException {
-        if (caseForBlock.getTypeId().length() > 255) {
+        if (getStringLength(caseForBlock.getTypeId()) > 255) {
             throw new InvalidCasePropertyLengthException("case_type");
-        } else if (caseForBlock.getUserId().length() > 255) {
+        } else if (getStringLength(caseForBlock.getUserId()) > 255) {
             throw new InvalidCasePropertyLengthException("owner_id");
-        } else if (caseForBlock.getName().length() > 255) {
+        } else if (getStringLength(caseForBlock.getName()) > 255) {
             throw new InvalidCasePropertyLengthException("case_name");
-        } else if (caseForBlock.getExternalId()!=null && caseForBlock.getExternalId().length() > 255) {
+        } else if (getStringLength(caseForBlock.getExternalId()) > 255) {
             throw new InvalidCasePropertyLengthException("external_id");
         }
+    }
+
+    /**
+     * Returns the length of string if it's not null, otherwise 0.
+     */
+    private int getStringLength(String input) {
+        return input != null ? input.length() : 0;
     }
 
     private Case loadCase(Case caseForBlock, String caseId, boolean errorIfMissing) throws InvalidStructureException {


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/SAAS-11376

Fixes a crash introduced here #922 
Logs: 
```
2020-10-02 17:19:37.388 16772-19125/org.commcare.dalvik.debug W/System.err: java.lang.NullPointerException: Attempt to invoke virtual method 'int java.lang.String.length()' on a null object reference
2020-10-02 17:19:37.390 16772-19125/org.commcare.dalvik.debug W/System.err:     at org.commcare.xml.CaseXmlParser.checkForMaxLength(CaseXmlParser.java:221)
2020-10-02 17:19:37.390 16772-19125/org.commcare.dalvik.debug W/System.err:     at org.commcare.xml.CaseXmlParser.updateCase(CaseXmlParser.java:215)
2020-10-02 17:19:37.390 16772-19125/org.commcare.dalvik.debug W/System.err:     at org.commcare.xml.CaseXmlParser.parse(CaseXmlParser.java:91)
2020-10-02 17:19:37.390 16772-19125/org.commcare.dalvik.debug W/System.err:     at org.commcare.xml.CaseXmlParser.parse(CaseXmlParser.java:32)
2020-10-02 17:19:37.390 16772-19125/org.commcare.dalvik.debug W/System.err:     at org.commcare.data.xml.DataModelPullParser.parseBlock(DataModelPullParser.java:147)
2020-10-02 17:19:37.390 16772-19125/org.commcare.dalvik.debug W/System.err:     at org.commcare.data.xml.DataModelPullParser.parse(DataModelPullParser.java:89)
2020-10-02 17:19:37.390 16772-19125/org.commcare.dalvik.debug W/System.err:     at org.commcare.tasks.FormRecordCleanupTask.reparseRecord(FormRecordCleanupTask.java:262)
2020-10-02 17:19:37.390 16772-19125/org.commcare.dalvik.debug W/System.err:     at org.commcare.tasks.FormRecordCleanupTask.updateAndWriteRecord(FormRecordCleanupTask.java:145)
2020-10-02 17:19:37.390 16772-19125/org.commcare.dalvik.debug W/System.err:     at org.commcare.android.database.user.models.FormRecord.updateAndWriteRecord(FormRecord.java:409)
2020-10-02 17:19:37.390 16772-19125/org.commcare.dalvik.debug W/System.err:     at org.commcare.android.database.user.models.FormRecord.updateAndProcessRecord(FormRecord.java:347)
2020-10-02 17:19:37.390 16772-19125/org.commcare.dalvik.debug W/System.err:     at org.commcare.android.database.user.models.FormRecord.finalizeRecord(FormRecord.java:331)
2020-10-02 17:19:37.390 16772-19125/org.commcare.dalvik.debug W/System.err:     at org.commcare.android.database.user.models.FormRecord.updateStatus(FormRecord.java:326)
2020-10-02 17:19:37.390 16772-19125/org.commcare.dalvik.debug W/System.err:     at org.commcare.tasks.SaveToDiskTask.updateFormRecord(SaveToDiskTask.java:186)
2020-10-02 17:19:37.390 16772-19125/org.commcare.dalvik.debug W/System.err:     at org.commcare.tasks.SaveToDiskTask.exportData(SaveToDiskTask.java:216)
2020-10-02 17:19:37.390 16772-19125/org.commcare.dalvik.debug W/System.err:     at org.commcare.tasks.SaveToDiskTask.doTaskBackground(SaveToDiskTask.java:107)
2020-10-02 17:19:37.390 16772-19125/org.commcare.dalvik.debug W/System.err:     at org.commcare.tasks.SaveToDiskTask.doTaskBackground(SaveToDiskTask.java:41)
2020-10-02 17:19:37.390 16772-19125/org.commcare.dalvik.debug W/System.err:     at org.commcare.tasks.templates.CommCareTask.doInBackground(CommCareTask.java:40)
2020-10-02 17:19:37.390 16772-19125/org.commcare.dalvik.debug W/System.err:     at android.os.AsyncTask$2.call(AsyncTask.java:304)
2020-10-02 17:19:37.390 16772-19125/org.commcare.dalvik.debug W/System.err:     at java.util.concurrent.FutureTask.run(FutureTask.java:237)
2020-10-02 17:19:37.391 16772-19125/org.commcare.dalvik.debug W/System.err:     at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1133)
2020-10-02 17:19:37.391 16772-19125/org.commcare.dalvik.debug W/System.err:     at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:607)
2020-10-02 17:19:37.391 16772-19125/org.commcare.dalvik.debug W/System.err:     at java.lang.Thread.run(Thread.java:760)
```

Oddly, I see no logs corresponding to this on crashlytics. 