### PR TITLE
Revert "Revert "add method to check for presence of case id""

### DIFF
--- a/src/cli/java/org/commcare/util/screen/EntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreen.java
@@ -109,8 +109,9 @@ public class EntityScreen extends CompoundScreenHost {
 
         if (full || references.size() == 1) {
             referenceMap = new Hashtable<>();
+            EntityDatum needed = (EntityDatum) session.getNeededDatum();
             for(TreeReference reference: references) {
-                referenceMap.put(getReturnValueFromSelection(reference, (EntityDatum) session.getNeededDatum(), evalContext), reference);
+                referenceMap.put(getReturnValueFromSelection(reference, needed, evalContext), reference);
             }
 
             // for now override 'here()' with the coords of Sao Paulo, eventually allow dynamic setting
@@ -317,5 +318,20 @@ public class EntityScreen extends CompoundScreenHost {
     @SuppressWarnings("unused")
     public Hashtable<String, TreeReference> getReferenceMap() {
         return referenceMap;
+    }
+
+    @SupressWarnings("unsused")
+    public boolean referencesContainStep(String stepValue) {
+        if (referenceMap != null) {
+            return referenceMap.containsKey(stepValue);
+        }
+        EntityDatum needed = (EntityDatum) session.getNeededDatum();
+        for (TreeReference ref: references) {
+            String id = getReturnValueFromSelection(ref, needed, evalContext);
+            if (id.equals(stepValue)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/cli/java/org/commcare/util/screen/EntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreen.java
@@ -320,7 +320,6 @@ public class EntityScreen extends CompoundScreenHost {
         return referenceMap;
     }
 
-    @SupressWarnings("unsused")
     public boolean referencesContainStep(String stepValue) {
         if (referenceMap != null) {
             return referenceMap.containsKey(stepValue);

--- a/src/cli/java/org/commcare/util/screen/EntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreen.java
@@ -325,9 +325,8 @@ public class EntityScreen extends CompoundScreenHost {
         if (referenceMap != null) {
             return referenceMap.containsKey(stepValue);
         }
-        EntityDatum needed = (EntityDatum) session.getNeededDatum();
         for (TreeReference ref: references) {
-            String id = getReturnValueFromSelection(ref, needed, evalContext);
+            String id = getReturnValueFromSelection(ref, mNeededDatum, evalContext);
             if (id.equals(stepValue)) {
                 return true;
             }


### PR DESCRIPTION
Reverts dimagi/commcare-core#991
Redo of https://github.com/dimagi/commcare-core/pull/987

Follow up for PR feedback on dimagi/formplayer#898 to move the bulk of the logic to the EntityScreen

This mostly just copies the logic that already existed, but does check if the referenceMap exists, which allows constant time lookup of the answer, but is not generally instantiated during this check (since it involves resolving every item in the entity list).