### PR TITLE
Get case name using 'case-name-descriptor' itext entry

### DIFF
--- a/src/main/java/org/commcare/util/FormMetaIndicatorUtil.java
+++ b/src/main/java/org/commcare/util/FormMetaIndicatorUtil.java
@@ -10,7 +10,7 @@ import io.reactivex.annotations.Nullable;
  */
 public class FormMetaIndicatorUtil {
 
-    public static final String CASE_NAME_DESCRIPTOR = "Pragma-Case-Name";
+    public static final String FORM_DESCRIPTOR = "Pragma-Form-Descriptor";
 
     @Nullable
     public static String getPragma(String key, FormDef formDef, TreeReference contextRef) {

--- a/src/main/java/org/commcare/util/FormMetaIndicatorUtil.java
+++ b/src/main/java/org/commcare/util/FormMetaIndicatorUtil.java
@@ -1,0 +1,24 @@
+package org.commcare.util;
+
+import org.javarosa.core.model.FormDef;
+import org.javarosa.core.model.instance.TreeReference;
+
+import io.reactivex.annotations.Nullable;
+
+/**
+ * @author $|-|!˅@M
+ */
+public class FormMetaIndicatorUtil {
+
+    public static final String CASE_NAME_DESCRIPTOR = "Pragma-Case-Name";
+
+    @Nullable
+    public static String getPragma(String key, FormDef formDef, TreeReference contextRef) {
+        String value = formDef.getLocalizer().getText(key);
+        if(value != null) {
+            return formDef.fillTemplateString(value, contextRef);
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/org/javarosa/form/api/FormController.java
+++ b/src/main/java/org/javarosa/form/api/FormController.java
@@ -5,6 +5,7 @@ import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.TreeElement;
+import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.services.transport.payload.ByteArrayPayload;
 import org.javarosa.model.xform.XFormSerializingVisitor;
 import org.javarosa.model.xform.XPathReference;
@@ -119,6 +120,17 @@ public class FormController {
 
     public void postProcessInstance() {
         mFormEntryController.getModel().getForm().postProcessInstance();
+    }
+
+    @Nullable
+    public String getFormDescriptor() {
+        FormDef formDef = mFormEntryController.getModel().getForm();
+        String caseNameDescriptor = formDef.getLocalizer().getText("case-name-descriptor");
+        if (caseNameDescriptor != null) {
+            return formDef.fillTemplateString(caseNameDescriptor, TreeReference.rootRef());
+        } else {
+            return null;
+        }
     }
 
     public FormInstance getInstance() {

--- a/src/main/java/org/javarosa/form/api/FormController.java
+++ b/src/main/java/org/javarosa/form/api/FormController.java
@@ -5,7 +5,6 @@ import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.TreeElement;
-import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.services.transport.payload.ByteArrayPayload;
 import org.javarosa.model.xform.XFormSerializingVisitor;
 import org.javarosa.model.xform.XPathReference;
@@ -120,17 +119,6 @@ public class FormController {
 
     public void postProcessInstance() {
         mFormEntryController.getModel().getForm().postProcessInstance();
-    }
-
-    @Nullable
-    public String getFormDescriptor() {
-        FormDef formDef = mFormEntryController.getModel().getForm();
-        String caseNameDescriptor = formDef.getLocalizer().getText("case-name-descriptor");
-        if (caseNameDescriptor != null) {
-            return formDef.fillTemplateString(caseNameDescriptor, TreeReference.rootRef());
-        } else {
-            return null;
-        }
     }
 
     public FormInstance getInstance() {


### PR DESCRIPTION
Jira https://dimagi-dev.atlassian.net/browse/SAAS-11500

Uses a special itext `case-name-descriptor` to grab case name from the form. 
cross-request: https://github.com/dimagi/commcare-android/pull/2462