### PR TITLE
Detect DAG cycles in case graphs explicitly

### DIFF
--- a/src/main/java/org/javarosa/core/util/DAG.java
+++ b/src/main/java/org/javarosa/core/util/DAG.java
@@ -1,6 +1,7 @@
 package org.javarosa.core.util;
 
 import java.util.Enumeration;
+import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Stack;
 import java.util.Vector;
@@ -161,5 +162,36 @@ public class DAG<I, N, E> {
 
     public Hashtable<I, Vector<Edge<I, E>>> getEdges() {
         return this.edges;
+    }
+
+    public boolean containsCycle() {
+        HashSet<I> visited = new HashSet();
+        HashSet<I> currentPath = new HashSet<>();
+
+        for (I i : nodes.keySet()) {
+            if (nodePathContainsCycle(i, visited, currentPath)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean nodePathContainsCycle(I i, HashSet<I> visited, HashSet<I> currentPath) {
+        if (!visited.contains(i)) {
+            visited.add(i);
+            currentPath.add(i);
+
+            if(edges.containsKey(i)) {
+                for (Edge<I, E> e : edges.get(i)) {
+                    if (!visited.contains(e.i) && nodePathContainsCycle(e.i, visited, currentPath)) {
+                        return true;
+                    } else if (currentPath.contains(e.i)) {
+                        return true;
+                    }
+                }
+            }
+        }
+        currentPath.remove(i);
+        return false;
     }
 }


### PR DESCRIPTION
Fixes the detection portion of https://github.com/dimagi/commcare-core/pull/985. I was incorrect about the initial hunch on guessing the maximum size of a graph walk, since the propagation algorithm can end up walking nodes redundantly (apologies, @shubham1g5 , bad advice on my part).

This replaces the implicit detection with a one-time explicit DFS dive into the graph to find cycles before beginning the purge process. Since we're already doing as (or less) efficient walks as part of the purge, this shouldn't meaningfully affect performance.

https://github.com/dimagi/formplayer/pull/948 should be updated against this once ready.