### PR TITLE
Updated refreshItemSetChoices to quit if no prompts

### DIFF
--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -189,6 +189,10 @@ public class RemoteQuerySessionManager {
     // loops over query prompts and validates selection until all selections are valid
     public void refreshItemSetChoices(Hashtable<String, String> userAnswers) {
         OrderedHashtable<String, QueryPrompt> userInputDisplays = getNeededUserInputDisplays();
+        if (userInputDisplays.size() == 0) {
+            return;
+        }
+
         boolean dirty = true;
         int index = 0;
         while (dirty) {


### PR DESCRIPTION
`refreshItemSetChoices` assumes that the datum has prompts, but the query datums being used for registries don't have any.