### PR TITLE
Allow Default Expressions for Query Screen Prompts

### DIFF
--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -53,7 +53,11 @@ public class RemoteQuerySessionManager {
         for (Enumeration en = queryPrompts.keys(); en.hasMoreElements(); ) {
             String promptId = (String)en.nextElement();
             QueryPrompt prompt = queryPrompts.get(promptId);
-            userAnswers.put(prompt.getKey(), "");
+            String defaultValue = "";
+            if(prompt.getDefaultValueExpr() != null) {
+                defaultValue = FunctionUtils.toString(prompt.getDefaultValueExpr().eval(evaluationContext));
+            }
+            userAnswers.put(prompt.getKey(), defaultValue);
         }
     }
 

--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -15,6 +15,7 @@ import org.javarosa.xml.ElementParser;
 import org.javarosa.xml.TreeElementParser;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
+import org.javarosa.xpath.XPathException;
 import org.javarosa.xpath.expr.FunctionUtils;
 import org.javarosa.xpath.expr.XPathExpression;
 import org.kxml2.io.KXmlParser;
@@ -42,13 +43,13 @@ public class RemoteQuerySessionManager {
             new Hashtable<>();
 
     private RemoteQuerySessionManager(RemoteQueryDatum queryDatum,
-                                      EvaluationContext evaluationContext) {
+                                      EvaluationContext evaluationContext) throws XPathException {
         this.queryDatum = queryDatum;
         this.evaluationContext = evaluationContext;
         initUserAnswers();
     }
 
-    private void initUserAnswers() {
+    private void initUserAnswers() throws XPathException {
         OrderedHashtable<String, QueryPrompt> queryPrompts = queryDatum.getUserQueryPrompts();
         for (Enumeration en = queryPrompts.keys(); en.hasMoreElements(); ) {
             String promptId = (String)en.nextElement();
@@ -62,7 +63,7 @@ public class RemoteQuerySessionManager {
     }
 
     public static RemoteQuerySessionManager buildQuerySessionManager(CommCareSession session,
-                                                                     EvaluationContext sessionContext) {
+                                                                     EvaluationContext sessionContext)  throws XPathException {
         SessionDatum datum;
         try {
             datum = session.getNeededDatum();

--- a/src/main/java/org/commcare/suite/model/QueryPrompt.java
+++ b/src/main/java/org/commcare/suite/model/QueryPrompt.java
@@ -4,8 +4,10 @@ import org.javarosa.core.model.ItemsetBinding;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.ExtWrapNullable;
+import org.javarosa.core.util.externalizable.ExtWrapTagged;
 import org.javarosa.core.util.externalizable.Externalizable;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.javarosa.xpath.expr.XPathExpression;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -29,18 +31,22 @@ public class QueryPrompt implements Externalizable {
     private DisplayUnit display;
 
     @Nullable
+    private XPathExpression defaultValueExpr;
+
+    @Nullable
     private ItemsetBinding itemsetBinding;
 
     @SuppressWarnings("unused")
     public QueryPrompt() {
     }
 
-    public QueryPrompt(String key, String appearance, String input, DisplayUnit display, ItemsetBinding itemsetBinding) {
+    public QueryPrompt(String key, String appearance, String input, DisplayUnit display, ItemsetBinding itemsetBinding, XPathExpression defaultValueExpr) {
         this.key = key;
         this.appearance = appearance;
         this.input = input;
         this.display = display;
         this.itemsetBinding = itemsetBinding;
+        this.defaultValueExpr = defaultValueExpr;
     }
 
     @Override
@@ -50,6 +56,7 @@ public class QueryPrompt implements Externalizable {
         input = (String)ExtUtil.read(in, new ExtWrapNullable(String.class), pf);
         display = (DisplayUnit)ExtUtil.read(in, DisplayUnit.class, pf);
         itemsetBinding = (ItemsetBinding)ExtUtil.read(in, new ExtWrapNullable(ItemsetBinding.class), pf);
+        defaultValueExpr = (XPathExpression)ExtUtil.read(in, new ExtWrapNullable(new ExtWrapTagged()), pf);
     }
 
     @Override
@@ -59,6 +66,7 @@ public class QueryPrompt implements Externalizable {
         ExtUtil.write(out, new ExtWrapNullable(input));
         ExtUtil.write(out, display);
         ExtUtil.write(out, new ExtWrapNullable(itemsetBinding));
+        ExtUtil.write(out, new ExtWrapNullable(defaultValueExpr == null ? null : new ExtWrapTagged(defaultValueExpr)));
     }
 
     public String getKey() {
@@ -82,5 +90,10 @@ public class QueryPrompt implements Externalizable {
     @Nullable
     public ItemsetBinding getItemsetBinding() {
         return itemsetBinding;
+    }
+
+    @Nullable
+    public XPathExpression getDefaultValueExpr() {
+        return defaultValueExpr;
     }
 }

--- a/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
@@ -1,0 +1,33 @@
+package org.commcare.backend.suite.model.test;
+
+import org.commcare.modern.session.SessionWrapper;
+import org.commcare.suite.model.Global;
+import org.commcare.suite.model.MenuDisplayable;
+import org.commcare.suite.model.MenuLoader;
+import org.commcare.suite.model.RemoteQueryDatum;
+import org.commcare.suite.model.SessionDatum;
+import org.commcare.test.utilities.MockApp;
+import org.commcare.util.LoggerInterface;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for basic app models for case claim
+ *
+ * @author ctsims
+ */
+public class CaseClaimModelTests {
+
+    @Test
+    public void testRemoteQueryDatum() throws Exception {
+        MockApp mApp = new MockApp("/case_claim_example/");
+
+        SessionWrapper session = mApp.getSession();
+        session.setCommand("patient-search");
+
+        SessionDatum datum = session.getNeededDatum();
+
+        Assert.assertTrue("Didn't find Remote Query datum definition", datum instanceof RemoteQueryDatum);
+    }
+}

--- a/src/test/resources/case_claim_example/form_placeholder.xml
+++ b/src/test/resources/case_claim_example/form_placeholder.xml
@@ -1,0 +1,17 @@
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Placeholder Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://commcarehq.org/test/placeholder" uiVersion="1" version="1" name="Placeholder">
+					<item/>
+				</data>
+			</instance>
+		</model>
+	</h:head>
+	<h:body>
+		<input ref="/data/item">
+			<label>placeholder</label>
+		</input>
+	</h:body>
+</h:html>

--- a/src/test/resources/case_claim_example/profile.ccpr
+++ b/src/test/resources/case_claim_example/profile.ccpr
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<profile version="1"
+         requiredMajor="2"
+         requiredMinor="22"
+         uniqueid="id"
+         update=""
+         name="trivial_test_resources"
+         descriptor="Profile">
+
+
+    <suite><resource id="suite" version="1">
+            <location authority="local">./suite.xml</location>
+    </resource></suite>
+</profile>

--- a/src/test/resources/case_claim_example/suite.xml
+++ b/src/test/resources/case_claim_example/suite.xml
@@ -1,0 +1,100 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<suite version="1" descriptor="Suite File">
+  <xform>
+    <resource id="546d5695ad31d060faac835fea2bc436810c81f9" version="1" descriptor="Form: Placeholder">
+      <location authority="local">./form_placeholder.xml</location>
+    </resource>
+  </xform>
+
+  <detail id="m0_case_short">
+    <title>
+      <text>Case List</text>
+    </title>
+    <field>
+      <header>
+        <text>Name</text>
+      </header>
+      <template>
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </template>
+      <sort type="string" order="1" direction="ascending">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
+    </field>
+  </detail>
+  <detail id="m0_case_long">
+    <title>
+      <text>Case Detail</text>
+    </title>
+    <field>
+      <header>
+        <text>Name</text>
+      </header>
+      <template>
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </template>
+    </field>
+  </detail>
+
+  <remote-request>
+    <post url="https://www.fake.com/claim_patient/"
+        relevant="count(instance('casedb')/casedb/case[@case_id=instance('session')/session/data/case_id]) = 0">
+      <data key="selected_case_id" ref="instance('session')/session/data/case_id"/>
+    </post>
+    <command id="patient-search">
+      <display>
+        <text>Global search for person</text>
+      </display>
+    </command>
+    <instance id="session" src="jr://instance/session"/>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <session>
+      <query url="https://www.fake.com/patient_search/" storage-instance="patients">
+        <data key="device_id" ref="instance('session')/session/context/deviceid"/>
+        <prompt key="name" default="instance('session')/session/context/deviceid">
+          <display>
+            <text>
+              <locale id="query.name"/>
+            </text>
+          </display>
+        </prompt>
+        <prompt key="patient_id">
+          <display>
+            <text>
+              <locale id="query.id"/>
+            </text>
+          </display>
+        </prompt>
+      </query>
+      <datum id="case_id" nodeset="instance('patients')/patients/patient" value="./id" detail-select="patient_short" detail-confirm="patient_long"/>
+    </session>
+    <stack>
+      <push>
+        <command value="'m1-f0'"/>
+        <datum id="calculated_data" value="'claimed'"/>
+      </push>
+    </stack>
+  </remote-request>
+
+  <entry>
+    <form>http://commcarehq.org/test/placeholder</form>
+    <command id="m0-f0">
+      <text>Form</text>
+    </command>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <session>
+      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='test_case'][@status='open']" value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
+    </session>
+  </entry>
+  <menu id="root">
+    <text>Menu</text>
+    <command id="m0-f0"/>
+    <command id="patient-search"/>
+  </menu>
+</suite>

--- a/src/test/resources/case_claim_example/user_restore.xml
+++ b/src/test/resources/case_claim_example/user_restore.xml
@@ -1,0 +1,21 @@
+<OpenRosaResponse>
+	<message nature="ota_restore_success">Successfully restored account test!</message>
+	<Sync xmlns="http://commcarehq.org/sync">
+		<restore_id>sync_token</restore_id>
+	</Sync>
+	<Registration xmlns="http://openrosa.org/user/registration">
+		<username>test</username>
+		<password>sha1$60441$53cf77c2ac3608a944db96af177a6dfe1579e4ba</password>
+		<uuid>test_uuid</uuid>
+		<date>2012-04-30</date>
+	</Registration>
+	<case case_id="case_one"
+		date_modified="2014-08-04T21:09:07.000000Z" user_id="test_uuid"
+		xmlns="http://commcarehq.org/case/transaction/v2">
+		<create>
+			<case_type>test_case</case_type>
+			<case_name>Test Case</case_name>
+			<owner_id>test_uuid</owner_id>
+		</create>
+	</case>
+</OpenRosaResponse>


### PR DESCRIPTION
Allows users to define a default expression for [Remote Request Query prompts](https://github.com/dimagi/commcare-core/wiki/Suite20#remote-request) which will be preloaded in before the user begins providing values. 