### PR TITLE
add option for minimal entity screen

### DIFF
--- a/src/cli/java/org/commcare/util/screen/EntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreen.java
@@ -50,6 +50,7 @@ public class EntityScreen extends CompoundScreenHost {
     private Hashtable<String, TreeReference> referenceMap;
 
     private boolean handleCaseIndex;
+    private boolean full = true;
 
     private Vector<TreeReference> references;
 
@@ -57,11 +58,20 @@ public class EntityScreen extends CompoundScreenHost {
         this.handleCaseIndex = handleCaseIndex;
     }
 
-    public void init(SessionWrapper session) throws CommCareSessionException {
-        init(session, true);
+    /**
+     * This constructor allows specifying whether to use the complete init or a minimal one
+     *
+     * @param handleCaseIndex Allow specifying entity by list index rather than unique ID
+     * @param full            If set to false, the subscreen and referenceMap, used for
+     *                        selecting and rendering entity details, will not be created.
+     *                        This speeds up initialization but makes further selection impossible.
+     */
+    public EntityScreen(boolean handleCaseIndex, boolean full) {
+        this.handleCaseIndex = handleCaseIndex;
+        this.full = full;
     }
 
-    public void init(SessionWrapper session, boolean full) throws CommCareSessionException {
+    public void init(SessionWrapper session) throws CommCareSessionException {
         SessionDatum datum = session.getNeededDatum();
         if (!(datum instanceof EntityDatum)) {
             throw new CommCareSessionException("Didn't find an entity select action where one is expected.");

--- a/src/cli/java/org/commcare/util/screen/EntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreen.java
@@ -58,6 +58,10 @@ public class EntityScreen extends CompoundScreenHost {
     }
 
     public void init(SessionWrapper session) throws CommCareSessionException {
+        init(session, true);
+    }
+
+    public void init(SessionWrapper session, boolean full) throws CommCareSessionException {
         SessionDatum datum = session.getNeededDatum();
         if (!(datum instanceof EntityDatum)) {
             throw new CommCareSessionException("Didn't find an entity select action where one is expected.");
@@ -91,22 +95,24 @@ public class EntityScreen extends CompoundScreenHost {
 
         evalContext.setQueryContext(newContext);
 
-        referenceMap = new Hashtable<>();
-        for(TreeReference reference: references) {
-            referenceMap.put(getReturnValueFromSelection(reference, (EntityDatum) session.getNeededDatum(), evalContext), reference);
-        }
-
-        // for now override 'here()' with the coords of Sao Paulo, eventually allow dynamic setting
-        evalContext.addFunctionHandler(new ScreenUtils.HereDummyFunc(-23.56, -46.66));
-
-        if (mNeededDatum.isAutoSelectEnabled() && references.size() == 1) {
-            this.setHighlightedEntity(references.firstElement());
-            if (!this.setCurrentScreenToDetail()) {
-                this.updateSession(session);
-                readyToSkip = true;
+        if (full) {
+            referenceMap = new Hashtable<>();
+            for(TreeReference reference: references) {
+                referenceMap.put(getReturnValueFromSelection(reference, (EntityDatum) session.getNeededDatum(), evalContext), reference);
             }
-        } else {
-            mCurrentScreen = new EntityListSubscreen(mShortDetail, references, evalContext, handleCaseIndex);
+
+            // for now override 'here()' with the coords of Sao Paulo, eventually allow dynamic setting
+            evalContext.addFunctionHandler(new ScreenUtils.HereDummyFunc(-23.56, -46.66));
+
+            if (mNeededDatum.isAutoSelectEnabled() && references.size() == 1) {
+                this.setHighlightedEntity(references.firstElement());
+                if (!this.setCurrentScreenToDetail()) {
+                    this.updateSession(session);
+                    readyToSkip = true;
+                }
+            } else {
+                mCurrentScreen = new EntityListSubscreen(mShortDetail, references, evalContext, handleCaseIndex);
+            }
         }
     }
 

--- a/src/cli/java/org/commcare/util/screen/EntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreen.java
@@ -95,7 +95,7 @@ public class EntityScreen extends CompoundScreenHost {
 
         evalContext.setQueryContext(newContext);
 
-        if (full) {
+        if (full || references.size() == 1) {
             referenceMap = new Hashtable<>();
             for(TreeReference reference: references) {
                 referenceMap.put(getReturnValueFromSelection(reference, (EntityDatum) session.getNeededDatum(), evalContext), reference);


### PR DESCRIPTION
The steps this cuts represent about 2/3 of the time to initialize an EntityScreen, and are not needed for case lists in formplayer, although they do appear to be needed for case detail requests. There will be a linked formplayer PR to take advantage of this, if the approach seems reasonable.

The part I was most unsure about was autoselect, so I only made the optimization take effect if autoselect could not be invoked anyway (more than 1 case), since in that case the cost of the skipped operations would be minimal anyway.

I am reasonably certain this is safe, and tests pass (both automated and some manual), but I am not totally sure of all possible uses of the `EntityListSubscreen`, although it appears to only be relevant for case details, which is handled in a separate request in formplayer.

Easiest to review with `?w=1`