### PR TITLE
reuse xformparser method for loading form XML into form def

### DIFF
--- a/src/main/java/org/javarosa/xform/parse/XFormParser.java
+++ b/src/main/java/org/javarosa/xform/parse/XFormParser.java
@@ -2814,8 +2814,8 @@ public class XFormParser {
         }
     }
 
-    public void loadXmlInstance(FormDef f, Reader xmlReader) throws IOException {
-        loadXmlInstance(f, getXMLDocument(xmlReader));
+    public static FormDef loadXmlInstance(FormDef formDef, Reader xmlReader) throws IOException {
+        return loadXmlInstance(formDef, getXMLDocument(xmlReader));
     }
 
     /**
@@ -2823,12 +2823,15 @@ public class XFormParser {
      *
      * call before f.initialize()!
      */
-    public static void loadXmlInstance(FormDef f, Document xmlInst) {
-        TreeElement savedRoot = XFormParser.restoreDataModel(xmlInst, null).getRoot();
-        TreeElement templateRoot = f.getMainInstance().getRoot().deepCopy(true);
+    public static FormDef loadXmlInstance(FormDef f, Document xmlInst) {
+        return loadXmlInstance(f, XFormParser.restoreDataModel(xmlInst, null));
+    }
+
+    public static FormDef loadXmlInstance(FormDef formDef, FormInstance xmlInst) {
+        TreeElement savedRoot = xmlInst.getRoot();
+        TreeElement templateRoot = formDef.getMainInstance().getRoot().deepCopy(true);
 
         // weak check for matching forms
-        // TODO: should check that namespaces match?
         if (!savedRoot.getName().equals(templateRoot.getName()) || savedRoot.getMult() != 0) {
             throw new RuntimeException("Saved form instance does not match template form definition");
         }
@@ -2839,14 +2842,9 @@ public class XFormParser {
         templateRoot.populate(savedRoot);
 
         // populated model to current form
-        f.getMainInstance().setRoot(templateRoot);
+        formDef.getMainInstance().setRoot(templateRoot);
 
-        // if the new instance is inserted into the formdef before f.initialize() is called, this
-        // locale refresh is unnecessary
-        //   Localizer loc = f.getLocalizer();
-        //   if (loc != null) {
-        //       f.localeChanged(loc.getLocale(), loc);
-        //     }
+        return formDef;
     }
 
     /**

--- a/src/translate/java/org/javarosa/xform/schema/FormInstanceLoader.java
+++ b/src/translate/java/org/javarosa/xform/schema/FormInstanceLoader.java
@@ -46,11 +46,6 @@ public class FormInstanceLoader {
     public static FormDef loadInstance(FormDef formDef,
                                        InputStream instanceInput) throws IOException {
         FormInstance formInstance = XFormParser.restoreDataModel(instanceInput, null);
-        try {
-            return XFormParser.loadXmlInstance(formDef, formInstance);
-        } catch (RuntimeException e) {
-            System.out.println(e.getMessage());
-            return null;
-        }
+        return XFormParser.loadXmlInstance(formDef, formInstance);
     }
 }

--- a/src/translate/java/org/javarosa/xform/schema/FormInstanceLoader.java
+++ b/src/translate/java/org/javarosa/xform/schema/FormInstanceLoader.java
@@ -45,29 +45,12 @@ public class FormInstanceLoader {
 
     public static FormDef loadInstance(FormDef formDef,
                                        InputStream instanceInput) throws IOException {
-        FormInstance savedModel;
-        savedModel = XFormParser.restoreDataModel(instanceInput, null);
-
-        // get the root of the saved and template instances
-        TreeElement savedRoot = savedModel.getRoot();
-        TreeElement templateRoot =
-                formDef.getInstance().getRoot().deepCopy(true);
-
-        // weak check for matching forms
-        if (!savedRoot.getName().equals(templateRoot.getName()) ||
-                savedRoot.getMult() != 0) {
-            System.out.println("Instance and template form definition don't match");
+        FormInstance formInstance = XFormParser.restoreDataModel(instanceInput, null);
+        try {
+            return XFormParser.loadXmlInstance(formDef, formInstance);
+        } catch (RuntimeException e) {
+            System.out.println(e.getMessage());
             return null;
-        } else {
-            // populate the data model
-            TreeReference tr = TreeReference.rootRef();
-            tr.add(templateRoot.getName(), TreeReference.INDEX_UNBOUND);
-            templateRoot.populate(savedRoot);
-
-            // populated model to current form
-            formDef.getInstance().setRoot(templateRoot);
         }
-
-        return formDef;
     }
 }


### PR DESCRIPTION
These two methods are essentially identical:

https://github.com/dimagi/commcare-core/blob/5184a5d9c4c76192b9d76f599823830c5f40ded0/src/main/java/org/javarosa/xform/parse/XFormParser.java#L2826
https://github.com/dimagi/commcare-core/blob/2f3530ad5df21f233c357ae07630514accb8fece/src/translate/java/org/javarosa/xform/schema/FormInstanceLoader.java#L46

Refactored the one used in less places (the utility in `translate` to call the one in `XFormParser`