### PR TITLE
remove artificial constraint on 'casedb' instance naming

### DIFF
--- a/src/main/java/org/commcare/cases/instance/CaseDataInstance.java
+++ b/src/main/java/org/commcare/cases/instance/CaseDataInstance.java
@@ -34,13 +34,7 @@ public class CaseDataInstance extends ExternalDataInstance {
     @Override
     public boolean hasTemplatePath(TreeReference ref) {
         loadTemplateSpecLazily();
-
-
-        // enforce (artificial) constraint that the instance name matches the
-        // root element name. For instance, instance('casedb')/casedb
-        boolean instanceNameMatch = ref.size() > 0 && instanceid.equals(ref.getName(0));
-
-        return instanceNameMatch && followsTemplateSpec(ref, caseDbSpecTemplate, 1);
+        return followsTemplateSpec(ref, caseDbSpecTemplate, 1);
     }
 
     private static synchronized void loadTemplateSpecLazily() {


### PR DESCRIPTION
I don't see a need for this constraint and with the addition
of more kinds of remote instances this constraint is likely to make it harder
to build workflows.

This was added here https://github.com/dimagi/commcare-core/pull/440/files#diff-ceb723c24e744a4a27afbbfc7905d161ec4820fa70b6875fb31cafda438cdb97R41