### PR TITLE
Adds hint parsing to case claim prompt

### DIFF
--- a/src/main/java/org/commcare/suite/model/DisplayData.java
+++ b/src/main/java/org/commcare/suite/model/DisplayData.java
@@ -1,5 +1,7 @@
 package org.commcare.suite.model;
 
+import javax.annotation.Nullable;
+
 /**
  * Created by wpride1 on 4/24/15.
  *
@@ -8,30 +10,44 @@ package org.commcare.suite.model;
 public class DisplayData {
 
     final String name;
+    @Nullable
     final String imageURI;
+    @Nullable
     final String audioURI;
+    @Nullable
     final String textForBadge;
+    @Nullable
+    final String hintText;
 
-    public DisplayData(String name, String imageURI, String audioURI, String badgeText) {
+    public DisplayData(String name, String imageURI, String audioURI, String badgeText, String hintText) {
         this.name = name;
         this.imageURI = imageURI;
         this.audioURI = audioURI;
         this.textForBadge = badgeText;
+        this.hintText = hintText;
     }
 
     public String getName() {
         return name;
     }
 
+    @Nullable
     public String getImageURI() {
         return imageURI;
     }
 
+    @Nullable
     public String getAudioURI() {
         return audioURI;
     }
 
+    @Nullable
     public String getTextForBadge() {
         return textForBadge;
+    }
+
+    @Nullable
+    public String getHintText() {
+        return hintText;
     }
 }

--- a/src/main/java/org/commcare/suite/model/DisplayUnit.java
+++ b/src/main/java/org/commcare/suite/model/DisplayUnit.java
@@ -11,6 +11,8 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 
+import javax.annotation.Nullable;
+
 /**
  * A display unit element contains text and a set of potential image/audio
  * references for menus or other UI elements
@@ -20,9 +22,14 @@ import java.io.IOException;
 public class DisplayUnit implements Externalizable, DetailTemplate {
 
     private Text name;
+    @Nullable
     private Text imageReference;
+    @Nullable
     private Text audioReference;
+    @Nullable
     private Text badgeFunction;
+    @Nullable
+    private Text hintText;
 
     /**
      * Serialization only!!!
@@ -32,16 +39,17 @@ public class DisplayUnit implements Externalizable, DetailTemplate {
     }
 
     public DisplayUnit(Text name) {
-        this(name, null, null, null);
+        this(name, null, null, null, null);
     }
 
 
     public DisplayUnit(Text name, Text imageReference, Text audioReference,
-                       Text badge) {
+                       Text badge, Text hintText) {
         this.name = name;
         this.imageReference = imageReference;
         this.audioReference = audioReference;
         this.badgeFunction = badge;
+        this.hintText = hintText;
     }
 
     public DisplayData evaluate() {
@@ -53,7 +61,8 @@ public class DisplayUnit implements Externalizable, DetailTemplate {
         String imageRef = imageReference == null ? null : imageReference.evaluate(ec);
         String audioRef = audioReference == null ? null : audioReference.evaluate(ec);
         String textForBadge = badgeFunction == null ? null : badgeFunction.evaluate(ec);
-        return new DisplayData(name.evaluate(ec), imageRef, audioRef, textForBadge);
+        String textForHint = hintText == null ? null : hintText.evaluate(ec);
+        return new DisplayData(name.evaluate(ec), imageRef, audioRef, textForBadge, textForHint);
     }
 
     /**
@@ -64,16 +73,24 @@ public class DisplayUnit implements Externalizable, DetailTemplate {
         return name;
     }
 
+    @Nullable
     public Text getImageURI() {
         return imageReference;
     }
 
+    @Nullable
     public Text getAudioURI() {
         return audioReference;
     }
 
+    @Nullable
     public Text getBadgeText() {
         return badgeFunction;
+    }
+
+    @Nullable
+    public Text getHintText() {
+        return hintText;
     }
 
     @Override
@@ -83,6 +100,7 @@ public class DisplayUnit implements Externalizable, DetailTemplate {
         imageReference = (Text)ExtUtil.read(in, new ExtWrapNullable(Text.class), pf);
         audioReference = (Text)ExtUtil.read(in, new ExtWrapNullable(Text.class), pf);
         badgeFunction = (Text)ExtUtil.read(in, new ExtWrapNullable(Text.class), pf);
+        hintText = (Text)ExtUtil.read(in, new ExtWrapNullable(Text.class), pf);
     }
 
     @Override
@@ -91,6 +109,7 @@ public class DisplayUnit implements Externalizable, DetailTemplate {
         ExtUtil.write(out, new ExtWrapNullable(imageReference));
         ExtUtil.write(out, new ExtWrapNullable(audioReference));
         ExtUtil.write(out, new ExtWrapNullable(badgeFunction));
+        ExtUtil.write(out, new ExtWrapNullable(hintText));
     }
 
 }

--- a/src/main/java/org/commcare/xml/CommCareElementParser.java
+++ b/src/main/java/org/commcare/xml/CommCareElementParser.java
@@ -31,6 +31,7 @@ public abstract class CommCareElementParser<T> extends ElementParser<T> {
         Text audioValue = null;
         Text displayText = null;
         Text badgeText = null;
+        Text hintText = null;
 
         while (nextTagInBlock("display")) {
             if (parser.getName().equals("text")) {
@@ -39,7 +40,7 @@ public abstract class CommCareElementParser<T> extends ElementParser<T> {
                     imageValue = new TextParser(parser).parse();
                 } else if ("audio".equals(attributeValue)) {
                     audioValue = new TextParser(parser).parse();
-                } else if ("badge".equals(attributeValue) ) {
+                } else if ("badge".equals(attributeValue)) {
                     badgeText = new TextParser(parser).parse();
                 } else {
                     displayText = new TextParser(parser).parse();
@@ -56,9 +57,13 @@ public abstract class CommCareElementParser<T> extends ElementParser<T> {
                 }
                 //only ends up grabbing the last entries with
                 //each attribute, but we can only use one of each anyway.
+            } else if ("hint".equals(parser.getName())) {
+                while (nextTagInBlock("hint")) {
+                    hintText = new TextParser(parser).parse();
+                }
             }
         }
 
-        return new DisplayUnit(displayText, imageValue, audioValue, badgeText);
+        return new DisplayUnit(displayText, imageValue, audioValue, badgeText, hintText);
     }
 }


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/QA-2695

Spec: https://docs.google.com/document/d/1kvav59bn6cAmfPAH0H0cith-dq-iGqfc1IsNOxfUocY/edit#heading=h.o94ysl5es54b

Gets the [changes here](https://github.com/dimagi/commcare-core/pull/974/commits/478ac8fc258a908e4abb3d76b3742a5bdd7224af) in master

Above spec definition resulted in a bug on mobile where hint text would override the question display text [during parsing](https://github.com/dimagi/commcare-core/blob/master/src/main/java/org/commcare/xml/CommCareElementParser.java#L36) without these changes being merged for mobile as well. 