### PR TITLE
Case claim: stop treating no results as an error

### DIFF
--- a/src/cli/java/org/commcare/util/screen/QueryScreen.java
+++ b/src/cli/java/org/commcare/util/screen/QueryScreen.java
@@ -104,9 +104,6 @@ public class QueryScreen extends Screen {
         if (instanceOrError.first == null) {
             currentMessage = "Query response format error: " + instanceOrError.second;
             return false;
-        } else if (isResponseEmpty(instanceOrError.first)) {
-            currentMessage = "Query successful but returned no results.";
-            return false;
         } else {
             sessionWrapper.setQueryDatum(instanceOrError.first);
             return true;


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/USH-471

Without this, you get the normal empty case list experience:

![Screen Shot 2020-11-20 at 12 09 35 PM](https://user-images.githubusercontent.com/1486591/99828712-4ff45c00-2b29-11eb-8ba4-da4c0477fc7f.png)

This doesn't affect mobile, which checks if the response is empty [here](https://github.com/dimagi/commcare-android/blob/30850534d42cf3ea80e180a7e5428364a7221c8b/app/src/org/commcare/activities/QueryRequestActivity.java#L384-L385).