### PR TITLE
Added auto_launch option for actions

### DIFF
--- a/src/cli/java/org/commcare/util/screen/EntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreen.java
@@ -73,35 +73,11 @@ public class EntityScreen extends CompoundScreenHost {
         this.full = full;
     }
 
-    public void init(SessionWrapper session) throws CommCareSessionException {
-        init(session, false);
-    }
+    public EntityScreen(boolean handleCaseIndex, boolean full, boolean allowAutoLaunch, SessionWrapper session) throws CommCareSessionException {
+        this.handleCaseIndex = handleCaseIndex;
+        this.full = full;
 
-    public void init(SessionWrapper session, boolean allowAutoLaunch) throws CommCareSessionException {
-        if (initialized) {
-            return;
-        }
-        SessionDatum datum = session.getNeededDatum();
-        if (!(datum instanceof EntityDatum)) {
-            throw new CommCareSessionException("Didn't find an entity select action where one is expected.");
-        }
-        mNeededDatum = (EntityDatum)datum;
-
-        this.mSession = session;
-        this.mPlatform = mSession.getPlatform();
-
-        String detailId = mNeededDatum.getShortDetail();
-        if (detailId == null) {
-            throw new CommCareSessionException("Can't handle entity selection with blank detail definition for datum " + mNeededDatum.getDataId());
-        }
-
-        mShortDetail = this.mPlatform.getDetail(detailId);
-
-        if (mShortDetail == null) {
-            throw new CommCareSessionException("Missing detail definition for: " + detailId);
-        }
-
-        evalContext = mSession.getEvaluationContext();
+        this.setSession(session);
 
         for (Action action : mShortDetail.getCustomActions(evalContext)) {
             if (action.isAutoLaunching()) {
@@ -115,6 +91,14 @@ public class EntityScreen extends CompoundScreenHost {
                 }
             }
         }
+    }
+
+    public void init(SessionWrapper session) throws CommCareSessionException {
+        if (initialized) {
+            return;
+        }
+
+        this.setSession(session);
 
         references = expandEntityReferenceSet(evalContext);
 
@@ -147,6 +131,30 @@ public class EntityScreen extends CompoundScreenHost {
             }
         }
         initialized = true;
+    }
+
+    private void setSession(SessionWrapper session) throws CommCareSessionException {
+        SessionDatum datum = session.getNeededDatum();
+        if (!(datum instanceof EntityDatum)) {
+            throw new CommCareSessionException("Didn't find an entity select action where one is expected.");
+        }
+        mNeededDatum = (EntityDatum)datum;
+
+        this.mSession = session;
+        this.mPlatform = mSession.getPlatform();
+
+        String detailId = mNeededDatum.getShortDetail();
+        if (detailId == null) {
+            throw new CommCareSessionException("Can't handle entity selection with blank detail definition for datum " + mNeededDatum.getDataId());
+        }
+
+        mShortDetail = this.mPlatform.getDetail(detailId);
+
+        if (mShortDetail == null) {
+            throw new CommCareSessionException("Missing detail definition for: " + detailId);
+        }
+
+        evalContext = mSession.getEvaluationContext();
     }
 
     private Vector<TreeReference> expandEntityReferenceSet(EvaluationContext context) {

--- a/src/cli/java/org/commcare/util/screen/EntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreen.java
@@ -74,6 +74,10 @@ public class EntityScreen extends CompoundScreenHost {
     }
 
     public void init(SessionWrapper session) throws CommCareSessionException {
+        init(session, false);
+    }
+
+    public void init(SessionWrapper session, boolean allowAutoLaunch) throws CommCareSessionException {
         if (initialized) {
             return;
         }
@@ -98,6 +102,19 @@ public class EntityScreen extends CompoundScreenHost {
         }
 
         evalContext = mSession.getEvaluationContext();
+
+        for (Action action : mShortDetail.getCustomActions(evalContext)) {
+            if (action.isAutoLaunching()) {
+                // Supply an empty case list so we can "select" from it later using getEntityFromID
+                mCurrentScreen = new EntityListSubscreen(mShortDetail, new Vector<TreeReference>(), evalContext, handleCaseIndex);
+                full = false;
+                if (allowAutoLaunch) {
+                    this.setPendingAction(action);
+                    this.updateSession(session);
+                    return;
+                }
+            }
+        }
 
         references = expandEntityReferenceSet(evalContext);
 
@@ -188,7 +205,11 @@ public class EntityScreen extends CompoundScreenHost {
     }
 
     public void setHighlightedEntity(String id) throws CommCareSessionException {
-        this.mCurrentSelection = referenceMap.get(id);
+        if (referenceMap == null) {
+            this.mCurrentSelection = mNeededDatum.getEntityFromID(evalContext, id);
+        } else {
+            this.mCurrentSelection = referenceMap.get(id);
+        }
         if (this.mCurrentSelection == null) {
             throw new CommCareSessionException("EntityScreen " + this.toString() + " could not select case " + id + "." +
                     " If this error persists please report a bug to CommCareHQ.");

--- a/src/main/java/org/commcare/suite/model/Action.java
+++ b/src/main/java/org/commcare/suite/model/Action.java
@@ -69,7 +69,7 @@ public class Action implements Externalizable {
     }
 
     public boolean isRelevant(EvaluationContext evalContext) {
-        if (relevantExpr == null) {
+        if (isAutoLaunching || relevantExpr == null) {
             return true;
         } else {
             String result = RemoteQuerySessionManager.evalXpathExpression(relevantExpr, evalContext);

--- a/src/main/java/org/commcare/suite/model/Action.java
+++ b/src/main/java/org/commcare/suite/model/Action.java
@@ -29,6 +29,7 @@ public class Action implements Externalizable {
     private Vector<StackOperation> stackOps;
     private XPathExpression relevantExpr;
     private String iconReferenceForActionBar;
+    private boolean isAutoLaunching;
 
     /**
      * Serialization only!!!
@@ -43,11 +44,12 @@ public class Action implements Externalizable {
      * operations set.
      */
     public Action(DisplayUnit display, Vector<StackOperation> stackOps,
-                  XPathExpression relevantExpr, String iconForActionBar) {
+                  XPathExpression relevantExpr, String iconForActionBar, boolean isAutoLaunching) {
         this.display = display;
         this.stackOps = stackOps;
         this.relevantExpr = relevantExpr;
         this.iconReferenceForActionBar = iconForActionBar == null ? "" : iconForActionBar;
+        this.isAutoLaunching = isAutoLaunching;
     }
 
     /**
@@ -75,6 +77,10 @@ public class Action implements Externalizable {
         }
     }
 
+    public boolean isAutoLaunching() {
+        return isAutoLaunching;
+    }
+
     public boolean hasActionBarIcon() {
         return !"".equals(iconReferenceForActionBar);
     }
@@ -87,6 +93,7 @@ public class Action implements Externalizable {
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         display = (DisplayUnit)ExtUtil.read(in, DisplayUnit.class, pf);
         stackOps = (Vector<StackOperation>)ExtUtil.read(in, new ExtWrapList(StackOperation.class), pf);
+        isAutoLaunching = ExtUtil.readBool(in);
         relevantExpr = (XPathExpression)ExtUtil.read(in, new ExtWrapNullable(new ExtWrapTagged()), pf);
         iconReferenceForActionBar = ExtUtil.readString(in);
     }
@@ -95,6 +102,7 @@ public class Action implements Externalizable {
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.write(out, display);
         ExtUtil.write(out, new ExtWrapList(stackOps));
+        ExtUtil.writeBool(out, isAutoLaunching);
         ExtUtil.write(out, new ExtWrapNullable(relevantExpr == null ? null : new ExtWrapTagged(relevantExpr)));
         ExtUtil.writeString(out, iconReferenceForActionBar);
     }

--- a/src/main/java/org/commcare/xml/ActionParser.java
+++ b/src/main/java/org/commcare/xml/ActionParser.java
@@ -36,6 +36,7 @@ public class ActionParser extends CommCareElementParser<Action> {
         Vector<StackOperation> stackOps = new Vector<>();
 
         XPathExpression relevantExpr = parseRelevancyExpr();
+        boolean isAutoLaunching = "true".equals(parser.getAttributeValue(null, "auto_launch"));
 
         while (nextTagInBlock(NAME_ACTION)) {
             if (parser.getName().equals("display")) {
@@ -54,7 +55,7 @@ public class ActionParser extends CommCareElementParser<Action> {
         if (stackOps.size() == 0) {
             throw new InvalidStructureException("An <action> block must define at least one stack operation", parser);
         }
-        return new Action(display, stackOps, relevantExpr, iconForActionBarPlacement);
+        return new Action(display, stackOps, relevantExpr, iconForActionBarPlacement, isAutoLaunching);
     }
 
     private XPathExpression parseRelevancyExpr() throws InvalidStructureException {

--- a/src/test/java/org/commcare/backend/session/test/SessionStackTests.java
+++ b/src/test/java/org/commcare/backend/session/test/SessionStackTests.java
@@ -309,8 +309,11 @@ public class SessionStackTests {
 
         Action actionToInspect = actions.get(1);
         assertTrue(actionToInspect.hasActionBarIcon());
-        assertEquals("Jump to Menu 2 Form 1", actionToInspect.getDisplay().getText().evaluate(ec));
+        assertEquals("Jump to Menu 2 Form 1, with icon", actionToInspect.getDisplay().getText().evaluate(ec));
         assertEquals(1, actionToInspect.getStackOperations().size());
+        assertFalse(actionToInspect.isAutoLaunching());
+
+        assertTrue(actions.get(0).isAutoLaunching());
     }
 
     private static void assertInstanceMissing(SessionWrapper session, String xpath)

--- a/src/test/resources/complex_stack/suite.xml
+++ b/src/test/resources/complex_stack/suite.xml
@@ -60,7 +60,7 @@
         <title>
             <text>Case List</text>
         </title>
-        <action>
+        <action auto_launch="true">
             <display>
                 <text>Jump to Menu 2 Form 1</text>
             </display>
@@ -73,7 +73,7 @@
         </action>
         <action relevant="true()" action-bar-icon="jr://fake-image-ref">
             <display>
-                <text>Jump to Menu 2 Form 1</text>
+                <text>Jump to Menu 2 Form 1, with icon</text>
             </display>
             <stack>
                 <push>
@@ -84,7 +84,7 @@
         </action>
         <action relevant="false()">
             <display>
-                <text>Jump to Menu 2 Form 1</text>
+                <text>Jump to Menu 2 Form 1, irrelevant</text>
             </display>
             <stack>
                 <push>


### PR DESCRIPTION
Support for https://github.com/dimagi/formplayer/pull/783

This uses the new "minimal" entity screen code to avoid running all of the usual entity list logic. Since minimal entities don't allow for selecting a case later on, this uses `getEntityFromID` to select the case (see commcare-core PR).

Merging into `formplayer` instead of `master` since mobile will ignore this attribute.