### PR TITLE
Add encrypt-string as an XPath function

### DIFF
--- a/src/main/java/org/javarosa/xpath/expr/FunctionUtils.java
+++ b/src/main/java/org/javarosa/xpath/expr/FunctionUtils.java
@@ -87,6 +87,7 @@ public class FunctionUtils {
         funcList.put(XPathDistinctValuesFunc.NAME, XPathDistinctValuesFunc.class);
         funcList.put(XPathSleepFunc.NAME, XPathSleepFunc.class);
         funcList.put(XPathIndexOfFunc.NAME, XPathIndexOfFunc.class);
+        funcList.put(XPathEncryptStringFunc.NAME, XPathEncryptStringFunc.class);
     }
 
     private static final CacheTable<String, Double> mDoubleParseCache = new CacheTable<>();

--- a/src/main/java/org/javarosa/xpath/expr/XPathEncryptStringFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathEncryptStringFunc.java
@@ -10,7 +10,6 @@ import org.javarosa.xpath.parser.XPathSyntaxException;
 
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
-import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
@@ -47,7 +46,6 @@ public class XPathEncryptStringFunc extends XPathFuncExpr {
         String algorithm = FunctionUtils.toString(o3);
 
         final String ENCRYPT_ALGO = "AES/GCM/NoPadding";
-        final int TAG_LENGTH_BIT = 128;
         final int IV_LENGTH_BYTE = 12;
         final int KEY_LENGTH_BIT = 256;
 
@@ -70,13 +68,11 @@ public class XPathEncryptStringFunc extends XPathFuncExpr {
         }
         SecretKey secret = new SecretKeySpec(keyBytes, "AES");
 
-        byte[] iv = new byte[IV_LENGTH_BYTE];
-        new SecureRandom().nextBytes(iv);
-
         try {
             Cipher cipher = Cipher.getInstance(ENCRYPT_ALGO);
-            cipher.init(Cipher.ENCRYPT_MODE, secret, new GCMParameterSpec(TAG_LENGTH_BIT, iv));
+            cipher.init(Cipher.ENCRYPT_MODE, secret);
             byte[] encryptedMessage = cipher.doFinal(message.getBytes(Charset.forName("UTF-8")));
+            byte[] iv = cipher.getIV();
             byte[] ivPlusMessage = ByteBuffer.allocate(iv.length + encryptedMessage.length)
                 .put(iv)
                 .put(encryptedMessage)

--- a/src/main/java/org/javarosa/xpath/expr/XPathEncryptStringFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathEncryptStringFunc.java
@@ -16,7 +16,7 @@ import java.nio.charset.Charset;
 import java.security.SecureRandom;
 
 public class XPathEncryptStringFunc extends XPathFuncExpr {
-    public static final String NAME = "encrypt-string";
+    public static final String NAME = "encrypt";
     private static final int EXPECTED_ARG_COUNT = 3;
 
     public XPathEncryptStringFunc() {

--- a/src/main/java/org/javarosa/xpath/expr/XPathEncryptStringFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathEncryptStringFunc.java
@@ -1,0 +1,84 @@
+package org.javarosa.xpath.expr;
+
+
+import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.model.instance.DataInstance;
+import org.javarosa.xpath.XPathException;
+import org.javarosa.xpath.parser.XPathSyntaxException;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+public class XPathEncryptStringFunc extends XPathFuncExpr {
+    public static final String NAME = "encrypt-string";
+    private static final int EXPECTED_ARG_COUNT = 3;
+
+    public XPathEncryptStringFunc() {
+        name = NAME;
+        expectedArgCount = EXPECTED_ARG_COUNT;
+    }
+
+    public XPathEncryptStringFunc(XPathExpression[] args) throws XPathSyntaxException {
+        super(NAME, args, EXPECTED_ARG_COUNT, true);
+    }
+
+    @Override
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
+        return encryptString(evaluatedArgs[0], evaluatedArgs[1], evaluatedArgs[2]);
+    }
+
+    /**
+     * Encrypt a message with the given algorithm and key.
+     *
+     * @param message    a message to be encrypted
+     * @param key        the key used for encryption
+     * @param algorithm  the encryption algorithm to use
+     */
+    private static String encryptString(Object o1, Object o2, Object o3) {
+        String message = FunctionUtils.toString(o1);
+        String key = FunctionUtils.toString(o2);
+        String algorithm = FunctionUtils.toString(o3);
+
+        final String ENCRYPT_ALGO = "AES/GCM/NoPadding";
+        final int TAG_LENGTH_BIT = 128;
+        final int IV_LENGTH_BYTE = 12;
+        final int KEY_LENGTH_BIT = 256;
+
+        if (!algorithm.equals("AES")) {
+            throw new XPathException("Unknown algorithm \"" + algorithm +
+                                     "\" for " + NAME);
+        }
+
+        Base64.Decoder keyDecoder = Base64.getUrlDecoder();
+        byte[] keyBytes = keyDecoder.decode(key);
+        if (8 * keyBytes.length != KEY_LENGTH_BIT) {
+            throw new XPathException("Key should be " + KEY_LENGTH_BIT +
+                                     " bits long, not " + 8 * keyBytes.length);
+        }
+        SecretKey secret = new SecretKeySpec(keyBytes, "AES");
+
+        byte[] iv = new byte[IV_LENGTH_BYTE];
+        new SecureRandom().nextBytes(iv);
+
+        try {
+            Cipher cipher = Cipher.getInstance(ENCRYPT_ALGO);
+            cipher.init(Cipher.ENCRYPT_MODE, secret, new GCMParameterSpec(TAG_LENGTH_BIT, iv));
+            byte[] encryptedMessage = cipher.doFinal(message.getBytes(StandardCharsets.UTF_8));
+            byte[] ivPlusMessage = ByteBuffer.allocate(iv.length + encryptedMessage.length)
+                .put(iv)
+                .put(encryptedMessage)
+                .array();
+            Base64.Encoder outputEncoder = Base64.getUrlEncoder();
+            return outputEncoder.encodeToString(ivPlusMessage);
+        } catch (Exception ex) {
+            throw new XPathException("Exception during encryption: " + ex);
+        }
+    }
+}

--- a/src/main/java/org/javarosa/xpath/expr/XPathEncryptStringFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathEncryptStringFunc.java
@@ -16,7 +16,7 @@ import java.nio.charset.Charset;
 import java.security.SecureRandom;
 
 public class XPathEncryptStringFunc extends XPathFuncExpr {
-    public static final String NAME = "encrypt";
+    public static final String NAME = "encrypt-string";
     private static final int EXPECTED_ARG_COUNT = 3;
 
     public XPathEncryptStringFunc() {
@@ -73,6 +73,11 @@ public class XPathEncryptStringFunc extends XPathFuncExpr {
             cipher.init(Cipher.ENCRYPT_MODE, secret);
             byte[] encryptedMessage = cipher.doFinal(message.getBytes(Charset.forName("UTF-8")));
             byte[] iv = cipher.getIV();
+            if (iv.length != IV_LENGTH_BYTE) {
+                throw new XPathException("Initialization vector should be " +
+                                         IV_LENGTH_BYTE + " bytes long, not " +
+                                         iv.length);
+            }
             byte[] ivPlusMessage = ByteBuffer.allocate(iv.length + encryptedMessage.length)
                 .put(iv)
                 .put(encryptedMessage)

--- a/src/main/java/org/javarosa/xpath/parser/ast/ASTNodeFunctionCall.java
+++ b/src/main/java/org/javarosa/xpath/parser/ast/ASTNodeFunctionCall.java
@@ -175,6 +175,8 @@ public class ASTNodeFunctionCall extends ASTNode {
                 return new XPathSleepFunc(args);
             case "index-of":
                 return new XPathIndexOfFunc(args);
+            case "encrypt-string":
+                return new XPathEncryptStringFunc(args);
             default:
                 return new XPathCustomRuntimeFunc(name, args);
         }

--- a/src/main/java/org/javarosa/xpath/parser/ast/ASTNodeFunctionCall.java
+++ b/src/main/java/org/javarosa/xpath/parser/ast/ASTNodeFunctionCall.java
@@ -175,7 +175,7 @@ public class ASTNodeFunctionCall extends ASTNode {
                 return new XPathSleepFunc(args);
             case "index-of":
                 return new XPathIndexOfFunc(args);
-            case "encrypt-string":
+            case "encrypt":
                 return new XPathEncryptStringFunc(args);
             default:
                 return new XPathCustomRuntimeFunc(name, args);

--- a/src/main/java/org/javarosa/xpath/parser/ast/ASTNodeFunctionCall.java
+++ b/src/main/java/org/javarosa/xpath/parser/ast/ASTNodeFunctionCall.java
@@ -175,7 +175,7 @@ public class ASTNodeFunctionCall extends ASTNode {
                 return new XPathSleepFunc(args);
             case "index-of":
                 return new XPathIndexOfFunc(args);
-            case "encrypt":
+            case "encrypt-string":
                 return new XPathEncryptStringFunc(args);
             default:
                 return new XPathCustomRuntimeFunc(name, args);

--- a/src/test/java/org/javarosa/xpath/test/XPathEvalTest.java
+++ b/src/test/java/org/javarosa/xpath/test/XPathEvalTest.java
@@ -793,7 +793,7 @@ public class XPathEvalTest {
         String keyString =
                 new String(Base64.getEncoder().encode(secretKey.getEncoded()), "UTF-8");
         try {
-            Object result = evalExpr("encrypt-string('" + message + "','" +
+            Object result = evalExpr("encrypt('" + message + "','" +
                                      keyString + "','" + algorithm + "')",
                                      null, ec);
             String resultString = FunctionUtils.toString(result);

--- a/src/test/java/org/javarosa/xpath/test/XPathEvalTest.java
+++ b/src/test/java/org/javarosa/xpath/test/XPathEvalTest.java
@@ -772,8 +772,7 @@ public class XPathEvalTest {
         bb.get(cipherText);
 
         Cipher cipher = Cipher.getInstance(ENCRYPT_ALGO);
-        cipher.init(Cipher.DECRYPT_MODE, secretKey,
-                    new GCMParameterSpec(TAG_LENGTH_BIT, iv));
+        cipher.init(Cipher.DECRYPT_MODE, secretKey, new GCMParameterSpec(TAG_LENGTH_BIT, iv));
         byte[] plainText = cipher.doFinal(cipherText);
         return new String(plainText, StandardCharsets.UTF_8);
     }
@@ -793,7 +792,6 @@ public class XPathEvalTest {
         // and check for the input message.
         String keyString =
                 new String(Base64.getEncoder().encode(secretKey.getEncoded()), "UTF-8");
-        System.out.println(keyString);
         try {
             Object result = evalExpr("encrypt-string('" + message + "','" +
                                      keyString + "','" + algorithm + "')",

--- a/src/test/java/org/javarosa/xpath/test/XPathEvalTest.java
+++ b/src/test/java/org/javarosa/xpath/test/XPathEvalTest.java
@@ -26,6 +26,14 @@ import org.javarosa.xpath.parser.XPathSyntaxException;
 import org.junit.Assert;
 import org.junit.Test;
 
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Base64;
 import java.util.Date;
 import java.util.TimeZone;
 import java.util.Vector;
@@ -74,6 +82,22 @@ public class XPathEvalTest {
         } catch (XPathException xpex) {
             assertExceptionExpected(exceptionExpected, expected, xpex);
         }
+    }
+
+    private Object evalExpr(String expr, FormInstance model,
+                            EvaluationContext ec) throws Exception {
+        XPathExpression xpe = null;
+        if (ec == null) {
+            ec = new EvaluationContext(model);
+        }
+
+        xpe = XPathParseTool.parseXPath(expr);
+
+        if (xpe == null) {
+            fail("Null expression or syntax error " + expr);
+        }
+
+        return FunctionUtils.unpack(xpe.eval(model, ec));
     }
 
     private void assertExceptionExpected(boolean exceptionExpected, Object expected, Exception xpex) {
@@ -720,6 +744,91 @@ public class XPathEvalTest {
         });
 
         testEval("now()", null, ec, "pass");
+    }
+
+    // Utility methods for string encryption.
+    private SecretKey generateSecretKey(int keyLength) throws Exception {
+        KeyGenerator keyGen = KeyGenerator.getInstance("AES");
+        keyGen.init(keyLength, SecureRandom.getInstanceStrong());
+        return keyGen.generateKey();
+    }
+
+    private String extractAndDecodeMessage(String output, SecretKey secretKey)
+        throws Exception {
+        final String ENCRYPT_ALGO = "AES/GCM/NoPadding";
+        final int TAG_LENGTH_BIT = 128;
+        final int IV_LENGTH_BYTE = 12;
+
+        Base64.Decoder messageDecoder = Base64.getUrlDecoder();
+        byte[] messageBytes = messageDecoder.decode(output);
+
+        ByteBuffer bb = ByteBuffer.wrap(messageBytes);
+        byte[] iv = new byte[IV_LENGTH_BYTE];
+        bb.get(iv);
+
+        byte[] cipherText = new byte[bb.remaining()];
+        bb.get(cipherText);
+
+        Cipher cipher = Cipher.getInstance(ENCRYPT_ALGO);
+        cipher.init(Cipher.DECRYPT_MODE, secretKey,
+                    new GCMParameterSpec(TAG_LENGTH_BIT, iv));
+        byte[] plainText = cipher.doFinal(cipherText);
+        return new String(plainText, StandardCharsets.UTF_8);
+    }
+
+    public void encryptAndCompare(EvaluationContext ec, String algorithm,
+                                  int keyLength, String message,
+                                  Exception expectedException) {
+        SecretKey secretKey = null;
+        try {
+            secretKey = generateSecretKey(keyLength);
+        } catch(Exception ex) {
+            fail("Unexpected exception generating secret key");
+        }
+
+        // The encrypted output contains a random initialization vector, so
+        // we can't know in advance what it will be. Instead decrypt the output
+        // and check for the input message.
+        String keyString =
+            Base64.getUrlEncoder().encodeToString(secretKey.getEncoded());
+        try {
+            Object result = evalExpr("encrypt-string('" + message + "','" +
+                                     keyString + "','" + algorithm + "')",
+                                     null, ec);
+            String resultString = FunctionUtils.toString(result);
+            String decryptedMessage = extractAndDecodeMessage(resultString,
+                                                              secretKey);
+            if (!message.equals(decryptedMessage)) {
+                fail("Expected decrypted message " + message + ", got " +
+                     decryptedMessage);
+            }
+        } catch(Exception ex) {
+            assertExceptionExpected(expectedException != null,
+                                    expectedException, ex);
+            return;
+        }
+    }
+
+    @Test
+    public void testEncryptString() {
+        final int KEY_LENGTH_BIT = 256;
+        EvaluationContext ec = getFunctionHandlers();
+        // Valid inputs that should decrypt to themselves.
+        encryptAndCompare(ec, "AES", KEY_LENGTH_BIT, "49812057128", null);
+        encryptAndCompare(ec, "AES", KEY_LENGTH_BIT,
+                          "A short message to be encrypted", null);
+        encryptAndCompare(ec, "AES", KEY_LENGTH_BIT,
+                          "A longer message to be encrypted by the AES GCM " +
+                          "method, which will test that somewhat longer " +
+                          "messages can be correctly encrypted", null);
+
+        // Invalid inputs that should raise exceptions.
+        encryptAndCompare(ec, "DES", KEY_LENGTH_BIT,
+                          "A short message to be encrypted",
+                          new XPathException());
+        encryptAndCompare(ec, "AES", KEY_LENGTH_BIT/2,
+                          "A short message to be encrypted",
+                          new XPathException());
     }
 
     protected void addDataRef(FormInstance dm, String ref, IAnswerData data) {

--- a/src/test/java/org/javarosa/xpath/test/XPathEvalTest.java
+++ b/src/test/java/org/javarosa/xpath/test/XPathEvalTest.java
@@ -793,7 +793,7 @@ public class XPathEvalTest {
         String keyString =
                 new String(Base64.getEncoder().encode(secretKey.getEncoded()), "UTF-8");
         try {
-            Object result = evalExpr("encrypt('" + message + "','" +
+            Object result = evalExpr("encrypt-string('" + message + "','" +
                                      keyString + "','" + algorithm + "')",
                                      null, ec);
             String resultString = FunctionUtils.toString(result);


### PR DESCRIPTION
Here is a version of encrypt-string as an XPath function. It replaces my first attempt to put encryption in the formplayer using Beans.

Please see [this document](https://docs.google.com/document/d/1OljNDYf-Z9nARKn5ww-ZZf2tWUIknHoEVJ__9Oq7YIo/edit) for some background on this change and choices made in the implementation.

Essentially, this encryption function accepts a message string and an encoded secret key, performs AES encryption using the GCM mode and returns the encoded message along with an initialization vector needed to decode it. It is intended to allow other algorithms to be used in the future, but only AES is implemented for now and certain encryption options are hardcoded that the message receiver will need to accomodate.

The code is passing its unit tests, but I have not yet tested it with the form that @ctsims designed. That won't happen until tomorrow. @calellowitz @orangejenny, I'll be asking you for review, but I understand if you prefer to wait until I've tested this with a form.
