### PR TITLE
CLI remote query entry (II)

### DIFF
--- a/src/cli/java/org/commcare/util/cli/ApplicationHost.java
+++ b/src/cli/java/org/commcare/util/cli/ApplicationHost.java
@@ -183,11 +183,13 @@ public class ApplicationHost {
                     printStream.println(s.getWrappedDisplaytitle(mSandbox, mPlatform));
 
                     printStream.println("====================");
-                    s.prompt(printStream);
-                    printStream.print("> ");
-
+                    boolean requiresInput = s.prompt(printStream);
                     screenIsRedrawing = false;
-                    String input = reader.readLine();
+                    String input = "";
+                    if (requiresInput) {
+                        printStream.print("> ");
+                        input = reader.readLine();
+                    }
 
                     //TODO: Command language
                     if (input.startsWith(":")) {

--- a/src/cli/java/org/commcare/util/mocks/MockQueryClient.java
+++ b/src/cli/java/org/commcare/util/mocks/MockQueryClient.java
@@ -1,0 +1,24 @@
+package org.commcare.util.mocks;
+
+import okhttp3.Request;
+import org.commcare.util.screen.QueryScreen;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+public class MockQueryClient implements QueryScreen.QueryClient {
+    private InputStream mockResponse;
+
+    public MockQueryClient(String mockResponse) {
+        this.mockResponse = new ByteArrayInputStream(mockResponse.getBytes());;
+    }
+
+    public MockQueryClient(InputStream mockResponse) {
+        this.mockResponse = mockResponse;
+    }
+
+    @Override
+    public InputStream makeRequest(Request request) {
+        return mockResponse;
+    }
+}

--- a/src/cli/java/org/commcare/util/screen/CompoundScreenHost.java
+++ b/src/cli/java/org/commcare/util/screen/CompoundScreenHost.java
@@ -21,8 +21,9 @@ public abstract class CompoundScreenHost extends Screen {
     public abstract Subscreen getCurrentScreen();
 
     @Override
-    public void prompt(PrintStream out) throws CommCareSessionException {
+    public boolean prompt(PrintStream out) throws CommCareSessionException {
         getCurrentScreen().prompt(out);
+        return true;
     }
 
     @Override

--- a/src/cli/java/org/commcare/util/screen/MenuScreen.java
+++ b/src/cli/java/org/commcare/util/screen/MenuScreen.java
@@ -95,11 +95,12 @@ public class MenuScreen extends Screen {
     }
 
     @Override
-    public void prompt(PrintStream out) {
+    public boolean prompt(PrintStream out) {
         for (int i = 0; i < mChoices.length; ++i) {
             MenuDisplayable d = mChoices[i];
             out.println(i + ")" + d.getDisplayText(mSession.getEvaluationContextWithAccumulatedInstances(d.getCommandID(), d.getRawText())));
         }
+        return true;
     }
 
     @Override

--- a/src/cli/java/org/commcare/util/screen/QueryScreen.java
+++ b/src/cli/java/org/commcare/util/screen/QueryScreen.java
@@ -213,11 +213,15 @@ public class QueryScreen extends Screen {
     }
 
     @Override
-    public void prompt(PrintStream out) {
+    public boolean prompt(PrintStream out) {
+        if (doDefaultSearch()) {
+            return false;
+        }
         out.println("Enter the search fields as a space separated list.");
         for (int i = 0; i < fields.length; i++) {
             out.println(i + ") " + fields[i]);
         }
+        return true;
     }
 
     @Override

--- a/src/cli/java/org/commcare/util/screen/Screen.java
+++ b/src/cli/java/org/commcare/util/screen/Screen.java
@@ -28,7 +28,13 @@ public abstract class Screen implements OptionsScreen {
      */
     public abstract void init(SessionWrapper session) throws CommCareSessionException;
 
-    public abstract void prompt(PrintStream out) throws CommCareSessionException;
+    /**
+     * Display a prompt to the user.
+     * @param out Output stream to write the prompt to.
+     * @return True if the screen requires an input from the user.
+     * @throws CommCareSessionException
+     */
+    public abstract boolean prompt(PrintStream out) throws CommCareSessionException;
 
     /**
      * Based on the the input provided from the user to the command line, either update the session

--- a/src/cli/java/org/commcare/util/screen/SyncScreen.java
+++ b/src/cli/java/org/commcare/util/screen/SyncScreen.java
@@ -112,12 +112,13 @@ public class SyncScreen extends Screen {
     }
 
     @Override
-    public void prompt(PrintStream printStream) throws CommCareSessionException {
+    public boolean prompt(PrintStream printStream) throws CommCareSessionException {
         if (syncSuccessful) {
             printStream.println("Sync complete, press Enter to continue");
         } else {
             printStream.println("Sync failed, press Enter to retry");
         }
+        return true;
     }
 
     @Override

--- a/src/main/java/org/commcare/core/process/CommCareInstanceInitializer.java
+++ b/src/main/java/org/commcare/core/process/CommCareInstanceInitializer.java
@@ -2,11 +2,12 @@ package org.commcare.core.process;
 
 import org.commcare.cases.instance.CaseDataInstance;
 import org.commcare.cases.instance.CaseInstanceTreeElement;
-import org.commcare.cases.instance.IndexedFixtureInstanceTreeElement;
 import org.commcare.cases.instance.LedgerInstanceTreeElement;
 import org.commcare.core.interfaces.UserSandbox;
 import org.commcare.core.sandbox.SandboxUtils;
+import org.commcare.session.SessionFrame;
 import org.commcare.session.SessionInstanceBuilder;
+import org.commcare.suite.model.StackFrameStep;
 import org.commcare.util.CommCarePlatform;
 import org.javarosa.core.model.User;
 import org.commcare.session.CommCareSession;
@@ -176,6 +177,11 @@ public class CommCareInstanceInitializer extends InstanceInitializationFactory {
     }
 
     protected AbstractTreeElement setupRemoteData(ExternalDataInstance instance) {
+        for (StackFrameStep step : session.getFrame().getSteps()) {
+            if (step.getId().equals(instance.getInstanceId()) && step.getType().equals(SessionFrame.STATE_QUERY_REQUEST)) {
+                return step.getXmlInstance().getRoot();
+            }
+        }
         return instance.getRoot();
     }
 

--- a/src/test/java/org/commcare/backend/suite/model/test/QueryModelTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/QueryModelTests.java
@@ -1,0 +1,56 @@
+package org.commcare.backend.suite.model.test;
+
+import org.commcare.core.process.CommCareInstanceInitializer;
+import org.commcare.modern.session.SessionWrapper;
+import org.commcare.session.SessionFrame;
+import org.commcare.suite.model.RemoteQueryDatum;
+import org.commcare.suite.model.SessionDatum;
+import org.commcare.suite.model.StackFrameStep;
+import org.commcare.test.utilities.MockApp;
+import org.commcare.util.mocks.MockQueryClient;
+import org.commcare.util.screen.QueryScreen;
+import org.javarosa.core.model.instance.AbstractTreeElement;
+import org.javarosa.core.model.instance.ExternalDataInstance;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.InputStream;
+
+/**
+ * Basic test for remote query as part of form entry session
+ */
+public class QueryModelTests {
+
+    @Test
+    public void testQueryEntryDatum() throws Exception {
+        MockApp mApp = new MockApp("/case_claim_example/");
+
+        SessionWrapper session = mApp.getSession();
+        session.setCommand("m0-f0");
+
+        SessionDatum datum = session.getNeededDatum();
+        Assert.assertTrue(datum instanceof RemoteQueryDatum);
+        Assert.assertEquals("registry", datum.getDataId());
+
+        // construct the screen
+        QueryScreen screen = new QueryScreen("username", "password", System.out);
+        screen.init(session);
+
+        // mock the query response
+        InputStream response = this.getClass().getResourceAsStream("/case_claim_example/query_response.xml");
+        screen.setClient(new MockQueryClient(response));
+
+        // perform the query
+        boolean success = screen.handleInputAndUpdateSession(session, "", false);
+        Assert.assertTrue(success);
+
+        // check that the datum got set and can be accessed correctly
+        CommCareInstanceInitializer iif = session.getIIF();
+        AbstractTreeElement root = iif.generateRoot(new ExternalDataInstance(ExternalDataInstance.JR_REMOTE_REFERENCE, "registry1"));
+        Assert.assertEquals("results", root.getName());
+        Assert.assertEquals(1, root.getNumChildren());
+
+        AbstractTreeElement root1 = iif.generateRoot(new ExternalDataInstance(ExternalDataInstance.JR_REMOTE_REFERENCE, "not-registry"));
+        Assert.assertNull("Expect that response is null if instanceId does not match", root1);
+    }
+}

--- a/src/test/java/org/commcare/backend/suite/model/test/QueryModelTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/QueryModelTests.java
@@ -30,7 +30,7 @@ public class QueryModelTests {
 
         SessionDatum datum = session.getNeededDatum();
         Assert.assertTrue(datum instanceof RemoteQueryDatum);
-        Assert.assertEquals("registry", datum.getDataId());
+        Assert.assertEquals("registry1", datum.getDataId());
 
         // construct the screen
         QueryScreen screen = new QueryScreen("username", "password", System.out);

--- a/src/test/resources/case_claim_example/query_response.xml
+++ b/src/test/resources/case_claim_example/query_response.xml
@@ -1,0 +1,7 @@
+<results id="case">
+	<case case_id="case_two" case_type="person" owner_id="owner1" status="open">
+		<case_name>Lucy</case_name>
+		<date_opened>2014-08-04T21:09:07.000000Z</date_opened>
+		<last_modified>2014-08-04T21:09:07.000000Z</last_modified>
+	</case>
+</results>

--- a/src/test/resources/case_claim_example/suite.xml
+++ b/src/test/resources/case_claim_example/suite.xml
@@ -87,9 +87,10 @@
     <command id="m0-f0">
       <text>Form</text>
     </command>
-    <instance id="casedb" src="jr://instance/casedb"/>
     <session>
-      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='test_case'][@status='open']" value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
+      <query url="http://www.example.com/a/domain/phone/get_case/" storage-instance="registry" template="case" default_search="true">
+        <data key="case_type" ref="'case'"/>
+      </query>
     </session>
   </entry>
   <menu id="root">

--- a/src/test/resources/case_claim_example/suite.xml
+++ b/src/test/resources/case_claim_example/suite.xml
@@ -88,7 +88,7 @@
       <text>Form</text>
     </command>
     <session>
-      <query url="http://www.example.com/a/domain/phone/get_case/" storage-instance="registry" template="case" default_search="true">
+      <query url="http://www.example.com/a/domain/phone/get_case/" storage-instance="registry1" template="case" default_search="true">
         <data key="case_type" ref="'case'"/>
       </query>
     </session>


### PR DESCRIPTION
Redo of: https://github.com/dimagi/commcare-core/pull/1030

Changes to the CLI to allow using a query in a form entry session to get data from remote:

Suite file entry:
```xml
  <entry>
    <form>http://openrosa.org/formdesigner/C6C1CFA4-6994-4CE9-8C56-16673A5EEED2</form>
    <command id="m0-f0">
      <text>
        <locale id="forms.m0f0"/>
      </text>
    </command>
    <instance id="commcaresession" src="jr://instance/session"/>
    <session>
      <datum id="case_id_new_case_0" function="uuid()"/>
      <query url="http://localhost:8000/a/test/phone/get_case/" storage-instance="registry" template="case" default_search="true">
        <data key="case_type" ref="'case'"/>
        <data key="case_id" ref="instance('commcaresession')/session/data/case_id_new_case_0"/>
        <data key="registry" ref="'test_registry'"/>
      </query>
    </session>
  </entry>
```

form XML:
```xml
<instance id="registry" src="jr://instance/remote"/>
<bind nodeset="/data/registry_result" calculate="instance('registry')/results/case[@case_id='2f462e82-1cea-4638-896b-f36b3dc73ee7']/case_name" />
```

I'm not 100% sure these are the right set of changes but they do work locally. Also unclear how to test this in a unit test.