### PR TITLE
update meta

### DIFF
--- a/src/main/java/org/javarosa/core/services/storage/util/DummyIndexedStorageUtility.java
+++ b/src/main/java/org/javarosa/core/services/storage/util/DummyIndexedStorageUtility.java
@@ -262,7 +262,7 @@ public class DummyIndexedStorageUtility<T extends Persistable> implements IStora
     @Override
     public void update(int id, T e) {
         data.put(DataUtil.integer(id), e);
-        syncMeta();
+        addMeta(DataUtil.integer(id));
     }
 
     @Override

--- a/src/main/java/org/javarosa/core/services/storage/util/DummyIndexedStorageUtility.java
+++ b/src/main/java/org/javarosa/core/services/storage/util/DummyIndexedStorageUtility.java
@@ -283,29 +283,7 @@ public class DummyIndexedStorageUtility<T extends Persistable> implements IStora
 
         for (Enumeration en = data.keys(); en.hasMoreElements(); ) {
             Integer i = (Integer)en.nextElement();
-            Externalizable e = data.get(i);
-
-            if (e instanceof IMetaData) {
-                IMetaData m = (IMetaData)e;
-                for (Enumeration keys = meta.keys(); keys.hasMoreElements(); ) {
-                    String key = (String)keys.nextElement();
-
-                    Object value = m.getMetaData(key);
-                    if (value == null) {
-                        continue;
-                    }
-
-                    Hashtable<Object, Vector<Integer>> records = meta.get(key);
-
-                    if (!records.containsKey(value)) {
-                        records.put(value, new Vector<Integer>());
-                    }
-                    Vector<Integer> indices = records.get(value);
-                    if (!indices.contains(i)) {
-                        indices.add(i);
-                    }
-                }
-            }
+            addMeta(i);
         }
     }
 


### PR DESCRIPTION
I think this is safe, but am not completely certain. If it is, it certainly fixed the performance problems I had with large case lists, which is that `syncMeta` iterates over every case each time a new one was added, and that degraded relatively quickly. My understanding is that this should only fail if a case property is set from a value to `null`. I don't think that is possible. I think it can only go to an empty string, but it is also possible I am missing other failure conditions. I used the CLI compiled from this branch, and it works, but I did not go particularly deep.