### PR TITLE
Suppress TimeZone info on TimeData questions

### DIFF
--- a/src/main/java/org/javarosa/core/model/data/TimeData.java
+++ b/src/main/java/org/javarosa/core/model/data/TimeData.java
@@ -82,7 +82,7 @@ public class TimeData implements IAnswerData {
 
     @Override
     public TimeData cast(UncastData data) throws IllegalArgumentException {
-        Date ret = DateUtils.parseTime(data.value);
+        Date ret = DateUtils.parseTime(data.value, true);
         if (ret != null) {
             return new TimeData(ret);
         }

--- a/src/main/java/org/javarosa/core/model/data/TimeData.java
+++ b/src/main/java/org/javarosa/core/model/data/TimeData.java
@@ -77,7 +77,7 @@ public class TimeData implements IAnswerData {
 
     @Override
     public UncastData uncast() {
-        return new UncastData(DateUtils.formatTime(d, DateUtils.FORMAT_ISO8601));
+        return new UncastData(DateUtils.formatTime(d, DateUtils.FORMAT_ISO8601_WALL_TIME));
     }
 
     @Override

--- a/src/main/java/org/javarosa/core/model/utils/DateUtils.java
+++ b/src/main/java/org/javarosa/core/model/utils/DateUtils.java
@@ -509,7 +509,11 @@ public class DateUtils {
     }
 
     public static Date parseTime(String str) {
-        if (timezoneOffset() != -1 && !str.contains("+") && !str.contains("-") && !str.contains("Z")) {
+        return parseTime(str, false);
+    }
+
+    public static Date parseTime(String str, boolean ignoreTimezone) {
+        if (!ignoreTimezone && (timezoneOffset() != -1 && !str.contains("+") && !str.contains("-") && !str.contains("Z"))) {
             str = str + getOffsetInStandardFormat(timezoneOffset());
         }
 

--- a/src/main/java/org/javarosa/core/model/utils/DateUtils.java
+++ b/src/main/java/org/javarosa/core/model/utils/DateUtils.java
@@ -20,6 +20,7 @@ public class DateUtils {
     private static final int MONTH_OFFSET = (1 - Calendar.JANUARY);
 
     public static final int FORMAT_ISO8601 = 1;
+    public static final int FORMAT_ISO8601_WALL_TIME = 10;
     public static final int FORMAT_HUMAN_READABLE_SHORT = 2;
     public static final int FORMAT_HUMAN_READABLE_DAYS_FROM_TODAY = 5;
     public static final int FORMAT_TIMESTAMP_SUFFIX = 7;
@@ -296,6 +297,8 @@ public class DateUtils {
         switch (format) {
             case FORMAT_ISO8601:
                 return formatTimeISO8601(f);
+            case FORMAT_ISO8601_WALL_TIME:
+                return formatTimeISO8601(f, true);
             case FORMAT_HUMAN_READABLE_SHORT:
                 return formatTimeColloquial(f);
             case FORMAT_TIMESTAMP_SUFFIX:
@@ -342,7 +345,14 @@ public class DateUtils {
     }
 
     private static String formatTimeISO8601(DateFields f) {
+        return formatTimeISO8601(f, false);
+    }
+
+    private static String formatTimeISO8601(DateFields f, boolean suppressTimezone) {
         String time = intPad(f.hour, 2) + ":" + intPad(f.minute, 2) + ":" + intPad(f.second, 2) + "." + intPad(f.secTicks, 3);
+        if (suppressTimezone) {
+            return time;
+        }
 
         int offset;
         if (timezoneOffset() != -1) {

--- a/src/main/java/org/javarosa/xform/util/XFormAnswerDataSerializer.java
+++ b/src/main/java/org/javarosa/xform/util/XFormAnswerDataSerializer.java
@@ -105,7 +105,7 @@ public class XFormAnswerDataSerializer implements IAnswerDataSerializer {
      * formatting
      */
     public Object serializeAnswerData(TimeData data) {
-        return DateUtils.formatTime((Date)data.getValue(), DateUtils.FORMAT_ISO8601);
+        return DateUtils.formatTime((Date)data.getValue(), DateUtils.FORMAT_ISO8601_WALL_TIME);
     }
 
     /**

--- a/src/test/java/org/javarosa/core/model/data/test/TimeDataTests.java
+++ b/src/test/java/org/javarosa/core/model/data/test/TimeDataTests.java
@@ -1,6 +1,7 @@
 package org.javarosa.core.model.data.test;
 
 import org.javarosa.core.model.data.TimeData;
+import org.javarosa.core.model.data.UncastData;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -65,5 +66,11 @@ public class TimeDataTests {
         }
         assertTrue("TimeData failed to throw an exception when setting null data", exceptionThrown);
         assertTrue("TimeData overwrote existing value on incorrect input", data.getValue().equals(now));
+    }
+
+    @Test
+    public void testIdentity() {
+        TimeData data = new TimeData().cast(new UncastData("10:00"));
+        assertEquals("10:00", data.getDisplayText());
     }
 }


### PR DESCRIPTION
A forum user identified that they were having "off by an hour" questions which end up blocking web apps from working correctly, because the server doesn't send back the same value for questions as the browser provided.

This is because the TimeData construct has been improperly carrying forward TZ info internally with the time value, despite it being a "WallClock" representation. Since the internal calendar date for the TimeDate Date is the Epoch, if the TimeZone offset in the current locale differs from the offset on the Epoch, dates would drift. Kevin's recent change to improve Timezone accuracy on formplayer had the unintended side effect of instructing the browser about the current Locale instead of the current offset, triggering the behavior there.

This change simply strips the TZ info when the question converts the internal value back out to a serialized representation, since the TZ (like the Date itself) isn't actually a part of the TimeData object.

Formplayer commit here: https://github.com/dimagi/formplayer/pull/778