### PR TITLE
Suggested refactor for Query Datum support

### DIFF
--- a/src/cli/java/org/commcare/util/screen/QueryScreen.java
+++ b/src/cli/java/org/commcare/util/screen/QueryScreen.java
@@ -170,7 +170,7 @@ public class QueryScreen extends Screen {
         }
         Pair<ExternalDataInstance, String> instanceOrError;
         try {
-            ExternalDataInstance instance = ExternalDataInstance.buildFromRemote(getQueryDatum().getDataId(), ExternalDataInstance.parseExternalTree(responseData, getQueryDatum().getDataId()), new ExternalDataInstanceSource(url), getQueryDatum().useCaseTemplate());
+            ExternalDataInstance instance = ExternalDataInstance.buildFromRemote(getQueryDatum().getDataId(), new ExternalDataInstanceSource(getQueryDatum().getDataId(), ExternalDataInstance.parseExternalTree(responseData, getQueryDatum().getDataId()), url), getQueryDatum().useCaseTemplate());
             instanceOrError =  new Pair<>(instance, "");
         } catch (InvalidStructureException | IOException
                 | XmlPullParserException | UnfullfilledRequirementsException e) {

--- a/src/cli/java/org/commcare/util/screen/QueryScreen.java
+++ b/src/cli/java/org/commcare/util/screen/QueryScreen.java
@@ -11,6 +11,7 @@ import org.commcare.suite.model.QueryPrompt;
 import org.commcare.suite.model.RemoteQueryDatum;
 import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.instance.ExternalDataInstance;
+import org.javarosa.core.model.instance.ExternalDataInstanceSource;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.util.NoLocalizedTextException;
@@ -169,7 +170,7 @@ public class QueryScreen extends Screen {
         }
         Pair<ExternalDataInstance, String> instanceOrError;
         try {
-            ExternalDataInstance instance = ExternalDataInstance.buildFromRemote(getQueryDatum().getDataId(), responseData, url, getQueryDatum().useCaseTemplate());
+            ExternalDataInstance instance = ExternalDataInstance.buildFromRemote(getQueryDatum().getDataId(), ExternalDataInstance.parseExternalTree(responseData, getQueryDatum().getDataId()), new ExternalDataInstanceSource(url), getQueryDatum().useCaseTemplate());
             instanceOrError =  new Pair<>(instance, "");
         } catch (InvalidStructureException | IOException
                 | XmlPullParserException | UnfullfilledRequirementsException e) {

--- a/src/main/java/org/commcare/core/interfaces/RemoteInstanceFetcher.java
+++ b/src/main/java/org/commcare/core/interfaces/RemoteInstanceFetcher.java
@@ -1,6 +1,8 @@
 package org.commcare.core.interfaces;
 
 import org.javarosa.core.model.instance.ExternalDataInstance;
+import org.javarosa.core.model.instance.ExternalDataInstanceSource;
+import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
 import org.xmlpull.v1.XmlPullParserException;
@@ -13,11 +15,10 @@ import java.net.URI;
  */
 public interface RemoteInstanceFetcher {
 
-    ExternalDataInstance getRemoteDataInstance(String instanceId, boolean useCaseTemplate, URI uri)
+    TreeElement getExternalRoot(String instanceId, ExternalDataInstanceSource source)
             throws UnfullfilledRequirementsException, XmlPullParserException, InvalidStructureException, IOException;
 
     class RemoteInstanceException extends Exception {
-
         public RemoteInstanceException(String message, Throwable cause) {
             super(message, cause);
         }

--- a/src/main/java/org/commcare/core/process/CommCareInstanceInitializer.java
+++ b/src/main/java/org/commcare/core/process/CommCareInstanceInitializer.java
@@ -209,12 +209,4 @@ public class CommCareInstanceInitializer extends InstanceInitializationFactory {
                     "Unable to find lookup table: " + lookupReference));
         }
     }
-
-    public void prepareExternalSources(RemoteInstanceFetcher remoteInstanceFetcher) throws RemoteInstanceFetcher.RemoteInstanceException {
-        for(StackFrameStep step : session.getFrame().getSteps()) {
-            if (step.hasXmlInstance() && step.getXmlInstance().needsInit()) {
-                step.getXmlInstance().remoteInit(remoteInstanceFetcher);
-            }
-        }
-    }
 }

--- a/src/main/java/org/commcare/core/process/CommCareInstanceInitializer.java
+++ b/src/main/java/org/commcare/core/process/CommCareInstanceInitializer.java
@@ -3,6 +3,7 @@ package org.commcare.core.process;
 import org.commcare.cases.instance.CaseDataInstance;
 import org.commcare.cases.instance.CaseInstanceTreeElement;
 import org.commcare.cases.instance.LedgerInstanceTreeElement;
+import org.commcare.core.interfaces.RemoteInstanceFetcher;
 import org.commcare.core.interfaces.UserSandbox;
 import org.commcare.core.sandbox.SandboxUtils;
 import org.commcare.session.SessionFrame;
@@ -86,17 +87,6 @@ public class CommCareInstanceInitializer extends InstanceInitializationFactory {
             return setupRemoteData(instance);
         } else if (ref.contains("migration")) {
             return setupMigrationData(instance);
-        }
-        return null;
-    }
-
-    @Nullable
-    @Override
-    public ExternalDataInstance getInstanceFromSession(String instanceId) {
-        for (StackFrameStep step : session.getFrame().getSteps()) {
-            if (step.getId().equals(instanceId) && step.getType().equals(SessionFrame.STATE_QUERY_REQUEST)) {
-                return step.getXmlInstance();
-            }
         }
         return null;
     }
@@ -190,6 +180,12 @@ public class CommCareInstanceInitializer extends InstanceInitializationFactory {
     }
 
     protected AbstractTreeElement setupRemoteData(ExternalDataInstance instance) {
+        for (StackFrameStep step : session.getFrame().getSteps()) {
+            if (step.getId().equals(instance.getInstanceId()) && step.getType().equals(SessionFrame.STATE_QUERY_REQUEST)) {
+                ExternalDataInstance externalInstance = step.getXmlInstance();
+                return externalInstance.getRoot();
+            }
+        }
         return instance.getRoot();
     }
 
@@ -211,6 +207,14 @@ public class CommCareInstanceInitializer extends InstanceInitializationFactory {
             super(Localization.getWithDefault("lookup.table.missing.error",
                     new String[]{lookupReference},
                     "Unable to find lookup table: " + lookupReference));
+        }
+    }
+
+    public void prepareExternalSources(RemoteInstanceFetcher remoteInstanceFetcher) throws RemoteInstanceFetcher.RemoteInstanceException {
+        for(StackFrameStep step : session.getFrame().getSteps()) {
+            if (step.hasXmlInstance() && step.getXmlInstance().needsInit()) {
+                step.getXmlInstance().remoteInit(remoteInstanceFetcher);
+            }
         }
     }
 }

--- a/src/main/java/org/commcare/modern/session/SessionWrapper.java
+++ b/src/main/java/org/commcare/modern/session/SessionWrapper.java
@@ -87,7 +87,11 @@ public class SessionWrapper extends CommCareSession implements SessionWrapperInt
     }
 
     public void prepareExternalSources(RemoteInstanceFetcher remoteInstanceFetcher) throws RemoteInstanceFetcher.RemoteInstanceException {
-        getIIF().prepareExternalSources(remoteInstanceFetcher);
+        for(StackFrameStep step : frame.getSteps()) {
+            if (step.hasXmlInstance() && step.getXmlInstance().needsInit()) {
+                step.getXmlInstance().remoteInit(remoteInstanceFetcher);
+            }
+        }
     }
 
     @Override

--- a/src/main/java/org/commcare/modern/session/SessionWrapper.java
+++ b/src/main/java/org/commcare/modern/session/SessionWrapper.java
@@ -1,13 +1,29 @@
 package org.commcare.modern.session;
 
+import org.commcare.core.interfaces.RemoteInstanceFetcher;
 import org.commcare.core.interfaces.UserSandbox;
 import org.commcare.core.process.CommCareInstanceInitializer;
 import org.commcare.session.CommCareSession;
+import org.commcare.session.SessionFrame;
+import org.commcare.suite.model.ComputedDatum;
+import org.commcare.suite.model.RemoteQueryDatum;
+import org.commcare.suite.model.SessionDatum;
+import org.commcare.suite.model.StackFrameStep;
 import org.commcare.util.CommCarePlatform;
 import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.model.instance.DataInstance;
+import org.javarosa.core.model.instance.ExternalDataInstance;
+import org.javarosa.xml.util.InvalidStructureException;
+import org.javarosa.xml.util.UnfullfilledRequirementsException;
 import org.javarosa.xpath.analysis.InstanceNameAccumulatingAnalyzer;
 import org.javarosa.xpath.analysis.XPathAnalyzable;
+import org.xmlpull.v1.XmlPullParserException;
 
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Enumeration;
 import java.util.Set;
 
 /**
@@ -68,6 +84,10 @@ public class SessionWrapper extends CommCareSession implements SessionWrapperInt
         }
 
         return initializer;
+    }
+
+    public void prepareExternalSources(RemoteInstanceFetcher remoteInstanceFetcher) throws RemoteInstanceFetcher.RemoteInstanceException {
+        getIIF().prepareExternalSources(remoteInstanceFetcher);
     }
 
     @Override

--- a/src/main/java/org/commcare/modern/session/SessionWrapperInterface.java
+++ b/src/main/java/org/commcare/modern/session/SessionWrapperInterface.java
@@ -1,5 +1,6 @@
 package org.commcare.modern.session;
 
+import org.commcare.core.interfaces.RemoteInstanceFetcher;
 import org.commcare.core.process.CommCareInstanceInitializer;
 import org.commcare.suite.model.Entry;
 import org.commcare.suite.model.SessionDatum;
@@ -21,4 +22,6 @@ public interface SessionWrapperInterface {
     EvaluationContext getEvaluationContext();
     EvaluationContext getRestrictedEvaluationContext(String commandId, Set<String> instancesToInclude);
     EvaluationContext getEvaluationContextWithAccumulatedInstances(String commandID, XPathAnalyzable xPathAnalyzable);
+
+    void prepareExternalSources(RemoteInstanceFetcher fetcher) throws RemoteInstanceFetcher.RemoteInstanceException;
 }

--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -10,6 +10,7 @@ import org.commcare.suite.model.SessionDatum;
 import org.javarosa.core.model.ItemsetBinding;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.ExternalDataInstance;
+import org.javarosa.core.model.instance.ExternalDataInstanceSource;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.utils.ItemSetUtils;
 import org.javarosa.core.util.OrderedHashtable;
@@ -144,7 +145,7 @@ public class RemoteQuerySessionManager {
      * @return Data instance built from xml root or the error message raised during parsing
      */
     public ExternalDataInstance buildExternalDataInstance(TreeElement root, String remoteUrl) {
-        return ExternalDataInstance.buildFromRemote(queryDatum.getDataId(), root, remoteUrl, queryDatum.useCaseTemplate());
+        return ExternalDataInstance.buildFromRemote(queryDatum.getDataId(), root, new ExternalDataInstanceSource(remoteUrl), queryDatum.useCaseTemplate());
     }
 
     public void populateItemSetChoices(QueryPrompt queryPrompt) {

--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -145,7 +145,7 @@ public class RemoteQuerySessionManager {
      * @return Data instance built from xml root or the error message raised during parsing
      */
     public ExternalDataInstance buildExternalDataInstance(TreeElement root, String remoteUrl) {
-        return ExternalDataInstance.buildFromRemote(queryDatum.getDataId(), root, new ExternalDataInstanceSource(remoteUrl), queryDatum.useCaseTemplate());
+        return ExternalDataInstance.buildFromRemote(queryDatum.getDataId(), new ExternalDataInstanceSource(queryDatum.getDataId(), root, remoteUrl), queryDatum.useCaseTemplate());
     }
 
     public void populateItemSetChoices(QueryPrompt queryPrompt) {

--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -1406,17 +1406,17 @@ public class FormDef implements IFormElement, IMetaData,
      *                            (presumably in HQ) - so don't fire end of form event.
      */
     public void initialize(boolean newInstance, boolean isCompletedInstance,
-                           InstanceInitializationFactory factory) throws RemoteInstanceFetcher.RemoteInstanceException {
-        initialize(newInstance, isCompletedInstance, factory, null, false, null);
+                           InstanceInitializationFactory factory) {
+        initialize(newInstance, isCompletedInstance, factory, null, false);
     }
 
-    public void initialize(boolean newInstance, InstanceInitializationFactory factory) throws RemoteInstanceFetcher.RemoteInstanceException {
-        initialize(newInstance, false, factory, null, false, null);
+    public void initialize(boolean newInstance, InstanceInitializationFactory factory) {
+        initialize(newInstance, false, factory, null, false);
     }
 
     public void initialize(boolean newInstance, InstanceInitializationFactory factory, String locale,
-                           boolean isReadOnly, RemoteInstanceFetcher remoteInstanceFetcher) throws RemoteInstanceFetcher.RemoteInstanceException {
-        initialize(newInstance, false, factory, locale, isReadOnly, remoteInstanceFetcher);
+                           boolean isReadOnly) {
+        initialize(newInstance, false, factory, locale, isReadOnly);
     }
 
     /**
@@ -1427,18 +1427,13 @@ public class FormDef implements IFormElement, IMetaData,
      * @param locale      The default locale in the current environment, if provided. Can be null
      *                    to rely on the form's internal default.
      * @param isReadOnly  If we are in read only mode and only wants to view form
-     * @param remoteInstanceFetcher utility to initialize remote instances over internet, can be null
      */
     public void initialize(boolean newInstance, boolean isCompletedInstance, InstanceInitializationFactory factory,
-                           String locale, boolean isReadOnly, @Nullable RemoteInstanceFetcher remoteInstanceFetcher) throws RemoteInstanceFetcher.RemoteInstanceException {
+                           String locale, boolean isReadOnly) {
         for (Enumeration en = formInstances.keys(); en.hasMoreElements(); ) {
             String instanceId = (String)en.nextElement();
             DataInstance instance = formInstances.get(instanceId);
             formInstances.put(instanceId, instance.initialize(factory, instanceId));
-        }
-
-        if (remoteInstanceFetcher != null) {
-            tryAttachingRemoteInstances(remoteInstanceFetcher);
         }
 
         initLocale(locale);
@@ -1452,41 +1447,6 @@ public class FormDef implements IFormElement, IMetaData,
         this.isCompletedInstance = isCompletedInstance;
         if (!isReadOnly) {
             initAllTriggerables();
-        }
-    }
-
-    private void tryAttachingRemoteInstances(RemoteInstanceFetcher remoteInstanceFetcher) throws RemoteInstanceFetcher.RemoteInstanceException {
-        ArrayList<DataInstance> replacedInstances = new ArrayList<>();
-        Enumeration<DataInstance> instances = getNonMainInstances();
-        while (instances.hasMoreElements()) {
-            DataInstance instance = instances.nextElement();
-            if (instance instanceof ExternalDataInstance &&
-                    instance.getRoot() == null &&
-                    ((ExternalDataInstance)instance).getRemoteUrl() != null) {
-                try {
-                    ExternalDataInstance externalDataInstance = (ExternalDataInstance)instance;
-                    ExternalDataInstance newExternalDataInstance = remoteInstanceFetcher.getRemoteDataInstance(instance.getInstanceId(),
-                            externalDataInstance.useCaseTemplate(),
-                            new URI(externalDataInstance.getRemoteUrl()));
-                    if (newExternalDataInstance != null && newExternalDataInstance.getRoot() != null) {
-                        replacedInstances.add(newExternalDataInstance);
-                    }
-                } catch (UnfullfilledRequirementsException | XmlPullParserException |
-                        InvalidStructureException | IOException | URISyntaxException e) {
-                    String errorMessage;
-                    if (e instanceof URISyntaxException) {
-                        errorMessage = "Invalid url found for the remote instance " + instance.getName() + ".";
-                    } else if (e instanceof IOException) {
-                        errorMessage = "Could not retrieve data for remote instance " + instance.getName() + ". Please try opening the form again.";
-                    } else {
-                        errorMessage = "Invalid data retrieved from remote instance " + instance.getName() + ". If the error persists please contact your help desk.";
-                    }
-                    throw new RemoteInstanceFetcher.RemoteInstanceException(errorMessage, e.getCause());
-                }
-            }
-        }
-        for (DataInstance replacedInstance : replacedInstances) {
-            addNonMainInstance(replacedInstance);
         }
     }
 

--- a/src/main/java/org/javarosa/core/model/instance/ExternalDataInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/ExternalDataInstance.java
@@ -104,9 +104,12 @@ public class ExternalDataInstance extends DataInstance {
         if (needsInit()) {
             throw new RuntimeException("Attempt to use instance " + instanceid + " without inititalization.");
         }
-        //TODO: We are just presuming this is lined up, but we should probably be pulling this
-        //straight from the source
-        return root;
+
+        if (source != null) {
+            return source.getRoot();
+        } else {
+            return root;
+        }
     }
 
     public String getReference() {
@@ -119,7 +122,7 @@ public class ExternalDataInstance extends DataInstance {
     }
 
     public boolean needsInit() {
-        if(source == null) {
+        if (source == null) {
             return false;
         } else {
             return source.needsInit();
@@ -135,8 +138,12 @@ public class ExternalDataInstance extends DataInstance {
             root.setInstanceName(this.instanceid);
             root.setParent(this.base);
             this.root = root;
-        } catch (Exception e) {
-            throw new RemoteInstanceFetcher.RemoteInstanceException(e.getMessage(), e);
+        } catch (IOException e) {
+            throw new RemoteInstanceFetcher.RemoteInstanceException(
+                    "Could not retrieve data for remote instance " + getName() + ". Please try opening the form again.", e);
+        } catch (XmlPullParserException | UnfullfilledRequirementsException | InvalidStructureException e) {
+            throw new RemoteInstanceFetcher.RemoteInstanceException(
+                    "Invalid data retrieved from remote instance " + getName() + ". If the error persists please contact your help desk.", e);
         }
     }
 

--- a/src/main/java/org/javarosa/core/model/instance/ExternalDataInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/ExternalDataInstance.java
@@ -101,6 +101,11 @@ public class ExternalDataInstance extends DataInstance {
 
     @Override
     public AbstractTreeElement getRoot() {
+        if (needsInit()) {
+            throw new RuntimeException("Attempt to use instance " + instanceid + " without inititalization.");
+        }
+        //TODO: We are just presuming this is lined up, but we should probably be pulling this
+        //straight from the source
         return root;
     }
 

--- a/src/main/java/org/javarosa/core/model/instance/ExternalDataInstanceSource.java
+++ b/src/main/java/org/javarosa/core/model/instance/ExternalDataInstanceSource.java
@@ -1,0 +1,49 @@
+package org.javarosa.core.model.instance;
+
+import org.commcare.core.interfaces.RemoteInstanceFetcher;
+import org.javarosa.core.util.externalizable.DeserializationException;
+import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.Externalizable;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+public class ExternalDataInstanceSource implements Externalizable {
+
+    TreeElement root;
+    private String sourceUri;
+
+    public ExternalDataInstanceSource(String sourceUri) {
+        this.sourceUri = sourceUri;
+    }
+
+    public boolean needsInit() {
+        if (root == null) {
+            return true;
+        }
+        return false;
+    }
+
+    protected TreeElement getRoot() {
+        if (needsInit()) {
+            throw new RuntimeException("Uninstantiated external instance source");
+        }
+        return root;
+    }
+
+    @Override
+    public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
+        sourceUri = ExtUtil.readString(in);
+    }
+
+    @Override
+    public void writeExternal(DataOutputStream out) throws IOException {
+        ExtUtil.write(out, sourceUri);
+    }
+
+    public String getSourceUri() {
+        return sourceUri;
+    }
+}

--- a/src/main/java/org/javarosa/core/model/instance/ExternalDataInstanceSource.java
+++ b/src/main/java/org/javarosa/core/model/instance/ExternalDataInstanceSource.java
@@ -49,7 +49,9 @@ public class ExternalDataInstanceSource implements Externalizable {
     }
 
     public void init(TreeElement root) {
-        //TODO: One-time init
+        if (this.root != null) {
+            throw new RuntimeException("Initializing an already instantiated external instance source is not permitted");
+        }
         this.root = root;
     }
 

--- a/src/main/java/org/javarosa/core/model/instance/ExternalDataInstanceSource.java
+++ b/src/main/java/org/javarosa/core/model/instance/ExternalDataInstanceSource.java
@@ -14,9 +14,24 @@ public class ExternalDataInstanceSource implements Externalizable {
 
     TreeElement root;
     private String sourceUri;
+    private String instanceId;
 
-    public ExternalDataInstanceSource(String sourceUri) {
+    /**
+     * Externalizable constructor
+     */
+    public ExternalDataInstanceSource() {
+
+    }
+
+    public ExternalDataInstanceSource(String instanceId, String sourceUri) {
+        this.instanceId = instanceId;
         this.sourceUri = sourceUri;
+    }
+
+    public ExternalDataInstanceSource(String instanceId, TreeElement root, String sourceUri) {
+        this.instanceId = instanceId;
+        this.sourceUri = sourceUri;
+        this.root = root;
     }
 
     public boolean needsInit() {
@@ -33,14 +48,21 @@ public class ExternalDataInstanceSource implements Externalizable {
         return root;
     }
 
+    public void init(TreeElement root) {
+        //TODO: One-time init
+        this.root = root;
+    }
+
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         sourceUri = ExtUtil.readString(in);
+        instanceId = ExtUtil.readString(in);
     }
 
     @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.write(out, sourceUri);
+        ExtUtil.write(out, instanceId);
     }
 
     public String getSourceUri() {

--- a/src/main/java/org/javarosa/core/model/instance/InstanceInitializationFactory.java
+++ b/src/main/java/org/javarosa/core/model/instance/InstanceInitializationFactory.java
@@ -16,9 +16,4 @@ public class InstanceInitializationFactory {
     public AbstractTreeElement generateRoot(ExternalDataInstance instance) {
         return null;
     }
-
-    public ExternalDataInstance getInstanceFromSession(String instanceId){
-        return null;
-    }
-
 }

--- a/src/test/java/org/commcare/backend/session/test/SessionStackTests.java
+++ b/src/test/java/org/commcare/backend/session/test/SessionStackTests.java
@@ -353,8 +353,7 @@ public class SessionStackTests {
         InputStream is = cls.getResourceAsStream(resourcePath);
         ExternalDataInstance instance = ExternalDataInstance.buildFromRemote(
                 remoteQuerySessionManager.getQueryDatum().getDataId(),
-                ExternalDataInstance.parseExternalTree(is, remoteQuerySessionManager.getQueryDatum().getDataId()),
-                new ExternalDataInstanceSource(resourcePath),
+                new ExternalDataInstanceSource(resourcePath, ExternalDataInstance.parseExternalTree(is, remoteQuerySessionManager.getQueryDatum().getDataId()), remoteQuerySessionManager.getQueryDatum().getDataId()),
                 remoteQuerySessionManager.getQueryDatum().useCaseTemplate());
         assertNotNull(instance);
         return instance;

--- a/src/test/java/org/commcare/backend/session/test/SessionStackTests.java
+++ b/src/test/java/org/commcare/backend/session/test/SessionStackTests.java
@@ -9,6 +9,7 @@ import org.commcare.test.utilities.CaseTestUtils;
 import org.commcare.test.utilities.MockApp;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.ExternalDataInstance;
+import org.javarosa.core.model.instance.ExternalDataInstanceSource;
 import org.javarosa.test_utils.ExprEvalUtils;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
@@ -352,8 +353,8 @@ public class SessionStackTests {
         InputStream is = cls.getResourceAsStream(resourcePath);
         ExternalDataInstance instance = ExternalDataInstance.buildFromRemote(
                 remoteQuerySessionManager.getQueryDatum().getDataId(),
-                is,
-                resourcePath,
+                ExternalDataInstance.parseExternalTree(is, remoteQuerySessionManager.getQueryDatum().getDataId()),
+                new ExternalDataInstanceSource(resourcePath),
                 remoteQuerySessionManager.getQueryDatum().useCaseTemplate());
         assertNotNull(instance);
         return instance;

--- a/src/test/java/org/javarosa/core/model/test/FormDefTest.java
+++ b/src/test/java/org/javarosa/core/model/test/FormDefTest.java
@@ -568,11 +568,9 @@ public class FormDefTest {
 
     private static FormEntryController initFormEntry(FormParseInit fpi, String locale) {
         FormEntryController fec = fpi.getFormEntryController();
-        try {
-            fpi.getFormDef().initialize(true, null, locale, false, null);
-        } catch (RemoteInstanceFetcher.RemoteInstanceException e) {
-            throw new RuntimeException(e.getMessage(), e.getCause());
-        }
+
+        fpi.getFormDef().initialize(true, null, locale, false);
+
         fec.jumpToIndex(FormIndex.createBeginningOfFormIndex());
         return fec;
     }

--- a/src/translate/java/org/javarosa/engine/XFormEnvironment.java
+++ b/src/translate/java/org/javarosa/engine/XFormEnvironment.java
@@ -58,11 +58,8 @@ public class XFormEnvironment {
     
     public FormEntryController setup(InstanceInitializationFactory factory) {
         form.setEvaluationContext(buildBaseEvaluationContext());
-        try {
-            form.initialize(true, factory, preferredLocale, false, null);
-        } catch (RemoteInstanceFetcher.RemoteInstanceException e) {
-            throw new RuntimeException(e.getMessage(), e.getCause());
-        }
+
+        form.initialize(true, factory, preferredLocale, false);
 
         if(recording) {
             session = new Session();


### PR DESCRIPTION
(not intended to be pulled, provided for illustration)

Builds on 
https://github.com/dimagi/commcare-core/pull/1040

but moves instantiating the external instances to a decoupled pre-condition rather than an update to initialization

would still need to be updated for clarity (and hasn't been tested) and conciseness. Also has the weakness that this approach currently isn't capable of **only** ensuring that instances which are referenced by the form are made available during form entry.