### PR TITLE
Revert 960 jls/autolaunch action round 2

### DIFF
--- a/src/cli/java/org/commcare/util/screen/EntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreen.java
@@ -84,7 +84,6 @@ public class EntityScreen extends CompoundScreenHost {
             if (action.isAutoLaunching()) {
                 // Supply an empty case list so we can "select" from it later using getEntityFromID
                 mCurrentScreen = new EntityListSubscreen(mShortDetail, new Vector<TreeReference>(), evalContext, handleCaseIndex);
-                this.full = false;
                 this.autoLaunchAction = action;
             }
         }

--- a/src/cli/java/org/commcare/util/screen/EntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreen.java
@@ -55,6 +55,7 @@ public class EntityScreen extends CompoundScreenHost {
     private Vector<TreeReference> references;
 
     private boolean initialized = false;
+    private Action autoLaunchAction;
 
     public EntityScreen(boolean handleCaseIndex) {
         this.handleCaseIndex = handleCaseIndex;
@@ -83,7 +84,8 @@ public class EntityScreen extends CompoundScreenHost {
             if (action.isAutoLaunching()) {
                 // Supply an empty case list so we can "select" from it later using getEntityFromID
                 mCurrentScreen = new EntityListSubscreen(mShortDetail, new Vector<TreeReference>(), evalContext, handleCaseIndex);
-                full = false;
+                this.full = false;
+                this.autoLaunchAction = action;
             }
         }
     }
@@ -301,6 +303,10 @@ public class EntityScreen extends CompoundScreenHost {
 
     public Vector<TreeReference> getReferences() {
         return references;
+    }
+
+    public boolean getAutoLaunchAction() {
+        return autoLaunchAction;
     }
 
     @Override

--- a/src/cli/java/org/commcare/util/screen/EntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreen.java
@@ -84,11 +84,6 @@ public class EntityScreen extends CompoundScreenHost {
                 // Supply an empty case list so we can "select" from it later using getEntityFromID
                 mCurrentScreen = new EntityListSubscreen(mShortDetail, new Vector<TreeReference>(), evalContext, handleCaseIndex);
                 full = false;
-                if (allowAutoLaunch) {
-                    this.setPendingAction(action);
-                    this.updateSession(session);
-                    return;
-                }
             }
         }
     }

--- a/src/cli/java/org/commcare/util/screen/EntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreen.java
@@ -305,7 +305,7 @@ public class EntityScreen extends CompoundScreenHost {
         return references;
     }
 
-    public boolean getAutoLaunchAction() {
+    public Action getAutoLaunchAction() {
         return autoLaunchAction;
     }
 

--- a/src/cli/java/org/commcare/util/screen/EntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreen.java
@@ -73,7 +73,7 @@ public class EntityScreen extends CompoundScreenHost {
         this.full = full;
     }
 
-    public EntityScreen(boolean handleCaseIndex, boolean full, SessionWrapper session) throws CommCareSessionException {
+    public EntityScreen(boolean handleCaseIndex, boolean full, boolean allowAutoLaunch, SessionWrapper session) throws CommCareSessionException {
         this.handleCaseIndex = handleCaseIndex;
         this.full = full;
 
@@ -81,7 +81,14 @@ public class EntityScreen extends CompoundScreenHost {
 
         for (Action action : mShortDetail.getCustomActions(evalContext)) {
             if (action.isAutoLaunching()) {
+                // Supply an empty case list so we can "select" from it later using getEntityFromID
+                mCurrentScreen = new EntityListSubscreen(mShortDetail, new Vector<TreeReference>(), evalContext, handleCaseIndex);
                 full = false;
+                if (allowAutoLaunch) {
+                    this.setPendingAction(action);
+                    this.updateSession(session);
+                    return;
+                }
             }
         }
     }
@@ -206,7 +213,11 @@ public class EntityScreen extends CompoundScreenHost {
     }
 
     public void setHighlightedEntity(String id) throws CommCareSessionException {
-        this.mCurrentSelection = referenceMap.get(id);
+        if (referenceMap == null) {
+            this.mCurrentSelection = mNeededDatum.getEntityFromID(evalContext, id);
+        } else {
+            this.mCurrentSelection = referenceMap.get(id);
+        }
         if (this.mCurrentSelection == null) {
             throw new CommCareSessionException("EntityScreen " + this.toString() + " could not select case " + id + "." +
                     " If this error persists please report a bug to CommCareHQ.");


### PR DESCRIPTION
This PR allows autolaunched case claim screens, to bypass rendering of the case list itself