### PR TITLE
Rotate large labels on x-axis in graph

### DIFF
--- a/src/main/java/org/commcare/core/graph/util/AbsStringExtension.java
+++ b/src/main/java/org/commcare/core/graph/util/AbsStringExtension.java
@@ -1,0 +1,8 @@
+package org.commcare.core.graph.util;
+
+/**
+ * @author $|-|!˅@M
+ */
+public interface AbsStringExtension {
+    int getWidth(String text);
+}

--- a/src/main/java/org/commcare/core/graph/util/StringWidthUtil.java
+++ b/src/main/java/org/commcare/core/graph/util/StringWidthUtil.java
@@ -1,0 +1,22 @@
+package org.commcare.core.graph.util;
+
+/**
+ * @author $|-|!˅@M
+ */
+public class StringWidthUtil {
+    private static AbsStringExtension stringExtension;
+
+    public static void addExtension(AbsStringExtension extension) {
+        stringExtension = extension;
+    }
+
+    /**
+     * Returns the width of string if possible otherwise -1
+     */
+    public static int getStringWidth(String text) {
+        if (stringExtension == null) {
+            return -1;
+        }
+        return stringExtension.getWidth(text);
+    }
+}


### PR DESCRIPTION
Rotates the graph label on x-axis when the label size is too large. 
cross-request: https://github.com/dimagi/commcare-android/pull/2494