### PR TITLE
preserve value of useCaseTemplate when initializing instances

### DIFF
--- a/src/main/java/org/javarosa/core/model/instance/ExternalDataInstanceSource.java
+++ b/src/main/java/org/javarosa/core/model/instance/ExternalDataInstanceSource.java
@@ -47,6 +47,7 @@ public class ExternalDataInstanceSource implements Externalizable {
         this.instanceId = externalDataInstanceSource.instanceId;
         this.sourceUri = externalDataInstanceSource.sourceUri;
         this.root = externalDataInstanceSource.root;
+        this.useCaseTemplate = externalDataInstanceSource.useCaseTemplate();
     }
 
     public boolean needsInit() {

--- a/src/main/java/org/javarosa/core/model/instance/InstanceInitializationFactory.java
+++ b/src/main/java/org/javarosa/core/model/instance/InstanceInitializationFactory.java
@@ -4,6 +4,27 @@ package org.javarosa.core.model.instance;
  * @author ctsims
  */
 public class InstanceInitializationFactory {
+
+    public class InstanceRoot {
+        private AbstractTreeElement root;
+        private boolean useCaseTemplate;
+        public InstanceRoot(AbstractTreeElement root) {
+            this(root, false);
+        }
+
+        public InstanceRoot(AbstractTreeElement root, boolean useCaseTemplate) {
+            this.root = root;
+            this.useCaseTemplate = useCaseTemplate;
+        }
+
+        public AbstractTreeElement getRoot() {
+            return root;
+        }
+
+        public boolean useCaseTemplate() {
+            return useCaseTemplate;
+        }
+    }
     /**
      * Specializes the instance to an ExternalDataInstance class extension.
      * E.g. one might want to use the CaseDataInstance if the instanceId is
@@ -13,7 +34,7 @@ public class InstanceInitializationFactory {
         return instance;
     }
 
-    public AbstractTreeElement generateRoot(ExternalDataInstance instance) {
+    public InstanceRoot generateRoot(ExternalDataInstance instance) {
         return null;
     }
 }

--- a/src/test/java/org/commcare/test/utilities/TestInstanceInitializer.java
+++ b/src/test/java/org/commcare/test/utilities/TestInstanceInitializer.java
@@ -30,10 +30,11 @@ public class TestInstanceInitializer extends InstanceInitializationFactory {
     }
 
     @Override
-    public AbstractTreeElement generateRoot(ExternalDataInstance instance) {
+    public InstanceRoot generateRoot(ExternalDataInstance instance) {
         String ref = instance.getReference();
         if (ref.contains(CaseInstanceTreeElement.MODEL_NAME)) {
-            return new CaseInstanceTreeElement(instance.getBase(), sandbox.getCaseStorage());
+            CaseInstanceTreeElement root = new CaseInstanceTreeElement(instance.getBase(), sandbox.getCaseStorage());
+            return new InstanceRoot(root, true);
         }
         return null;
     }

--- a/src/test/java/org/javarosa/core/model/instance/test/DummyInstanceInitializationFactory.java
+++ b/src/test/java/org/javarosa/core/model/instance/test/DummyInstanceInitializationFactory.java
@@ -18,7 +18,7 @@ public class DummyInstanceInitializationFactory extends InstanceInitializationFa
         return instance;
     }
     @Override
-    public AbstractTreeElement generateRoot(ExternalDataInstance instance) {
+    public InstanceRoot generateRoot(ExternalDataInstance instance) {
         throw new RuntimeException("Loading external instances isn't supported " +
                 "using this instance initialization factory.");
     }

--- a/src/translate/java/org/javarosa/engine/MockupProviderFactory.java
+++ b/src/translate/java/org/javarosa/engine/MockupProviderFactory.java
@@ -28,7 +28,7 @@ public class MockupProviderFactory extends InstanceInitializationFactory {
     }
 
     @Override
-    public AbstractTreeElement generateRoot(ExternalDataInstance instance) {
+    public InstanceRoot generateRoot(ExternalDataInstance instance) {
         String ref = instance.getReference();
 
         if(instances.containsKey(ref)) {
@@ -39,7 +39,7 @@ public class MockupProviderFactory extends InstanceInitializationFactory {
 
             root.setParent(instance.getBase());
 
-            return root;
+            return new InstanceRoot(root);
         } else if(ref.equals("jr://session")) {
             throw new IllegalArgumentException("Session instances not yet supported");
         } else {


### PR DESCRIPTION
For instances inside forms there is no way to declare that the instance uses a template. This will preserve the value of the instance from the session.

Using the 'case' template allows referencing case properties that don't exist in the case without causing errors.

PR into https://github.com/dimagi/commcare-core/pull/1040