### PR TITLE
add option to removeArchiveFile

### DIFF
--- a/src/main/java/org/commcare/modern/reference/ArchiveFileRoot.java
+++ b/src/main/java/org/commcare/modern/reference/ArchiveFileRoot.java
@@ -57,6 +57,17 @@ public class ArchiveFileRoot implements ReferenceFactory {
         return mGUID;
     }
 
+    public String removeArchiveFile(String appId) {
+        String mGUID;
+        if (appId == null) {
+            mGUID = PropertyUtils.genGUID(GUID_LENGTH);
+        } else {
+            mGUID = appId;
+        }
+        guidToFolderMap.remove(mGUID);
+        return mGUID;
+    }
+
     protected String getGUID(String jrpath) {
         String prependRemoved = jrpath.substring("jr://archive/".length());
         int slashindex = prependRemoved.indexOf("/");


### PR DESCRIPTION
Related to https://dimagi-dev.atlassian.net/browse/SAAS-11333

We run into an issue where if the ccz that downloaded is corrupted, we hit an exception and formplayer does not try to download a new ccz. This allows formplayer to remove the zip file from memory so subsequent requests can try to download it. 