### PR TITLE
Rotate 75 degrees for all values

### DIFF
--- a/src/main/java/org/commcare/core/graph/c3/AxisConfiguration.java
+++ b/src/main/java/org/commcare/core/graph/c3/AxisConfiguration.java
@@ -86,7 +86,7 @@ public class AxisConfiguration extends Configuration {
         JSONObject tick = new JSONObject();
         boolean usingCustomText = false;
         boolean isX = key.startsWith("x");
-        int height = -1;
+        int largestHeight = -1;
 
         mVariables.put(varName, "{}");
         if (labelString != null) {
@@ -131,7 +131,7 @@ public class AxisConfiguration extends Configuration {
                     mVariables.put(varName, labels.toString());
                     usingCustomText = true;
                     // These custom labels can be large, rotating them ensures that they're shown correctly on X axis.
-                    height = StringWidthUtil.getStringWidth(largestLabel);
+                    largestHeight = StringWidthUtil.getStringWidth(largestLabel);
                 } catch (JSONException e) {
                     // Assume labelString is just a scalar, which
                     // represents the number of labels the user wants.
@@ -161,13 +161,13 @@ public class AxisConfiguration extends Configuration {
         if ((isX && !isRotatedBarGraph) || (isRotatedBarGraph && key.startsWith("y"))) {
             String largestLabel = mData.getLargestXLabel();
             if (largestLabel != null && !largestLabel.isEmpty()) {
-                int largestHeight = StringWidthUtil.getStringWidth(largestLabel);
-                if (height < largestHeight) {
-                    height = largestHeight;
+                int height = StringWidthUtil.getStringWidth(largestLabel);
+                if (height > largestHeight) {
+                    largestHeight = height;
                 }
             }
             tick.put("rotate", 75);
-            axis.put("height", height);
+            axis.put("height", largestHeight);
         }
         if (tick.length() > 0) {
             axis.put("tick", tick);

--- a/src/main/java/org/commcare/core/graph/c3/AxisConfiguration.java
+++ b/src/main/java/org/commcare/core/graph/c3/AxisConfiguration.java
@@ -191,7 +191,7 @@ public class AxisConfiguration extends Configuration {
 
         // Show title regardless of whether or not it exists, to give all graphs consistent padding
         JSONObject label = new JSONObject();
-        label.put("text", "title, rad");
+        label.put("text", title);
         label.put("position", position);
         axis.put("label", label);
     }

--- a/src/main/java/org/commcare/core/graph/c3/AxisConfiguration.java
+++ b/src/main/java/org/commcare/core/graph/c3/AxisConfiguration.java
@@ -35,8 +35,7 @@ public class AxisConfiguration extends Configuration {
         mConfiguration.put("y2", y2);
 
         // Bar graphs may be rotated. C3 defaults to vertical bars.
-        if (mData.getType().equals(GraphUtil.TYPE_BAR)
-                && !mData.getConfiguration("bar-orientation", "horizontal").equalsIgnoreCase("vertical")) {
+        if (isRotatedBarGraph) {
             mConfiguration.put("rotated", true);
         }
     }
@@ -133,9 +132,6 @@ public class AxisConfiguration extends Configuration {
                     usingCustomText = true;
                     // These custom labels can be large, rotating them ensures that they're shown correctly on X axis.
                     height = StringWidthUtil.getStringWidth(largestLabel);
-                    if (isX && largestLabel.length() > 5 && height != -1) {
-                        tick.put("rotate", 75);
-                    }
                 } catch (JSONException e) {
                     // Assume labelString is just a scalar, which
                     // represents the number of labels the user wants.
@@ -162,11 +158,19 @@ public class AxisConfiguration extends Configuration {
             }
         }
 
+        if ((isX && !isRotatedBarGraph) || (isRotatedBarGraph && key.startsWith("y"))) {
+            String largestLabel = mData.getLargestXLabel();
+            if (largestLabel != null && !largestLabel.isEmpty()) {
+                int largestHeight = StringWidthUtil.getStringWidth(largestLabel);
+                if (height < largestHeight) {
+                    height = largestHeight;
+                }
+            }
+            tick.put("rotate", 75);
+            axis.put("height", height);
+        }
         if (tick.length() > 0) {
             axis.put("tick", tick);
-            if (isX && height != -1) {
-                axis.put("height", height);
-            }
         }
     }
 
@@ -187,7 +191,7 @@ public class AxisConfiguration extends Configuration {
 
         // Show title regardless of whether or not it exists, to give all graphs consistent padding
         JSONObject label = new JSONObject();
-        label.put("text", title);
+        label.put("text", "title, rad");
         label.put("position", position);
         axis.put("label", label);
     }

--- a/src/main/java/org/commcare/core/graph/c3/Configuration.java
+++ b/src/main/java/org/commcare/core/graph/c3/Configuration.java
@@ -3,6 +3,7 @@ package org.commcare.core.graph.c3;
 import org.commcare.core.graph.model.GraphData;
 import org.commcare.core.graph.util.GraphException;
 
+import org.commcare.core.graph.util.GraphUtil;
 import org.json.JSONObject;
 
 import java.text.SimpleDateFormat;
@@ -25,11 +26,14 @@ public class Configuration {
     final GraphData mData;
     final JSONObject mConfiguration;
     final SortedMap<String, String> mVariables;
+    final boolean isRotatedBarGraph;
 
     Configuration(GraphData data) {
         mData = data;
         mConfiguration = new JSONObject();
         mVariables = new TreeMap<>();
+        isRotatedBarGraph = mData.getType().equals(GraphUtil.TYPE_BAR)
+                && !mData.getConfiguration("bar-orientation", "horizontal").equalsIgnoreCase("vertical");
     }
 
     public JSONObject getConfiguration() {

--- a/src/main/java/org/commcare/core/graph/c3/DataConfiguration.java
+++ b/src/main/java/org/commcare/core/graph/c3/DataConfiguration.java
@@ -378,7 +378,7 @@ public class DataConfiguration extends Configuration {
                     if (!isRotatedBarGraph) {
                         currentXLabelStr = p.getX();
                     }
-                    mBarLabels.put(currentXLabelStr);
+                    mBarLabels.put(p.getX());
                 }
             } else {
                 if (mData.getType().equals(GraphUtil.TYPE_TIME)) {

--- a/src/main/java/org/commcare/core/graph/c3/DataConfiguration.java
+++ b/src/main/java/org/commcare/core/graph/c3/DataConfiguration.java
@@ -387,11 +387,11 @@ public class DataConfiguration extends Configuration {
                 } else {
                     double val = parseDouble(p.getX(), description);
                     xValues.put(val);
-                    currentXLabelStr = "" + val;
+                    currentXLabelStr = String.valueOf(val);
                 }
             }
             if (isRotatedBarGraph) {
-                currentXLabelStr = "" + parseDouble(p.getY(), description);
+                currentXLabelStr = String.valueOf(parseDouble(p.getY(), description));
             }
             if (currentXLabelStr.length() > largestLabel.length()) {
                 largestLabel = currentXLabelStr;

--- a/src/main/java/org/commcare/core/graph/c3/DataConfiguration.java
+++ b/src/main/java/org/commcare/core/graph/c3/DataConfiguration.java
@@ -358,12 +358,14 @@ public class DataConfiguration extends Configuration {
         xValues.put(xID);
         yValues.put(yID);
 
+        String largestLabel = "";
         int barIndex = 0;
         boolean addBarLabels = mData.getType().equals(GraphUtil.TYPE_BAR) && mBarLabels.length() == 1;
         JSONArray rValues = new JSONArray();
         double maxRadius = parseDouble(s.getConfiguration("max-radius", "0"), "max-radius");
         for (XYPointData p : s.getPoints()) {
             String description = "data (" + p.getX() + ", " + p.getY() + ")";
+            String currentXLabelStr = "";
             if (mData.getType().equals(GraphUtil.TYPE_BAR)) {
                 // In CommCare, bar graphs are specified with x as a set of text labels
                 // and y as a set of values. In C3, bar graphs are still basically
@@ -373,14 +375,26 @@ public class DataConfiguration extends Configuration {
                 xValues.put(barIndex + 1);
                 mBarCount = Math.max(mBarCount, barIndex + 1);
                 if (addBarLabels) {
-                    mBarLabels.put(p.getX());
+                    if (!isRotatedBarGraph) {
+                        currentXLabelStr = p.getX();
+                    }
+                    mBarLabels.put(currentXLabelStr);
                 }
             } else {
                 if (mData.getType().equals(GraphUtil.TYPE_TIME)) {
-                    xValues.put(parseTime(p.getX(), description));
+                    currentXLabelStr = parseTime(p.getX(), description);
+                    xValues.put(currentXLabelStr);
                 } else {
-                    xValues.put(parseDouble(p.getX(), description));
+                    double val = parseDouble(p.getX(), description);
+                    xValues.put(val);
+                    currentXLabelStr = "" + val;
                 }
+            }
+            if (isRotatedBarGraph) {
+                currentXLabelStr = "" + parseDouble(p.getY(), description);
+            }
+            if (currentXLabelStr.length() > largestLabel.length()) {
+                largestLabel = currentXLabelStr;
             }
             yValues.put(parseDouble(p.getY(), description));
 
@@ -400,6 +414,7 @@ public class DataConfiguration extends Configuration {
             mRadii.put(yID, rValues);
             mMaxRadii.put(yID, maxRadius);
         }
+        mData.setLargestXLabel(largestLabel);
     }
 
     /**

--- a/src/main/java/org/commcare/core/graph/model/GraphData.java
+++ b/src/main/java/org/commcare/core/graph/model/GraphData.java
@@ -13,6 +13,8 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.Vector;
 
+import javax.annotation.Nullable;
+
 /**
  * Contains all of the fully-evaluated data to draw a graph: a type, set of series, set of text annotations, and key-value map of configuration.
  *
@@ -23,6 +25,9 @@ public class GraphData implements ConfigurableData {
     private final Vector<SeriesData> mSeries;
     private final Hashtable<String, String> mConfiguration;
     private final Vector<AnnotationData> mAnnotations;
+
+    @Nullable
+    private String largestXLabel;
 
     public GraphData() {
         mSeries = new Vector<>();
@@ -52,6 +57,15 @@ public class GraphData implements ConfigurableData {
 
     public Vector<AnnotationData> getAnnotations() {
         return mAnnotations;
+    }
+
+    @Nullable
+    public String getLargestXLabel() {
+        return largestXLabel;
+    }
+
+    public void setLargestXLabel(@Nullable String largestXLabel) {
+        this.largestXLabel = largestXLabel;
     }
 
     @Override


### PR DESCRIPTION
Fix for https://dimagi-dev.atlassian.net/browse/QA-3223
Earlier we were only rotating labels when someone was using json specified `x-labels`. Now, we'll be rotating x labels for all values. 