### PR TITLE
Use SecureRandom instead of SecureRandom.getInstanceStrong for test

### DIFF
--- a/src/test/java/org/javarosa/xpath/test/XPathEvalTest.java
+++ b/src/test/java/org/javarosa/xpath/test/XPathEvalTest.java
@@ -37,7 +37,6 @@ import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.Base64;
 import java.util.Date;
-import java.util.TimeZone;
 import java.util.Vector;
 
 import static org.junit.Assert.fail;
@@ -751,7 +750,7 @@ public class XPathEvalTest {
     // Utility methods for string encryption.
     private SecretKey generateSecretKey(int keyLength) throws Exception {
         KeyGenerator keyGen = KeyGenerator.getInstance("AES");
-        keyGen.init(keyLength, SecureRandom.getInstanceStrong());
+        keyGen.init(keyLength, new SecureRandom());
         return keyGen.generateKey();
     }
 


### PR DESCRIPTION
`keyGen.generateKey()` was taking huge amount of time in jenkins, causing the tests to run for ~ 30 minutes. 
![Screenshot 2020-11-19 at 4 16 20 PM](https://user-images.githubusercontent.com/29516995/99656172-96db4680-2a82-11eb-98b1-c54437a92bfe.png)

This PR will make use of `SecretKeySpec` to generate the `SecretKey` for the tests.  

[Jira](https://dimagi-dev.atlassian.net/browse/SAAS-11537)