### PR TITLE
Avoid having Duplicate params in case search

### DIFF
--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -118,8 +118,10 @@ public class RemoteQuerySessionManager {
             for (Enumeration e = userAnswers.keys(); e.hasMoreElements(); ) {
                 String key = (String)e.nextElement();
                 String value = userAnswers.get(key);
-                if (!StringUtils.isEmpty(value)) {
-                    params.put(key, userAnswers.get(key));
+                if (!(params.containsKey(key) && params.get(key).contains(value))) {
+                    if (!StringUtils.isEmpty(value)) {
+                        params.put(key, userAnswers.get(key));
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/dimagi/commcare-core/pull/1002 which causes same key-value pair to be included twice in the case search params for ex when the rating is specified as user input and hidden search property as well it results in url https://www.commcarehq.org/a/domain/phone/search/?rating=5&rating=5

This is causing a test to fail in  https://github.com/dimagi/formplayer/pull/976 after switch to Multimap. 