### PR TITLE
debug log

### DIFF
--- a/src/main/java/org/javarosa/form/api/FormEntryController.java
+++ b/src/main/java/org/javarosa/form/api/FormEntryController.java
@@ -398,7 +398,8 @@ public class FormEntryController {
         if (element instanceof GroupDef) {
             //Assert that this is a valid condition (only field lists return prompts)
             if (!this.isHostWithAppearance(currentIndex, FIELD_LIST)) {
-                throw new RuntimeException("Cannot get question prompts from a non-field-list group");
+                throw new RuntimeException("Cannot get question prompts from a non-field-list group at index "
+                        + currentIndex + " for form " + getModel().getForm().getName());
             }
 
             // Questions to collect


### PR DESCRIPTION
Adding more info for [Sentry](https://sentry.io/organizations/dimagi/discover/formplayer:9102f26e5154409290a0520522ba746f/?field=title&field=event.type&field=project&field=user.display&field=timestamp&field=domain&field=uri&id=8335&name=Case+DB+-+Cannot+get+question+prompts&query=title%3A%22RuntimeException%3A+Cannot+get+question+prompts+from+a+non-field-list+group%22&sort=-timestamp&statsPeriod=30d&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1)

https://dimagi-dev.atlassian.net/browse/USH-724