### PR TITLE
Use configuration from HQ for rotating x-label

### DIFF
--- a/src/main/java/org/commcare/core/graph/c3/AxisConfiguration.java
+++ b/src/main/java/org/commcare/core/graph/c3/AxisConfiguration.java
@@ -132,9 +132,16 @@ public class AxisConfiguration extends Configuration {
                     mVariables.put(varName, labels.toString());
                     usingCustomText = true;
                     // These custom labels can be large, rotating them ensures that they're shown correctly on X axis.
-                    height = StringWidthUtil.getStringWidth(largestLabel);
-                    if (isX && largestLabel.length() > 5 && height != -1) {
-                        tick.put("rotate", 75);
+                    if (isX) {
+                        height = StringWidthUtil.getStringWidth(largestLabel);
+                        if (largestLabel.length() > 5 && height != -1) {
+                            tick.put("rotate", 75);
+                        }
+                        // Use configuration from HQ
+                        String rotation = mData.getConfiguration("x-label-rotation");
+                        if (rotation != null) {
+                            tick.put("rotate", Integer.parseInt(rotation));
+                        }
                     }
                 } catch (JSONException e) {
                     // Assume labelString is just a scalar, which


### PR DESCRIPTION
Responding to https://forum.dimagi.com/t/commcare-2-52-0-pre-release-available/8279/2 user feedback from forum. 
This PR adds a config `x-label-rotation` to set a rotation angel from HQ. If none is set, we'll default to using 75 whenever label is large. 

Need to update the graph wiki post merge/release. 