### PR TITLE
Fixed StackOperation.buildClearFrame

### DIFF
--- a/src/main/java/org/commcare/suite/model/StackOperation.java
+++ b/src/main/java/org/commcare/suite/model/StackOperation.java
@@ -60,7 +60,7 @@ public class StackOperation implements Externalizable {
     }
 
     public static StackOperation buildClearFrame(String ifCondition) throws XPathSyntaxException {
-        return new StackOperation(OPERATION_CLEAR, ifCondition, null);
+        return new StackOperation(OPERATION_CLEAR, ifCondition, new Vector<>());
     }
 
     private StackOperation(int opType, String ifCondition,


### PR DESCRIPTION
Found this while experimenting with clear operations in the CLI.

Clear ops [don't support children](https://github.com/dimagi/commcare-core/blob/16397aa3df78c238f6b6f9341ccb786cdc89d428/src/main/java/org/commcare/xml/StackOpParser.java#L40), so this constructor passes in null, but that ultimately breaks serialization:
```
Unhandled Fatal Error executing CommCare appjava.lang.NullPointerException
        at org.javarosa.core.util.externalizable.ExtWrapList.<init>(ExtWrapList.java:24)
        at org.javarosa.core.util.externalizable.ExtWrapList.<init>(ExtWrapList.java:19)
        at org.commcare.suite.model.StackOperation.writeExternal(StackOperation.java:122)
        ...
```