### PR TITLE
add method to check for presence of case id

### DIFF
--- a/src/cli/java/org/commcare/util/screen/EntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreen.java
@@ -109,8 +109,9 @@ public class EntityScreen extends CompoundScreenHost {
 
         if (full || references.size() == 1) {
             referenceMap = new Hashtable<>();
+            EntityDatum needed = (EntityDatum) session.getNeededDatum();
             for(TreeReference reference: references) {
-                referenceMap.put(getReturnValueFromSelection(reference, (EntityDatum) session.getNeededDatum(), evalContext), reference);
+                referenceMap.put(getReturnValueFromSelection(reference, needed, evalContext), reference);
             }
 
             // for now override 'here()' with the coords of Sao Paulo, eventually allow dynamic setting
@@ -324,8 +325,9 @@ public class EntityScreen extends CompoundScreenHost {
         if (referenceMap != null) {
             return referenceMap.containsKey(stepValue);
         }
+        EntityDatum needed = (EntityDatum) session.getNeededDatum();
         for (TreeReference ref: references) {
-            String id = getReturnValueFromSelection(ref,(EntityDatum) session.getNeededDatum(), evalContext);
+            String id = getReturnValueFromSelection(ref, needed, evalContext);
             if (id.equals(stepValue)) {
                 return true;
             }

--- a/src/cli/java/org/commcare/util/screen/EntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreen.java
@@ -318,4 +318,18 @@ public class EntityScreen extends CompoundScreenHost {
     public Hashtable<String, TreeReference> getReferenceMap() {
         return referenceMap;
     }
+
+    @SupressWarnings("unsused")
+    public boolean referencesContainStep(String stepValue) {
+        if (referenceMap != null) {
+            return referenceMap.containsKey(stepValue);
+        }
+        for (TreeReference ref: references) {
+            String id = getReturnValueFromSelection(ref,(EntityDatum) session.getNeededDatum(), evalContext);
+            if (id.equals(stepValue)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
Follow up for PR feedback on https://github.com/dimagi/formplayer/pull/898 to move the bulk of the logic to the `EntityScreen`

This mostly just copies the logic that already existed, but does check if the `referenceMap` exists, which allows constant time lookup of the answer, but is not generally instantiated during this check (since it involves resolving every item in the entity list).