### PR TITLE
index state category

### DIFF
--- a/src/main/java/org/commcare/cases/instance/CaseChildElement.java
+++ b/src/main/java/org/commcare/cases/instance/CaseChildElement.java
@@ -121,11 +121,11 @@ public class CaseChildElement extends StorageBackedChildElement<Case> implements
         }
 
         if (c.getCategory() != null) {
-            cacheBuilder.setAttribute(null, "category", "");
+            cacheBuilder.setAttribute(null, "category", c.getCategory());
         }
 
         if (c.getState() != null) {
-            cacheBuilder.setAttribute(null, "state", "");
+            cacheBuilder.setAttribute(null, "state", c.getState());
         }
 
 

--- a/src/main/java/org/commcare/cases/instance/CaseChildElement.java
+++ b/src/main/java/org/commcare/cases/instance/CaseChildElement.java
@@ -44,6 +44,8 @@ public class CaseChildElement extends StorageBackedChildElement<Case> implements
         empty.setAttribute(null, "case_type", "");
         empty.setAttribute(null, "status", "");
         empty.setAttribute(null, "external_id", "");
+        empty.setAttribute(null, "category", "");
+        empty.setAttribute(null, "state", "");
 
         TreeElement scratch = new TreeElement("case_name");
         scratch.setAnswer(null);
@@ -117,6 +119,15 @@ public class CaseChildElement extends StorageBackedChildElement<Case> implements
         if (c.getExternalId() != null) {
             cacheBuilder.setAttribute(null, "external_id", c.getExternalId());
         }
+
+        if (c.getCategory() != null) {
+            cacheBuilder.setAttribute(null, "category", "");
+        }
+
+        if (c.getState() != null) {
+            cacheBuilder.setAttribute(null, "state", "");
+        }
+
 
         final boolean[] done = new boolean[]{false};
 

--- a/src/main/java/org/commcare/cases/instance/CaseInstanceTreeElement.java
+++ b/src/main/java/org/commcare/cases/instance/CaseInstanceTreeElement.java
@@ -27,6 +27,8 @@ public class CaseInstanceTreeElement extends StorageInstanceTreeElement<Case, Ca
     private final static XPathPathExpr CASE_INDEX_EXPR = XPathReference.getPathExpr("index/*");
     private final static XPathPathExpr OWNER_ID_EXPR = XPathReference.getPathExpr("@owner_id");
     private final static XPathPathExpr EXTERNAL_ID_EXPR = XPathReference.getPathExpr("@external_id");
+    private final static XPathPathExpr CATEGORY_EXPR = XPathReference.getPathExpr("category");
+    private final static XPathPathExpr STATE_EXPR = XPathReference.getPathExpr("state");
     private final static XPathPathExpr PATIENT_TYPE_EXPR = XPathReference.getPathExpr("patient_type");
     private final static XPathPathExpr CURRENT_STATUS_EXPR = XPathReference.getPathExpr("current_status");
 
@@ -72,8 +74,10 @@ public class CaseInstanceTreeElement extends StorageInstanceTreeElement<Case, Ca
         indices.put(CASE_INDEX_EXPR, Case.INDEX_CASE_INDEX_PRE);
         indices.put(OWNER_ID_EXPR, Case.INDEX_OWNER_ID);
         indices.put(EXTERNAL_ID_EXPR, Case.INDEX_EXTERNAL_ID);
-        indices.put(PATIENT_TYPE_EXPR, Case.INDEX_PATIENT_TYPE);
-        indices.put(CURRENT_STATUS_EXPR, Case.INDEX_CURRENT_STATUS);
+        indices.put(CATEGORY_EXPR, Case.INDEX_CATEGORY);
+        indices.put(STATE_EXPR, Case.INDEX_STATE);
+        indices.put(PATIENT_TYPE_EXPR, Case.INDEX_CATEGORY);
+        indices.put(CURRENT_STATUS_EXPR, Case.INDEX_STATE);
 
         return indices;
     }

--- a/src/main/java/org/commcare/cases/instance/CaseInstanceTreeElement.java
+++ b/src/main/java/org/commcare/cases/instance/CaseInstanceTreeElement.java
@@ -27,6 +27,8 @@ public class CaseInstanceTreeElement extends StorageInstanceTreeElement<Case, Ca
     private final static XPathPathExpr CASE_INDEX_EXPR = XPathReference.getPathExpr("index/*");
     private final static XPathPathExpr OWNER_ID_EXPR = XPathReference.getPathExpr("@owner_id");
     private final static XPathPathExpr EXTERNAL_ID_EXPR = XPathReference.getPathExpr("@external_id");
+    private final static XPathPathExpr PATIENT_TYPE_EXPR = XPathReference.getPathExpr("patient_type");
+    private final static XPathPathExpr CURRENT_STATUS_EXPR = XPathReference.getPathExpr("current_status");
 
     public CaseInstanceTreeElement(AbstractTreeElement instanceRoot,
                                    IStorageUtilityIndexed<Case> storage) {
@@ -70,6 +72,8 @@ public class CaseInstanceTreeElement extends StorageInstanceTreeElement<Case, Ca
         indices.put(CASE_INDEX_EXPR, Case.INDEX_CASE_INDEX_PRE);
         indices.put(OWNER_ID_EXPR, Case.INDEX_OWNER_ID);
         indices.put(EXTERNAL_ID_EXPR, Case.INDEX_EXTERNAL_ID);
+        indices.put(PATIENT_TYPE_EXPR, Case.INDEX_PATIENT_TYPE);
+        indices.put(CURRENT_STATUS_EXPR, Case.INDEX_CURRENT_STATUS);
 
         return indices;
     }

--- a/src/main/java/org/commcare/cases/instance/CaseInstanceTreeElement.java
+++ b/src/main/java/org/commcare/cases/instance/CaseInstanceTreeElement.java
@@ -27,10 +27,8 @@ public class CaseInstanceTreeElement extends StorageInstanceTreeElement<Case, Ca
     private final static XPathPathExpr CASE_INDEX_EXPR = XPathReference.getPathExpr("index/*");
     private final static XPathPathExpr OWNER_ID_EXPR = XPathReference.getPathExpr("@owner_id");
     private final static XPathPathExpr EXTERNAL_ID_EXPR = XPathReference.getPathExpr("@external_id");
-    private final static XPathPathExpr CATEGORY_EXPR = XPathReference.getPathExpr("category");
-    private final static XPathPathExpr STATE_EXPR = XPathReference.getPathExpr("state");
-    private final static XPathPathExpr PATIENT_TYPE_EXPR = XPathReference.getPathExpr("patient_type");
-    private final static XPathPathExpr CURRENT_STATUS_EXPR = XPathReference.getPathExpr("current_status");
+    private final static XPathPathExpr CATEGORY_EXPR = XPathReference.getPathExpr("@category");
+    private final static XPathPathExpr STATE_EXPR = XPathReference.getPathExpr("@state");
 
     public CaseInstanceTreeElement(AbstractTreeElement instanceRoot,
                                    IStorageUtilityIndexed<Case> storage) {
@@ -76,8 +74,6 @@ public class CaseInstanceTreeElement extends StorageInstanceTreeElement<Case, Ca
         indices.put(EXTERNAL_ID_EXPR, Case.INDEX_EXTERNAL_ID);
         indices.put(CATEGORY_EXPR, Case.INDEX_CATEGORY);
         indices.put(STATE_EXPR, Case.INDEX_STATE);
-        indices.put(PATIENT_TYPE_EXPR, Case.INDEX_CATEGORY);
-        indices.put(CURRENT_STATUS_EXPR, Case.INDEX_STATE);
 
         return indices;
     }

--- a/src/main/java/org/commcare/cases/model/Case.java
+++ b/src/main/java/org/commcare/cases/model/Case.java
@@ -30,6 +30,8 @@ public class Case implements Persistable, IMetaData {
     public static final String EXTERNAL_ID_KEY = "external_id";
     public static final String CATEGORY_KEY = "category";
     public static final String STATE_KEY = "state";
+    public static final String PATIENT_TYPE_KEY = "patient_type";
+    public static final String CURRENT_STATUS_KEY = "current_status";
     public static final String STORAGE_KEY = "CASE";
 
     public static final String INDEX_CASE_ID = "case-id";
@@ -123,7 +125,11 @@ public class Case implements Persistable, IMetaData {
     }
 
     public String getCategory() {
-        return (String)data.get(CATEGORY_KEY);
+        String category = (String)data.get(CATEGORY_KEY);
+        if (category == null) {
+            category = (String)data.get(PATIENT_TYPE_KEY);
+        }
+        return category;
     }
 
     public void setCategory(String id) {
@@ -131,7 +137,11 @@ public class Case implements Persistable, IMetaData {
     }
 
     public String getState() {
-        return (String)data.get(STATE_KEY);
+        String state = (String)data.get(STATE_KEY);
+        if (state == null) {
+            state = (String)data.get(CURRENT_STATUS_KEY);
+        }
+        return state;
     }
 
     public void setState(String id) {

--- a/src/main/java/org/commcare/cases/model/Case.java
+++ b/src/main/java/org/commcare/cases/model/Case.java
@@ -30,8 +30,12 @@ public class Case implements Persistable, IMetaData {
     public static final String EXTERNAL_ID_KEY = "external_id";
     public static final String CATEGORY_KEY = "category";
     public static final String STATE_KEY = "state";
+
+    // Allowed as alias for preferred property category
     public static final String PATIENT_TYPE_KEY = "patient_type";
+    // Allowed as alias for preferred property state
     public static final String CURRENT_STATUS_KEY = "current_status";
+
     public static final String STORAGE_KEY = "CASE";
 
     public static final String INDEX_CASE_ID = "case-id";

--- a/src/main/java/org/commcare/cases/model/Case.java
+++ b/src/main/java/org/commcare/cases/model/Case.java
@@ -28,8 +28,8 @@ import java.util.Vector;
 public class Case implements Persistable, IMetaData {
     public static final String USER_ID_KEY = "userid";
     public static final String EXTERNAL_ID_KEY = "external_id";
-    public static final String PATIENT_TYPE_KEY = "patient_type";
-    public static final String CURRENT_STATUS_KEY = "currrent_status";
+    public static final String CATEGORY_KEY = "category";
+    public static final String STATE_KEY = "state";
     public static final String STORAGE_KEY = "CASE";
 
     public static final String INDEX_CASE_ID = "case-id";
@@ -38,8 +38,8 @@ public class Case implements Persistable, IMetaData {
     public static final String INDEX_CASE_INDEX_PRE = "case-in-";
     public static final String INDEX_OWNER_ID = "owner-id";
     public static final String INDEX_EXTERNAL_ID = "external-id";
-    public static final String INDEX_PATIENT_TYPE = "patient-type";
-    public static final String INDEX_CURRENT_STATUS = "current-status";
+    public static final String INDEX_CATEGORY = "category";
+    public static final String INDEX_STATE = "state";
 
     private static final String ATTACHMENT_PREFIX = "attachmentdata";
 
@@ -122,20 +122,20 @@ public class Case implements Persistable, IMetaData {
         data.put(EXTERNAL_ID_KEY, id);
     }
 
-    public String getPatientType() {
-        return (String)data.get(PATIENT_TYPE_KEY);
+    public String getCategory() {
+        return (String)data.get(CATEGORY_KEY);
     }
 
-    public void setPatientType(String id) {
-        data.put(PATIENT_TYPE_KEY, id);
+    public void setCategory(String id) {
+        data.put(CATEGORY_KEY, id);
     }
 
-    public String getCurrentStatus() {
-        return (String)data.get(CURRENT_STATUS_KEY);
+    public String getState() {
+        return (String)data.get(STATE_KEY);
     }
 
-    public void setCurrentStatus(String id) {
-        data.put(CURRENT_STATUS_KEY, id);
+    public void setState(String id) {
+        data.put(STATE_KEY, id);
     }
 
     public void setCaseId(String id) {
@@ -231,12 +231,12 @@ public class Case implements Persistable, IMetaData {
         } else if (fieldName.equals(INDEX_EXTERNAL_ID)) {
             String externalId = getExternalId();
             return externalId == null ? "" : externalId;
-        } else if (fieldName.equals(INDEX_PATIENT_TYPE)) {
-            String patientType = getPatientType();
-            return patientType == null ? "" : patientType;
-        } else if (fieldName.equals(INDEX_CURRENT_STATUS)) {
-            String currentStatus = getCurrentStatus();
-            return currentStatus == null ? "" : currentStatus;
+        } else if (fieldName.equals(INDEX_CATEGORY)) {
+            String category = getCategory();
+            return category == null ? "" : category;
+        } else if (fieldName.equals(INDEX_STATE)) {
+            String state = getState();
+            return state == null ? "" : state;
         } else {
             throw new IllegalArgumentException("No metadata field " + fieldName + " in the case storage system");
         }
@@ -244,7 +244,7 @@ public class Case implements Persistable, IMetaData {
 
     @Override
     public String[] getMetaDataFields() {
-        return new String[]{INDEX_CASE_ID, INDEX_CASE_TYPE, INDEX_CASE_STATUS, INDEX_OWNER_ID, INDEX_EXTERNAL_ID, INDEX_PATIENT_TYPE, INDEX_CURRENT_STATUS};
+        return new String[]{INDEX_CASE_ID, INDEX_CASE_TYPE, INDEX_CASE_STATUS, INDEX_OWNER_ID, INDEX_EXTERNAL_ID, INDEX_CATEGORY, INDEX_STATE};
     }
 
     /**

--- a/src/main/java/org/commcare/cases/model/Case.java
+++ b/src/main/java/org/commcare/cases/model/Case.java
@@ -28,6 +28,8 @@ import java.util.Vector;
 public class Case implements Persistable, IMetaData {
     public static final String USER_ID_KEY = "userid";
     public static final String EXTERNAL_ID_KEY = "external_id";
+    public static final String PATIENT_TYPE_KEY = "patient_type";
+    public static final String CURRENT_STATUS_KEY = "currrent_status";
     public static final String STORAGE_KEY = "CASE";
 
     public static final String INDEX_CASE_ID = "case-id";
@@ -36,6 +38,8 @@ public class Case implements Persistable, IMetaData {
     public static final String INDEX_CASE_INDEX_PRE = "case-in-";
     public static final String INDEX_OWNER_ID = "owner-id";
     public static final String INDEX_EXTERNAL_ID = "external-id";
+    public static final String INDEX_PATIENT_TYPE = "patient-type";
+    public static final String INDEX_CURRENT_STATUS = "current-status";
 
     private static final String ATTACHMENT_PREFIX = "attachmentdata";
 
@@ -116,6 +120,22 @@ public class Case implements Persistable, IMetaData {
 
     public void setExternalId(String id) {
         data.put(EXTERNAL_ID_KEY, id);
+    }
+
+    public String getPatientType() {
+        return (String)data.get(PATIENT_TYPE_KEY);
+    }
+
+    public void setPatientType(String id) {
+        data.put(PATIENT_TYPE_KEY, id);
+    }
+
+    public String getCurrentStatus() {
+        return (String)data.get(CURRENT_STATUS_KEY);
+    }
+
+    public void setCurrentStatus(String id) {
+        data.put(CURRENT_STATUS_KEY, id);
     }
 
     public void setCaseId(String id) {
@@ -211,6 +231,12 @@ public class Case implements Persistable, IMetaData {
         } else if (fieldName.equals(INDEX_EXTERNAL_ID)) {
             String externalId = getExternalId();
             return externalId == null ? "" : externalId;
+        } else if (fieldName.equals(INDEX_PATIENT_TYPE)) {
+            String patientType = getPatientType();
+            return patientType == null ? "" : patientType;
+        } else if (fieldName.equals(INDEX_CURRENT_STATUS)) {
+            String currentStatus = getCurrentStatus();
+            return currentStatus == null ? "" : currentStatus;
         } else {
             throw new IllegalArgumentException("No metadata field " + fieldName + " in the case storage system");
         }
@@ -218,7 +244,7 @@ public class Case implements Persistable, IMetaData {
 
     @Override
     public String[] getMetaDataFields() {
-        return new String[]{INDEX_CASE_ID, INDEX_CASE_TYPE, INDEX_CASE_STATUS, INDEX_OWNER_ID, INDEX_EXTERNAL_ID};
+        return new String[]{INDEX_CASE_ID, INDEX_CASE_TYPE, INDEX_CASE_STATUS, INDEX_OWNER_ID, INDEX_EXTERNAL_ID, INDEX_PATIENT_TYPE, INDEX_CURRENT_STATUS};
     }
 
     /**

--- a/src/main/java/org/commcare/cases/query/NegativeIndexedValueLookup.java
+++ b/src/main/java/org/commcare/cases/query/NegativeIndexedValueLookup.java
@@ -1,0 +1,27 @@
+package org.commcare.cases.query;
+
+/**
+ *
+ * A negative indexed value lookup is a singular key/value comparison where the key being checked is
+ * indexed by the current platform
+ *
+ * IE:
+ *
+ * index != 'a'
+ *
+ * Created by cellowitz on 11/23/2020.
+ */
+
+public class NegativeIndexedValueLookup implements PredicateProfile {
+    public final String key;
+    public final Object value;
+
+    public NegativeIndexedValueLookup(String key, Object value ) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getKey() {
+        return key;
+    }
+}

--- a/src/main/java/org/commcare/cases/util/StorageBackedTreeRoot.java
+++ b/src/main/java/org/commcare/cases/util/StorageBackedTreeRoot.java
@@ -150,11 +150,13 @@ public abstract class StorageBackedTreeRoot<T extends AbstractTreeElement> imple
                             PredicateProfile lookup;
                             if (((XPathEqExpr)xpe).op == XPathEqExpr.EQ) {
                                 lookup = new IndexedValueLookup(filterIndex, o);
-                            } else {
+                                optimizations.add(lookup);
+                                continue predicate;
+                            } else if (((XPathEqExpr)xpe).op == XPathEqExpr.NEQ) {
                                 lookup = new NegativeIndexedValueLookup(filterIndex, o);
+                                optimizations.add(lookup);
+                                continue predicate;
                             }
-                            optimizations.add(lookup);
-                            continue predicate;
                         }
                     }
                 }
@@ -329,9 +331,11 @@ public abstract class StorageBackedTreeRoot<T extends AbstractTreeElement> imple
         String[] valuesArray = valuesToMatch.toArray(new String[valuesToMatch.size()]);
         String[] inverseNames = namesToInverseMatch.toArray(new String[namesToInverseMatch.size()]);
         String[] inverseValues = valuesToInverseMatch.toArray(new String[valuesToInverseMatch.size()]);
-        mMostRecentBatchFetch = new String[2][];
+        mMostRecentBatchFetch = new String[4][];
         mMostRecentBatchFetch[0] = namesArray;
         mMostRecentBatchFetch[1] = valuesArray;
+        mMostRecentBatchFetch[2] = inverseNames;
+        mMostRecentBatchFetch[3] = inverseValues;
 
         String storageTreeName = this.getStorageCacheName();
 

--- a/src/main/java/org/commcare/cases/util/StorageBackedTreeRoot.java
+++ b/src/main/java/org/commcare/cases/util/StorageBackedTreeRoot.java
@@ -317,7 +317,7 @@ public abstract class StorageBackedTreeRoot<T extends AbstractTreeElement> imple
                 namesToMatch.add(name);
                 valuesToMatch.add(value);
                 operator = "=";
-            } else {
+            } else if (profiles.elementAt(i) instanceof NegativeIndexedValueLookup) {
                 name = profiles.elementAt(i).getKey();
                 value = (String)(((NegativeIndexedValueLookup)profiles.elementAt(i)).value);
                 namesToInverseMatch.add(name);

--- a/src/main/java/org/commcare/cases/util/StorageBackedTreeRoot.java
+++ b/src/main/java/org/commcare/cases/util/StorageBackedTreeRoot.java
@@ -308,9 +308,9 @@ public abstract class StorageBackedTreeRoot<T extends AbstractTreeElement> imple
         String keyDescription ="";
 
         for (int i = numKeysToProcess - 1; i >= 0; i--) {
-            String name;
-            String value;
-            String operator;
+            String name = "";
+            String value = "";
+            String operator = "";
             if (profiles.elementAt(i) instanceof IndexedValueLookup) {
                 name = profiles.elementAt(i).getKey();
                 value = (String)(((IndexedValueLookup)profiles.elementAt(i)).value);

--- a/src/main/java/org/commcare/cases/util/StorageBackedTreeRoot.java
+++ b/src/main/java/org/commcare/cases/util/StorageBackedTreeRoot.java
@@ -3,6 +3,7 @@ package org.commcare.cases.util;
 import org.commcare.cases.query.*;
 import org.commcare.cases.query.IndexedSetMemberLookup;
 import org.commcare.cases.query.IndexedValueLookup;
+import org.commcare.cases.query.NegativeIndexedValueLookup;
 import org.commcare.cases.query.PredicateProfile;
 import org.commcare.cases.query.handlers.BasicStorageBackedCachingQueryHandler;
 import org.commcare.modern.engine.cases.RecordSetResultCache;
@@ -134,7 +135,7 @@ public abstract class StorageBackedTreeRoot<T extends AbstractTreeElement> imple
         for (XPathExpression xpe : predicates) {
             //what we want here is a static evaluation of the expression to see if it consists of evaluating
             //something we index with something static.
-            if (xpe instanceof XPathEqExpr && ((XPathEqExpr)xpe).op == XPathEqExpr.EQ) {
+            if (xpe instanceof XPathEqExpr) {
                 XPathExpression left = ((XPathEqExpr)xpe).a;
                 if (left instanceof XPathPathExpr) {
                     for (Enumeration en = indices.keys(); en.hasMoreElements(); ) {
@@ -146,8 +147,13 @@ public abstract class StorageBackedTreeRoot<T extends AbstractTreeElement> imple
                             //sure the best way to do that....? Maybe tell the evaluation context to skip out here if it detects a request
                             //to resolve in a certain area?
                             Object o = FunctionUtils.unpack(((XPathEqExpr)xpe).b.eval(evalContext));
-                            optimizations.addElement(new IndexedValueLookup(filterIndex, o));
-
+                            PredicateProfile lookup;
+                            if (((XPathEqExpr)xpe).op == XPathEqExpr.EQ) {
+                                lookup = new IndexedValueLookup(filterIndex, o);
+                            } else {
+                                lookup = new NegativeIndexedValueLookup(filterIndex, o);
+                            }
+                            optimizations.add(lookup);
                             continue predicate;
                         }
                     }
@@ -291,23 +297,41 @@ public abstract class StorageBackedTreeRoot<T extends AbstractTreeElement> imple
         }
 
 
-        String[] namesToMatch = new String[numKeysToProcess];
-        String[] valuesToMatch = new String[numKeysToProcess];
+        Vector<String> namesToMatch = new Vector<>();
+        Vector<String> valuesToMatch = new Vector<>();
+        Vector<String> namesToInverseMatch = new Vector<>();
+        Vector<String> valuesToInverseMatch = new Vector<>();
 
         String cacheKey = "";
         String keyDescription ="";
 
         for (int i = numKeysToProcess - 1; i >= 0; i--) {
-            namesToMatch[i] = profiles.elementAt(i).getKey();
-            valuesToMatch[i] = (String)
-                    (((IndexedValueLookup)profiles.elementAt(i)).value);
-
-            cacheKey += "|" + namesToMatch[i] + "=" + valuesToMatch[i];
-            keyDescription += namesToMatch[i] + "|";
+            String name;
+            String value;
+            String operator;
+            if (profiles.elementAt(i) instanceof IndexedValueLookup) {
+                name = profiles.elementAt(i).getKey();
+                value = (String)(((IndexedValueLookup)profiles.elementAt(i)).value);
+                namesToMatch.add(name);
+                valuesToMatch.add(value);
+                operator = "=";
+            } else {
+                name = profiles.elementAt(i).getKey();
+                value = (String)(((NegativeIndexedValueLookup)profiles.elementAt(i)).value);
+                namesToInverseMatch.add(name);
+                valuesToInverseMatch.add(value);
+                operator = "!=";                
+            }
+            cacheKey += "|" + name + operator + value;
+            keyDescription += name + "|";
         }
+        String[] namesArray = namesToMatch.toArray(new String[namesToMatch.size()]);
+        String[] valuesArray = valuesToMatch.toArray(new String[valuesToMatch.size()]);
+        String[] inverseNames = namesToInverseMatch.toArray(new String[namesToInverseMatch.size()]);
+        String[] inverseValues = valuesToInverseMatch.toArray(new String[valuesToInverseMatch.size()]);
         mMostRecentBatchFetch = new String[2][];
-        mMostRecentBatchFetch[0] = namesToMatch;
-        mMostRecentBatchFetch[1] = valuesToMatch;
+        mMostRecentBatchFetch[0] = namesArray;
+        mMostRecentBatchFetch[1] = valuesArray;
 
         String storageTreeName = this.getStorageCacheName();
 
@@ -317,7 +341,7 @@ public abstract class StorageBackedTreeRoot<T extends AbstractTreeElement> imple
         } else {
             EvaluationTrace trace = new EvaluationTrace(String.format("Storage [%s] Key Lookup [%s]", storageTreeName, keyDescription));
             ids = new LinkedHashSet<>();
-            storage.getIDsForValues(namesToMatch, valuesToMatch, ids);
+            storage.getIDsForValues(namesArray, valuesArray, inverseNames, inverseValues, ids);
             trace.setOutcome("Results: " + ids.size());
             currentQueryContext.reportTrace(trace);
 
@@ -350,7 +374,8 @@ public abstract class StorageBackedTreeRoot<T extends AbstractTreeElement> imple
         //Otherwise see how many of these we can bulk process
         for (int i = 0; i < profiles.size(); ++i) {
             //If the current key isn't an indexedvalue lookup, we can't process in this step
-            if (!(profiles.elementAt(i) instanceof IndexedValueLookup)) {
+            if (!(profiles.elementAt(i) instanceof IndexedValueLookup ||
+                  profiles.elementAt(i) instanceof NegativeIndexedValueLookup)) {
                 break;
             }
 

--- a/src/main/java/org/commcare/modern/database/DatabaseHelper.java
+++ b/src/main/java/org/commcare/modern/database/DatabaseHelper.java
@@ -34,6 +34,20 @@ public class DatabaseHelper {
     public static Pair<String, String[]> createWhere(String[] fieldNames, Object[] values,
                                                      EncryptedModel em, Persistable p)
             throws IllegalArgumentException {
+        return createWhere(fieldNames, values, null, null, em, p);
+    }
+
+     public static Pair<String, String[]> createWhere(String[] fieldNames, Object[] values,
+                                                     String[] inverseFieldNames, Object[] inverseValues,
+                                                     Persistable p)
+             throws IllegalArgumentException {
+         return createWhere(fieldNames, values, null, null, null, p);
+     }
+
+    public static Pair<String, String[]> createWhere(String[] fieldNames, Object[] values,
+                                                     String[] inverseFieldNames, Object[] inverseValues,
+                                                     EncryptedModel em, Persistable p)
+            throws IllegalArgumentException {
         Set<String> fields = null;
         if (p instanceof IMetaData) {
             IMetaData m = (IMetaData)p;
@@ -75,6 +89,26 @@ public class DatabaseHelper {
             arguments.add(values[i].toString());
 
             set = true;
+        }
+        if (inverseFieldNames != null) {
+            for (int i=0; i < inverseFieldNames.length; ++i) {
+                String columnName = TableBuilder.scrubName(inverseFieldNames[i]);
+                if (fields != null) {
+                    if (!fields.contains(columnName)) {
+                        continue;
+                    }
+                }
+                if (set) {
+                    stringBuilder.append(" AND ");
+                }
+
+                stringBuilder.append(columnName);
+                stringBuilder.append("!=?");
+
+                arguments.add(inverseValues[i].toString());
+
+                set = true;
+            }
         }
         // we couldn't match any of the fields to our columns
         if (!set) {

--- a/src/main/java/org/commcare/modern/database/DatabaseHelper.java
+++ b/src/main/java/org/commcare/modern/database/DatabaseHelper.java
@@ -34,14 +34,14 @@ public class DatabaseHelper {
     public static Pair<String, String[]> createWhere(String[] fieldNames, Object[] values,
                                                      EncryptedModel em, Persistable p)
             throws IllegalArgumentException {
-        return createWhere(fieldNames, values, null, null, em, p);
+        return createWhere(fieldNames, values, new String[0], new String[0], em, p);
     }
 
      public static Pair<String, String[]> createWhere(String[] fieldNames, Object[] values,
                                                      String[] inverseFieldNames, Object[] inverseValues,
                                                      Persistable p)
              throws IllegalArgumentException {
-         return createWhere(fieldNames, values, null, null, null, p);
+         return createWhere(fieldNames, values, inverseFieldNames, inverseValues, null, p);
      }
 
     public static Pair<String, String[]> createWhere(String[] fieldNames, Object[] values,
@@ -90,25 +90,23 @@ public class DatabaseHelper {
 
             set = true;
         }
-        if (inverseFieldNames != null) {
-            for (int i=0; i < inverseFieldNames.length; ++i) {
-                String columnName = TableBuilder.scrubName(inverseFieldNames[i]);
-                if (fields != null) {
-                    if (!fields.contains(columnName)) {
-                        continue;
-                    }
+        for (int i=0; i < inverseFieldNames.length; ++i) {
+            String columnName = TableBuilder.scrubName(inverseFieldNames[i]);
+            if (fields != null) {
+                if (!fields.contains(columnName)) {
+                    continue;
                 }
-                if (set) {
-                    stringBuilder.append(" AND ");
-                }
-
-                stringBuilder.append(columnName);
-                stringBuilder.append("!=?");
-
-                arguments.add(inverseValues[i].toString());
-
-                set = true;
             }
+            if (set) {
+                stringBuilder.append(" AND ");
+            }
+
+            stringBuilder.append(columnName);
+            stringBuilder.append("!=?");
+
+            arguments.add(inverseValues[i].toString());
+
+            set = true;
         }
         // we couldn't match any of the fields to our columns
         if (!set) {

--- a/src/main/java/org/commcare/xml/CaseXmlParser.java
+++ b/src/main/java/org/commcare/xml/CaseXmlParser.java
@@ -204,11 +204,17 @@ public class CaseXmlParser extends TransactionParser<Case> {
                 case "external_id":
                     caseForBlock.setExternalId(value);
                     break;
+                case "category":
+                    caseForBlock.setCategory(value);
+                    break;
+                case "state":
+                    caseForBlock.setState(value);
+                    break;
                 case "patient_type":
-                    caseForBlock.setPatientType(value);
+                    caseForBlock.setCategory(value);
                     break;
                 case "current_status":
-                    caseForBlock.setCurrentStatus(value);
+                    caseForBlock.setState(value);
                     break;
                 default:
                     caseForBlock.setProperty(key, value);

--- a/src/main/java/org/commcare/xml/CaseXmlParser.java
+++ b/src/main/java/org/commcare/xml/CaseXmlParser.java
@@ -204,6 +204,12 @@ public class CaseXmlParser extends TransactionParser<Case> {
                 case "external_id":
                     caseForBlock.setExternalId(value);
                     break;
+                case "patient_type":
+                    caseForBlock.setPatientType(value);
+                    break;
+                case "current_status":
+                    caseForBlock.setCurrentStatus(value);
+                    break;
                 default:
                     caseForBlock.setProperty(key, value);
                     break;

--- a/src/main/java/org/commcare/xml/CaseXmlParser.java
+++ b/src/main/java/org/commcare/xml/CaseXmlParser.java
@@ -210,12 +210,6 @@ public class CaseXmlParser extends TransactionParser<Case> {
                 case "state":
                     caseForBlock.setState(value);
                     break;
-                case "patient_type":
-                    caseForBlock.setCategory(value);
-                    break;
-                case "current_status":
-                    caseForBlock.setState(value);
-                    break;
                 default:
                     caseForBlock.setProperty(key, value);
                     break;

--- a/src/main/java/org/commcare/xml/bulk/BulkProcessingCaseXmlParser.java
+++ b/src/main/java/org/commcare/xml/bulk/BulkProcessingCaseXmlParser.java
@@ -213,11 +213,17 @@ public abstract class BulkProcessingCaseXmlParser extends BulkElementParser<Case
                 case "external_id":
                     caseForBlock.setExternalId(value);
                     break;
+                case "category":
+                    caseForBlock.setCategory(value);
+                    break;
+                case "state":
+                    caseForBlock.setState(value);
+                    break;
                 case "patient_type":
-                    caseForBlock.setPatientType(value);
+                    caseForBlock.setCategory(value);
                     break;
                 case "current_status":
-                    caseForBlock.setCurrentStatus(value);
+                    caseForBlock.setState(value);
                     break;
                 default:
                     caseForBlock.setProperty(key, value);

--- a/src/main/java/org/commcare/xml/bulk/BulkProcessingCaseXmlParser.java
+++ b/src/main/java/org/commcare/xml/bulk/BulkProcessingCaseXmlParser.java
@@ -219,12 +219,6 @@ public abstract class BulkProcessingCaseXmlParser extends BulkElementParser<Case
                 case "state":
                     caseForBlock.setState(value);
                     break;
-                case "patient_type":
-                    caseForBlock.setCategory(value);
-                    break;
-                case "current_status":
-                    caseForBlock.setState(value);
-                    break;
                 default:
                     caseForBlock.setProperty(key, value);
                     break;

--- a/src/main/java/org/commcare/xml/bulk/BulkProcessingCaseXmlParser.java
+++ b/src/main/java/org/commcare/xml/bulk/BulkProcessingCaseXmlParser.java
@@ -213,6 +213,12 @@ public abstract class BulkProcessingCaseXmlParser extends BulkElementParser<Case
                 case "external_id":
                     caseForBlock.setExternalId(value);
                     break;
+                case "patient_type":
+                    caseForBlock.setPatientType(value);
+                    break;
+                case "current_status":
+                    caseForBlock.setCurrentStatus(value);
+                    break;
                 default:
                     caseForBlock.setProperty(key, value);
                     break;

--- a/src/main/java/org/javarosa/core/model/utils/CacheHost.java
+++ b/src/main/java/org/javarosa/core/model/utils/CacheHost.java
@@ -38,15 +38,17 @@ public interface CacheHost {
     /**
      * Get the set of parameters expected to yield the best results for
      * priming the cache based on the most recent query sets. Expected
-     * is a set of String Key/Value pairs which make sense to the current
+     * is a two sets of String Key/Value pairs which make sense to the current
      * cache, ideally these pairs cover a close set of reference caches to
      * the most recent batch query.
      *
      * TODO: Super unclear whether this is the best place to put this
      *
-     * @return a two-deep array of keys and values that are the same length, IE:
+     * @return a four-deep array of keys and values. The first two and last two are the same length, IE:
      * String[] keys = returvalue[0];
      * String[] values = returnvalue[1];
+     * String[] inverseKeys = returnvalue[2];
+     * String[] inverseValues = returnvalue[3];
      */
     String[][] getCachePrimeGuess();
 }

--- a/src/main/java/org/javarosa/core/services/storage/IStorageUtilityIndexed.java
+++ b/src/main/java/org/javarosa/core/services/storage/IStorageUtilityIndexed.java
@@ -194,6 +194,23 @@ public interface IStorageUtilityIndexed<E extends Externalizable> {
     List<Integer> getIDsForValues(String[] metaFieldNames, Object[] values, LinkedHashSet<Integer> returnSet);
 
     /**
+    * Retrieves a Vector of IDs of Externalizable objects in storage for which the field
+    * specified contains the values specified.
+    *
+    * @param metaFieldNames A list of metadata field names to match
+    * @param values     The values which must match the field names provided
+    * @param inverseFieldNames A list of field names to inverse match (!=)
+    * @param inverseValues     The values which the field must not match
+    * @param returnSet A LinkedHashSet of integers which match the return value
+    * @return A Vector of Integers such that retrieving the Externalizable object with any
+    * of those integer IDs will result in an object for which the fields specified are equal
+    * to the value provided.
+    * @throws RuntimeException (Fix this exception type) if the field is unrecognized by the
+    *                          meta data
+    */
+    List<Integer> getIDsForValues(String[] metaFieldNames, Object[] values, String[] inverseFieldNames, Object[] inverseValues, LinkedHashSet<Integer> returnSet);
+
+    /**
      * Retrieves a Externalizable object from the storage which is reference by the unique index fieldName.
      *
      * @param metaFieldName The name of the index field which will be evaluated

--- a/src/main/java/org/javarosa/core/services/storage/IStorageUtilityIndexed.java
+++ b/src/main/java/org/javarosa/core/services/storage/IStorageUtilityIndexed.java
@@ -195,7 +195,8 @@ public interface IStorageUtilityIndexed<E extends Externalizable> {
 
     /**
     * Retrieves a Vector of IDs of Externalizable objects in storage for which the field
-    * specified contains the values specified.
+    * specified contains the values specified and the fields specified in inverseFieldNames
+    * do not contain the value specified in inverseValues. If no values are passed, all cases are returned
     *
     * @param metaFieldNames A list of metadata field names to match
     * @param values     The values which must match the field names provided
@@ -205,7 +206,7 @@ public interface IStorageUtilityIndexed<E extends Externalizable> {
     * @return A Vector of Integers such that retrieving the Externalizable object with any
     * of those integer IDs will result in an object for which the fields specified are equal
     * to the value provided.
-    * @throws RuntimeException (Fix this exception type) if the field is unrecognized by the
+    * @throws RuntimeException (Fix this exception type) if any field in is unrecognized by the
     *                          meta data
     */
     List<Integer> getIDsForValues(String[] metaFieldNames, Object[] values, String[] inverseFieldNames, Object[] inverseValues, LinkedHashSet<Integer> returnSet);

--- a/src/main/java/org/javarosa/core/services/storage/util/DummyIndexedStorageUtility.java
+++ b/src/main/java/org/javarosa/core/services/storage/util/DummyIndexedStorageUtility.java
@@ -73,6 +73,24 @@ public class DummyIndexedStorageUtility<T extends Persistable> implements IStora
         }
     }
 
+    private Vector<Integer> getIDsForInverseValue(String fieldName, Object value) {
+        if (meta.get(fieldName) == null) {
+            throw new IllegalArgumentException("Unsupported index: " + fieldName + " for storage of " + prototype.getName());
+        }
+        Hashtable<Object, Vector<Integer>> allValues = meta.get(fieldName);
+        Vector<Integer> ids = new Vector<>();
+        for (Enumeration en = allValues.keys(); en.hasMoreElements(); ) {
+            Object key = en.nextElement();
+
+            if (!key.equals(value) && allValues.get(key) != null) {
+                for (Integer id : allValues.get(key)) {
+                    ids.add(id);
+                }
+            }
+        }
+        return ids;
+    }
+
     @Override
     public Vector<Integer> getIDsForValue(String fieldName, Object value) {
         //We don't support all index types
@@ -92,9 +110,22 @@ public class DummyIndexedStorageUtility<T extends Persistable> implements IStora
 
     @Override
     public List<Integer> getIDsForValues(String[] fieldNames, Object[] values, LinkedHashSet<Integer> returnSet) {
+        return getIDsForValues(fieldNames, values, new String[0], new Object[0], returnSet);
+    }
+
+    @Override
+    public List<Integer> getIDsForValues(String[] fieldNames, Object[] values, String[] inverseMatchFields, Object[] inverseMatchValues, LinkedHashSet<Integer> returnSet) {
         List<Integer> accumulator = null;
         for (int i = 0; i < fieldNames.length; ++i) {
             Vector<Integer> matches = getIDsForValue(fieldNames[i], values[i]);
+            if (accumulator == null) {
+                accumulator = new Vector<>(matches);
+            } else {
+                accumulator = DataUtil.intersection(accumulator, matches);
+            }
+        }
+        for (int i = 0; i < inverseMatchFields.length; ++i) {
+            Vector<Integer> matches = getIDsForInverseValue(inverseMatchFields[i], inverseMatchValues[i]);
             if (accumulator == null) {
                 accumulator = new Vector<>(matches);
             } else {

--- a/src/main/resources/casedb_instance_structure.xml
+++ b/src/main/resources/casedb_instance_structure.xml
@@ -1,5 +1,5 @@
 <wrapper>
-    <case case_id="" case_type="" owner_id="" status="" external_id="">
+    <case case_id="" case_type="" owner_id="" status="" external_id="" state="" category="">
         <!-- case_id: The unique GUID of this case -->
         <!-- case_type: The id of this case's type -->
         <!-- owner_id: The GUID of the case or group which owns this case -->

--- a/src/test/java/org/commcare/cases/test/CaseXPathQueryTest.java
+++ b/src/test/java/org/commcare/cases/test/CaseXPathQueryTest.java
@@ -118,4 +118,24 @@ public class CaseXPathQueryTest {
         Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(ec,
                 "count(instance('casedb')/casedb/case[@case_id != 'case_one'])", 2.0));
     }
+
+    @Test
+    public void caseIndexAliasTest() throws Exception {
+        config.parseIntoSandbox(
+                this.getClass().getResourceAsStream("/case_query_testing.xml"), sandbox);
+        EvaluationContext ec =
+                MockDataUtils.buildContextWithInstance(sandbox, "casedb",
+                        CaseTestUtils.CASE_INSTANCE);
+
+        Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(ec,
+                "count(instance('casedb')/casedb/case[@category = 'real'])", 1.0));
+        Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(ec,
+                "count(instance('casedb')/casedb/case[patient_type = 'real'])", 1.0));
+        Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(ec,
+                "count(instance('casedb')/casedb/case[current_status = 'c'])", 1.0));
+        Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(ec,
+                "count(instance('casedb')/casedb/case[@state = 'c'])", 1.0));
+        Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(ec,
+                "count(instance('casedb')/casedb/case[@category != 'real'])", 2.0));
+    }
 }

--- a/src/test/java/org/commcare/cases/test/CaseXPathQueryTest.java
+++ b/src/test/java/org/commcare/cases/test/CaseXPathQueryTest.java
@@ -132,10 +132,20 @@ public class CaseXPathQueryTest {
         Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(ec,
                 "count(instance('casedb')/casedb/case[patient_type = 'real'])", 1.0));
         Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(ec,
-                "count(instance('casedb')/casedb/case[current_status = 'c'])", 1.0));
+                "count(instance('casedb')/casedb/case[current_status = 'c'])", 2.0));
         Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(ec,
                 "count(instance('casedb')/casedb/case[@state = 'c'])", 1.0));
         Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(ec,
                 "count(instance('casedb')/casedb/case[@category != 'real'])", 2.0));
+        Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(ec,
+                "count(instance('casedb')/casedb/case[@category = 'fake'])", 0.0));
+        Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(ec,
+                "count(instance('casedb')/casedb/case[@category != 'fake'])", 3.0));
+        Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(ec,
+                "count(instance('casedb')/casedb/case[true() and @category != 'real'])", 2.0));
+        Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(ec,
+                "count(instance('casedb')/casedb/case[@state = 'c'][@category = 'real'])", 1.0));
+        Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(ec,
+                "count(instance('casedb')/casedb/case[current_status = 'c'][@category = 'real'])", 1.0));
     }
 }

--- a/src/test/java/org/commcare/cases/test/CaseXPathQueryTest.java
+++ b/src/test/java/org/commcare/cases/test/CaseXPathQueryTest.java
@@ -147,5 +147,8 @@ public class CaseXPathQueryTest {
                 "count(instance('casedb')/casedb/case[@state = 'c'][@category = 'real'])", 1.0));
         Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(ec,
                 "count(instance('casedb')/casedb/case[current_status = 'c'][@category = 'real'])", 1.0));
+        Assert.assertTrue(CaseTestUtils.xpathEvalAndCompare(ec,
+                "count(instance('casedb')/casedb/case[@state = 'a'][@current_status != 'b'])", 1.0));
+
     }
 }

--- a/src/test/resources/case_query_testing.xml
+++ b/src/test/resources/case_query_testing.xml
@@ -35,6 +35,10 @@
             <case_name>case</case_name>
             <owner_id>test_group</owner_id>
         </create>
+        <update>
+            <state>a</state>
+            <current_status>c</current_status>
+        </update>
     </case>
 
     <case case_id="case_three"

--- a/src/test/resources/case_query_testing.xml
+++ b/src/test/resources/case_query_testing.xml
@@ -45,5 +45,9 @@
             <case_name>case name</case_name>
             <owner_id>test_group</owner_id>
         </create>
+        <update>
+            <patient_type>real</patient_type>
+            <current_status>c</current_status>
+        </update>
     </case>
 </OpenRosaResponse>


### PR DESCRIPTION
This adds two new indexed case properties (`state` and `category`) with two aliases (`current_status` and `patient_type`, respectively). It also adds functionality to allow indexed lookups for `!=` constructions, and implements support for that in the CLI data store.