### PR TITLE
Ability to require search for a case list

### DIFF
--- a/src/main/java/org/commcare/suite/model/Detail.java
+++ b/src/main/java/org/commcare/suite/model/Detail.java
@@ -72,11 +72,13 @@ public class Detail implements Externalizable {
     private OrderedHashtable<String, String> variables;
     private OrderedHashtable<String, XPathExpression> variablesCompiled;
 
-
     private Vector<Action> actions;
 
     // Force the activity that is showing this detail to show itself in landscape view only
     private boolean forceLandscapeView;
+
+    // Only fetch entities if user has provided a search term
+    private boolean requireSearch;
 
     private XPathExpression focusFunction;
 
@@ -109,7 +111,7 @@ public class Detail implements Externalizable {
                   Vector<DetailField> fieldsVector, OrderedHashtable<String, String> variables,
                   Vector<Action> actions, Callout callout, String fitAcross,
                   String uniformUnitsString, String forceLandscape, String focusFunction,
-                  String printPathProvided, String relevancy) {
+                  String printPathProvided, String relevancy, String requireSearch) {
 
         if (detailsVector.size() > 0 && fieldsVector.size() > 0) {
             throw new IllegalArgumentException("A detail may contain either sub-details or fields, but not both.");
@@ -127,6 +129,8 @@ public class Detail implements Externalizable {
         this.callout = callout;
         this.useUniformUnitsInCaseTile = "true".equals(uniformUnitsString);
         this.forceLandscapeView = "true".equals(forceLandscape);
+        this.requireSearch = "true".equals(requireSearch);
+
         this.printEnabled = templatePathValid(printPathProvided);
 
         if (focusFunction != null) {
@@ -246,6 +250,7 @@ public class Detail implements Externalizable {
         forceLandscapeView = ExtUtil.readBool(in);
         focusFunction = (XPathExpression)ExtUtil.read(in, new ExtWrapNullable(new ExtWrapTagged()), pf);
         numEntitiesToDisplayPerRow = (int)ExtUtil.readNumeric(in);
+        requireSearch = ExtUtil.readBool(in);
         useUniformUnitsInCaseTile = ExtUtil.readBool(in);
         parsedRelevancyExpression = (XPathExpression)ExtUtil.read(in, new ExtWrapNullable(new ExtWrapTagged()), pf);
     }
@@ -264,6 +269,7 @@ public class Detail implements Externalizable {
         ExtUtil.writeBool(out, forceLandscapeView);
         ExtUtil.write(out, new ExtWrapNullable(focusFunction == null ? null : new ExtWrapTagged(focusFunction)));
         ExtUtil.writeNumeric(out, numEntitiesToDisplayPerRow);
+        ExtUtil.writeBool(out, requireSearch);
         ExtUtil.writeBool(out, useUniformUnitsInCaseTile);
         ExtUtil.write(out, new ExtWrapNullable(
                 parsedRelevancyExpression == null ? null : new ExtWrapTagged(parsedRelevancyExpression)));
@@ -507,6 +513,10 @@ public class Detail implements Externalizable {
             }
         }
         return false;
+    }
+
+    public boolean doesRequireSearch() {
+        return this.requireSearch;
     }
 
     public boolean isPrintEnabled() {

--- a/src/main/java/org/commcare/suite/model/Detail.java
+++ b/src/main/java/org/commcare/suite/model/Detail.java
@@ -515,7 +515,7 @@ public class Detail implements Externalizable {
         return false;
     }
 
-    public boolean doesRequireSearch() {
+    public boolean isSearchRequired() {
         return this.requireSearch;
     }
 

--- a/src/main/java/org/commcare/xml/DetailParser.java
+++ b/src/main/java/org/commcare/xml/DetailParser.java
@@ -35,6 +35,7 @@ public class DetailParser extends CommCareElementParser<Detail> {
         String forceLandscapeView = parser.getAttributeValue(null, "force-landscape");
         String printTemplatePath = parser.getAttributeValue(null, "print-template");
         String relevancy = parser.getAttributeValue(null, "relevant");
+        String requireSearch = parser.getAttributeValue(null, "require-search");
 
         // First fetch the title
         getNextTagInBlock("detail");
@@ -111,7 +112,7 @@ public class DetailParser extends CommCareElementParser<Detail> {
 
         return new Detail(id, title, nodeset, subdetails, fields, variables, actions, callout,
                 fitAcross, useUniformUnits, forceLandscapeView, focusFunction, printTemplatePath,
-                relevancy);
+                relevancy, requireSearch);
     }
 
     protected DetailParser getDetailParser() {

--- a/src/test/java/org/commcare/backend/suite/model/test/AppStructureTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/AppStructureTests.java
@@ -99,6 +99,16 @@ public class AppStructureTests {
     }
 
     @Test
+    public void testCaseListRequiresSearch() {
+        Assert.assertTrue(mApp.getSession().getPlatform().getDetail("m1_case_short").isSearchRequired());
+    }
+
+    @Test
+    public void testCaseListDoesNotRequireSearch() {
+        Assert.assertFalse(mApp.getSession().getPlatform().getDetail("m0_case_short").isSearchRequired());
+    }
+
+    @Test
     public void testDemoUserRestoreParsing() throws Exception {
         // Test parsing an app with a properly-formed demo user restore file
         MockApp appWithGoodUserRestore = new MockApp("/app_with_good_demo_restore/");

--- a/src/test/resources/app_structure/suite.xml
+++ b/src/test/resources/app_structure/suite.xml
@@ -61,7 +61,7 @@
     </field>
   </detail>
 
-  <detail id="m1_case_short">
+  <detail id="m1_case_short" require-search="true">
     <title>
       <text>With focus function</text>
     </title>


### PR DESCRIPTION
See https://github.com/dimagi/commcare-hq/pull/28677

This adds `require-search` as a boolean option on `<detail>` elements in the suite.
I considered adding it to the `<datum>` instead, as `detail-list-require-search`. Open to feedback.