### PR TITLE
Fix issues with graph label overlapping

### DIFF
--- a/src/main/java/org/commcare/core/graph/c3/AxisConfiguration.java
+++ b/src/main/java/org/commcare/core/graph/c3/AxisConfiguration.java
@@ -158,7 +158,7 @@ public class AxisConfiguration extends Configuration {
             }
         }
 
-        if ((isX && !isRotatedBarGraph) || (isRotatedBarGraph && key.startsWith("y"))) {
+        if (isX && !isRotatedBarGraph) {
             String largestLabel = mData.getLargestXLabel();
             if (largestLabel != null && !largestLabel.isEmpty()) {
                 int height = StringWidthUtil.getStringWidth(largestLabel);
@@ -168,6 +168,9 @@ public class AxisConfiguration extends Configuration {
             }
             tick.put("rotate", 75);
             axis.put("height", largestHeight);
+        } else if (isRotatedBarGraph && key.startsWith("y")) {
+            // For rotated bar graph, we will show the label inside the graph so no need to set height
+            tick.put("rotate", 75);
         }
         if (tick.length() > 0) {
             axis.put("tick", tick);
@@ -219,7 +222,12 @@ public class AxisConfiguration extends Configuration {
         // Undo C3's automatic axis padding
         config.put("padding", new JSONObject("{top: 0, right: 0, bottom: 0, left: 0}"));
 
-        addTitle(config, prefix + "-title", isX ? "outer-center" : "outer-middle");
+
+        if (isRotatedBarGraph && prefix.startsWith("y")) {
+            addTitle(config, prefix + "-title", "inner-right");
+        } else {
+            addTitle(config, prefix + "-title", isX ? "outer-center" : "outer-middle");
+        }
 
         addBounds(config, prefix);
 

--- a/src/main/java/org/commcare/core/graph/c3/DataConfiguration.java
+++ b/src/main/java/org/commcare/core/graph/c3/DataConfiguration.java
@@ -382,8 +382,9 @@ public class DataConfiguration extends Configuration {
                 }
             } else {
                 if (mData.getType().equals(GraphUtil.TYPE_TIME)) {
-                    currentXLabelStr = parseTime(p.getX(), description);
-                    xValues.put(currentXLabelStr);
+                    String time = parseTime(p.getX(), description); // c3 needs YYYY-MM-DD HH:MM:SS format
+                    currentXLabelStr = time.split(" ")[0]; // On graph we only show YYYY-MM-DD
+                    xValues.put(time);
                 } else {
                     double val = parseDouble(p.getX(), description);
                     xValues.put(val);


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/QA-3223

This PR addresses 2 issues: 
- When we use horizontal bar graphs(rotated=true), y and x axis interchange. https://c3js.org/reference.html#axis-x-height C3 supports setting height for x-axis but not for y-axis, so the label overlap with ticks. 
To overcome this, for rotated bar graphs, we'll not set the height and simply show the labels inside the graph [inner-right](https://c3js.org/samples/axes_label_position.html)
- Secondly, for time graphs, c3 accepts the ticks in format [YYYY-MM-DD HH:MM:SS](https://github.com/dimagi/commcare-core/blob/master/src/main/java/org/commcare/core/graph/c3/Configuration.java#L49), but in the graph we truncate the ticks and only show [YYYY-MM-DD](https://github.com/dimagi/commcare-core/blob/master/src/main/java/org/commcare/core/graph/c3/AxisConfiguration.java#L148) part. This was causing issues because the height calculation was taking the full string. This PR will change that and use the `largest label` to store  the actual string that'll be shown on graph. 


Rotated Bar Graph Before: 
![before_rotated](https://user-images.githubusercontent.com/29516995/124874228-1c494200-dfe5-11eb-85d8-257ca0cecc8b.jpeg)

Rotated Bar Graph Updated:
![after_rotated](https://user-images.githubusercontent.com/29516995/124874269-2703d700-dfe5-11eb-81a7-1e5594cd287e.jpeg)

Time Graph Before: 
![before_time](https://user-images.githubusercontent.com/29516995/124874288-2cf9b800-dfe5-11eb-8ccb-3de331908593.jpeg)

Time Graph Updated: 
![after_time](https://user-images.githubusercontent.com/29516995/124874304-32570280-dfe5-11eb-88e9-29dddc159dbd.jpeg)


