### PR TITLE
Make endpoint args error more user friendly (formplayer)

### DIFF
--- a/src/main/java/org/commcare/suite/model/Endpoint.java
+++ b/src/main/java/org/commcare/suite/model/Endpoint.java
@@ -62,7 +62,8 @@ public class Endpoint implements Externalizable {
         Vector<String> endpointArguments = endpoint.getArguments();
 
         if (endpointArguments.size() > args.size()) {
-            throw new InvalidNumberOfEndpointArgumentsException();
+            Vector<String> missingArguments = new Vector<String>(endpointArguments.subList(args.size(), endpointArguments.size()));
+            throw new InvalidEndpointArgumentsException(missingArguments, null);
         }
 
         for (int i = 0; i < endpointArguments.size(); i++) {
@@ -74,34 +75,47 @@ public class Endpoint implements Externalizable {
     public static void populateEndpointArgumentsToEvaluationContext(Endpoint endpoint, HashMap<String, String> args, EvaluationContext evaluationContext) {
         Vector<String> endpointArguments = endpoint.getArguments();
 
-        if (endpointArguments.size() > args.size()) {
-            throw new InvalidNumberOfEndpointArgumentsException();
+        Vector<String> missingArguments = (Vector<String>)endpointArguments.clone();
+        missingArguments.removeAll(args.keySet());
+
+        Vector<String> unexpectedArguments = new Vector<String>(args.keySet());
+        unexpectedArguments.removeAll(endpointArguments);
+
+        if (missingArguments.size() > 0 || unexpectedArguments.size() > 0) {
+            throw new InvalidEndpointArgumentsException(missingArguments, unexpectedArguments);
         }
 
         for (int i = 0; i < endpointArguments.size(); i++) {
             String argumentName = endpointArguments.elementAt(i);
             if (args.containsKey(argumentName)) {
                 evaluationContext.setVariable(argumentName, args.get(argumentName));
-            } else {
-                throw new InvalidEndpointArgumentsException(argumentName);
             }
         }
     }
 
     public static class InvalidEndpointArgumentsException extends RuntimeException {
-        private final String argumentName;
+        private final Vector<String> missingArguments;
+        private final Vector<String> unexpectedArguments;
 
-        public InvalidEndpointArgumentsException(String argumentName) {
-            this.argumentName = argumentName;
+        public InvalidEndpointArgumentsException(Vector<String> missingArguments, Vector<String> unexpectedArguments) {
+            this.missingArguments = missingArguments;
+            this.unexpectedArguments = unexpectedArguments;
         }
 
-        public String getArgumentName() {
-            return argumentName;
+        public boolean hasMissingArguments() {
+            return missingArguments != null && missingArguments.size() > 0;
         }
-    }
 
-    public static class InvalidNumberOfEndpointArgumentsException extends RuntimeException {
-        public InvalidNumberOfEndpointArgumentsException() {
+        public Vector<String> getMissingArguments() {
+            return missingArguments;
+        }
+
+        public boolean hasUnexpectedArguments() {
+            return unexpectedArguments != null && unexpectedArguments.size() > 0;
+        }
+
+        public Vector<String> getUnexpectedArguments() {
+            return unexpectedArguments;
         }
     }
 }


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/QA-3382

Show user both missing and invalid arguments.

Corresponds to https://github.com/dimagi/formplayer/pull/993 but can be merged earlier, since formplayer doesn't support endpoints yet.
