### PR TITLE
Added translation for Case Claim title on the 'search all cases' page

### DIFF
--- a/src/cli/java/org/commcare/util/screen/QueryScreen.java
+++ b/src/cli/java/org/commcare/util/screen/QueryScreen.java
@@ -7,6 +7,8 @@ import org.commcare.session.RemoteQuerySessionManager;
 import org.commcare.suite.model.DisplayUnit;
 import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.util.OrderedHashtable;
+import org.javarosa.core.services.locale.Localization;
+import org.javarosa.core.util.NoLocalizedTextException;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -65,7 +67,11 @@ public class QueryScreen extends Screen {
         for (Map.Entry<String, DisplayUnit> displayEntry : userInputDisplays.entrySet()) {
             fields[count] = displayEntry.getValue().getText().evaluate(sessionWrapper.getEvaluationContext());
         }
-        mTitle = "Case Claim";
+        try {
+            mTitle = Localization.get("case.search.title");
+        } catch (NoLocalizedTextException nlte) {
+            mTitle = "Case Claim";
+        }
 
     }
 


### PR DESCRIPTION
Goes along with other PRs including this one https://github.com/dimagi/commcare-hq/compare/smh/case-claim-translation?expand=1

Tested locally and I was able to changes "Case Claim" and change it back successfully.