### PR TITLE
No badges

### DIFF
--- a/src/cli/java/org/commcare/util/screen/MenuScreen.java
+++ b/src/cli/java/org/commcare/util/screen/MenuScreen.java
@@ -34,11 +34,22 @@ public class MenuScreen extends Screen {
     private String mTitle;
 
     public String[] getBadges() {
+        if (badges == null) {
+            calculateBadges();
+        }
         return badges;
     }
 
     public void setBadges(String[] badges) {
         this.badges = badges;
+    }
+
+    private void calculateBadges() {
+        badges = new String[mChoices.length];
+        for (int i = 0; i < mChoices.length; i++) {
+            MenuDisplayable menu = mChoices[i];
+            badges[i] = menu.getTextForBadge(mSession.getEvaluationContext(menu.getCommandID())).blockingGet();
+        }
     }
 
     class ScreenLogger implements LoggerInterface {
@@ -58,10 +69,9 @@ public class MenuScreen extends Screen {
     public void init(SessionWrapper session) throws CommCareSessionException {
         mSession = session;
         String root = deriveMenuRoot(session);
-        MenuLoader menuLoader = new MenuLoader(session.getPlatform(), session, root, new ScreenLogger(), false, false);
+        MenuLoader menuLoader = new MenuLoader(session.getPlatform(), session, root, new ScreenLogger(), false, false, false);
         this.mChoices = menuLoader.getMenus();
         this.mTitle = this.getBestTitle();
-        this.badges = menuLoader.getBadgeText();
         Exception loadException = menuLoader.getLoadException();
         if (loadException != null) {
             throw new CommCareSessionException(menuLoader.getErrorMessage());

--- a/src/main/java/org/commcare/suite/model/MenuLoader.java
+++ b/src/main/java/org/commcare/suite/model/MenuLoader.java
@@ -42,6 +42,16 @@ public class MenuLoader {
         this.getMenuDisplayables(platform, sessionWrapper, menuId, hideTrainingRoot);
     }
 
+    public MenuLoader(CommCarePlatform platform, SessionWrapperInterface sessionWrapper,
+                      String menuId, LoggerInterface loggerInterface,
+                      boolean shouldOutputEvalTrace, boolean hideTrainingRoot, boolean includeBadges) {
+        this.loggerInterface = loggerInterface;
+        if (shouldOutputEvalTrace) {
+            this.traceReporter = new ReducingTraceReporter(false);
+        }
+        this.getMenuDisplayables(platform, sessionWrapper, menuId, hideTrainingRoot, includeBadges);
+    }
+
     public String getErrorMessage() {
         if (loadException != null) {
             String errorMessage = loadException.getMessage();
@@ -54,6 +64,12 @@ public class MenuLoader {
     private void getMenuDisplayables(CommCarePlatform platform,
                                      SessionWrapperInterface sessionWrapper,
                                      String menuID, boolean hideTrainingRoot) {
+        getMenuDisplayables(platform,sessionWrapper, menuID, hideTrainingRoot, false);
+    }
+    private void getMenuDisplayables(CommCarePlatform platform,
+                                     SessionWrapperInterface sessionWrapper,
+                                     String menuID, boolean hideTrainingRoot,
+                                     boolean includeBadges) {
         Vector<MenuDisplayable> items = new Vector<>();
         Vector<String> badges = new Vector<>();
         Hashtable<String, Entry> map = platform.getCommandToEntryMap();
@@ -62,10 +78,10 @@ public class MenuLoader {
                 try {
                     if (m.getId().equals(menuID)) {
                         if (menuIsRelevant(sessionWrapper, m)) {
-                            addRelevantCommandEntries(sessionWrapper, m, items, badges, map);
+                            addRelevantCommandEntries(sessionWrapper, m, items, badges, map, includeBadges);
                         }
                     } else {
-                        addUnaddedMenu(sessionWrapper, menuID, m, items, badges, hideTrainingRoot);
+                        addUnaddedMenu(sessionWrapper, menuID, m, items, badges, hideTrainingRoot, includeBadges);
                     }
                 } catch (CommCareInstanceInitializer.FixtureInitializationException
                         | XPathSyntaxException | XPathException xpe) {
@@ -77,13 +93,15 @@ public class MenuLoader {
         }
         menus = new MenuDisplayable[items.size()];
         items.copyInto(menus);
-        this.badges = new String[badges.size()];
-        badges.copyInto(this.badges);
+        if (includeBadges) {
+            this.badges = new String[badges.size()];
+            badges.copyInto(this.badges);
+        }
     }
 
     private void addUnaddedMenu(SessionWrapperInterface sessionWrapper, String currentMenuId,
                                 Menu toAdd, Vector<MenuDisplayable> items, Vector<String> badges,
-                                boolean hideTrainingRoot) throws XPathSyntaxException {
+                                boolean hideTrainingRoot, boolean includeBadges) throws XPathSyntaxException {
         if (hideTrainingRoot && toAdd.getId().equals(Menu.TRAINING_MENU_ROOT)) {
             return;
         }
@@ -101,7 +119,9 @@ public class MenuLoader {
             if (!idExists) {
                 if (menuIsRelevant(sessionWrapper, toAdd)) {
                     items.add(toAdd);
-                    badges.add(toAdd.getTextForBadge(sessionWrapper.getEvaluationContext(toAdd.getCommandID())).blockingGet());
+                    if (includeBadges) {
+                        badges.add(toAdd.getTextForBadge(sessionWrapper.getEvaluationContext(toAdd.getCommandID())).blockingGet());
+                    }
                 }
             }
         }
@@ -133,7 +153,8 @@ public class MenuLoader {
                                            Menu m,
                                            Vector<MenuDisplayable> items,
                                            Vector<String> badges,
-                                           Hashtable<String, Entry> map)
+                                           Hashtable<String, Entry> map,
+                                           boolean includeBadges)
             throws XPathSyntaxException {
         xPathErrorMessage = "";
         for (String command : m.getCommandIds()) {
@@ -171,7 +192,9 @@ public class MenuLoader {
             }
 
             items.add(e);
-            badges.add(e.getTextForBadge(sessionWrapper.getEvaluationContext(e.getCommandId())).blockingGet());
+            if (includeBadges) {
+                badges.add(e.getTextForBadge(sessionWrapper.getEvaluationContext(e.getCommandId())).blockingGet());
+            }
         }
     }
 

--- a/src/main/java/org/commcare/suite/model/MenuLoader.java
+++ b/src/main/java/org/commcare/suite/model/MenuLoader.java
@@ -35,11 +35,7 @@ public class MenuLoader {
     public MenuLoader(CommCarePlatform platform, SessionWrapperInterface sessionWrapper,
                       String menuId, LoggerInterface loggerInterface,
                       boolean shouldOutputEvalTrace, boolean hideTrainingRoot) {
-        this.loggerInterface = loggerInterface;
-        if (shouldOutputEvalTrace) {
-            this.traceReporter = new ReducingTraceReporter(false);
-        }
-        this.getMenuDisplayables(platform, sessionWrapper, menuId, hideTrainingRoot);
+        this(platform, sessionWrapper, menuId, loggerInterface, shouldOutputEvalTrace, hideTrainingRoot, false);
     }
 
     public MenuLoader(CommCarePlatform platform, SessionWrapperInterface sessionWrapper,


### PR DESCRIPTION
This PR makes the value of badges on a menu screen lazily evaluated. Currently when formplayer walks through your menu session it evaluates them when constructing the main screen, which means for apps with badges every request is quite slow since all navigations goes through the home screen. 