### PR TITLE
Update CliTests.java

### DIFF
--- a/src/test/java/org/cli/CliTests.java
+++ b/src/test/java/org/cli/CliTests.java
@@ -217,8 +217,8 @@ public class CliTests {
         void processLine(int stepIndex, String output) {
             switch(stepIndex) {
                 case 0:
-                    Assert.assertTrue(output.contains("0)Update a Case"));
-                    Assert.assertTrue(output.contains("1)Close a Case"));
+                    Assert.assertTrue(output.contains("0) Update a Case"));
+                    Assert.assertTrue(output.contains("1) Close a Case"));
                     throw new TestPassException();
                 default:
                     throw new RuntimeException(String.format("Did not recognize output %s at stepIndex %s", output, stepIndex));


### PR DESCRIPTION
This should fix the test failure on https://github.com/dimagi/commcare-android/pull/2522

This is a merge conflict that was missed because of PR timing. https://github.com/dimagi/commcare-core/pull/1019/commits/ebbb27f521b774e03662d68b3742b41e06d09a8e updated spacing, while at the same time https://github.com/dimagi/commcare-core/pull/1020 added this new test with the old spacing style.

I think that I had branched https://github.com/dimagi/commcare-core/pull/1026 off of an old version of master and that's why tests didn't fail on it.