### PR TITLE
Removed try/except from Case Claim translation

### DIFF
--- a/src/cli/java/org/commcare/util/screen/QueryScreen.java
+++ b/src/cli/java/org/commcare/util/screen/QueryScreen.java
@@ -8,7 +8,6 @@ import org.commcare.suite.model.DisplayUnit;
 import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.util.OrderedHashtable;
 import org.javarosa.core.services.locale.Localization;
-import org.javarosa.core.util.NoLocalizedTextException;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -67,12 +66,7 @@ public class QueryScreen extends Screen {
         for (Map.Entry<String, DisplayUnit> displayEntry : userInputDisplays.entrySet()) {
             fields[count] = displayEntry.getValue().getText().evaluate(sessionWrapper.getEvaluationContext());
         }
-        try {
-            mTitle = Localization.get("case.search.title");
-        } catch (NoLocalizedTextException nlte) {
-            mTitle = "Case Claim";
-        }
-
+        mTitle = Localization.get("case.search.title");
     }
 
     private static String buildUrl(String baseUrl, Hashtable<String, String> queryParams) {


### PR DESCRIPTION
As pointed out in Jenny's comment [here](https://github.com/dimagi/commcare-core/pull/958), the try/catch is not necessary/misleading. 

This is the [other PR](https://github.com/dimagi/commcare-core/pull/962) connected to that comment

Tested locally and it works the same as before on an app with the modified title and another app that does not modify the "Case Claim" title. 