### PR TITLE
support multiple extras with the same key in stack frames

### DIFF
--- a/src/main/java/org/commcare/session/CommCareSession.java
+++ b/src/main/java/org/commcare/session/CommCareSession.java
@@ -1,5 +1,6 @@
 package org.commcare.session;
 
+import com.google.common.collect.Multimap;
 import org.commcare.suite.model.ComputedDatum;
 import org.commcare.suite.model.Detail;
 import org.commcare.suite.model.EntityDatum;
@@ -942,8 +943,17 @@ public class CommCareSession {
         frame.addExtraTopStep(key, value);
     }
 
+    /**
+     * Get the 'extra' value for the given key.
+     * This method only supports keys that have a single value. For keys with multiple values
+     * use `getCurrentFrameStepExtras().get(key)` which returns a Collection of the values.
+     */
     public Object getCurrentFrameStepExtra(String key) {
-        return frame.getTopStepExtra(key);
+        return frame.getTopStep().getExtra(key);
+    }
+
+    public Multimap<String, Object> getCurrentFrameStepExtras() {
+        return frame.getTopStep().getExtras();
     }
 
     /**

--- a/src/main/java/org/commcare/session/SessionFrame.java
+++ b/src/main/java/org/commcare/session/SessionFrame.java
@@ -222,10 +222,9 @@ public class SessionFrame implements Externalizable {
         }
     }
 
-    public synchronized Object getTopStepExtra(String key) {
+    public synchronized StackFrameStep getTopStep() {
         if (!steps.isEmpty()) {
-            StackFrameStep topStep = steps.elementAt(steps.size() - 1);
-            return topStep.getExtra(key);
+            return steps.elementAt(steps.size() - 1);
         }
         return null;
     }

--- a/src/main/java/org/commcare/suite/model/StackFrameStep.java
+++ b/src/main/java/org/commcare/suite/model/StackFrameStep.java
@@ -1,12 +1,13 @@
 package org.commcare.suite.model;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 import org.commcare.session.SessionFrame;
 import org.javarosa.core.model.condition.EvaluationContext;
-import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.ExternalDataInstanceSource;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
-import org.javarosa.core.util.externalizable.ExtWrapMapPoly;
+import org.javarosa.core.util.externalizable.ExtWrapMultiMap;
 import org.javarosa.core.util.externalizable.ExtWrapNullable;
 import org.javarosa.core.util.externalizable.Externalizable;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
@@ -19,9 +20,8 @@ import org.javarosa.xpath.parser.XPathSyntaxException;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.Enumeration;
-import java.util.Hashtable;
-import java.util.Map;
+import java.util.Collection;
+import java.util.NoSuchElementException;
 
 /**
  * @author ctsims
@@ -32,7 +32,7 @@ public class StackFrameStep implements Externalizable {
     private String id;
     private String value;
     private boolean valueIsXpath;
-    private Hashtable<String, Object> extras = new Hashtable<>();
+    private Multimap<String, Object> extras = ArrayListMultimap.create();
 
     /**
      * XML instance collected during session navigation that is made available
@@ -56,11 +56,7 @@ public class StackFrameStep implements Externalizable {
         this.id = oldStackFrameStep.id;
         this.value = oldStackFrameStep.value;
         this.valueIsXpath = oldStackFrameStep.valueIsXpath;
-        for (Enumeration e = oldStackFrameStep.extras.keys(); e.hasMoreElements(); ) {
-            String key = (String)e.nextElement();
-            // shallow copy of extra value
-            extras.put(key, oldStackFrameStep.extras.get(key));
-        }
+        extras.putAll(oldStackFrameStep.getExtras());
 
         if (oldStackFrameStep.hasXmlInstance()) {
             this.xmlInstanceSource = new ExternalDataInstanceSource(oldStackFrameStep.xmlInstanceSource);
@@ -123,10 +119,18 @@ public class StackFrameStep implements Externalizable {
     }
 
     public Object getExtra(String key) {
-        return extras.get(key);
+        Collection<Object> values = extras.get(key);
+        if (values.size() > 1) {
+            throw new RuntimeException(String.format("Multiple extras found with key %s", key));
+        }
+        try {
+            return values.iterator().next();
+        } catch (NoSuchElementException e) {
+            return null;
+        }
     }
 
-    public Map<String, Object> getExtras() {
+    public Multimap<String, Object> getExtras() {
         return extras;
     }
 
@@ -158,10 +162,10 @@ public class StackFrameStep implements Externalizable {
             case SessionFrame.STATE_QUERY_REQUEST:
             case SessionFrame.STATE_SMART_LINK:
                 StackFrameStep defined = new StackFrameStep(elementType, id, evaluateValue(ec));
-                for (String key : extras.keySet()) {
-                    XPathExpression expr = (XPathExpression) getExtra(key);
+                extras.forEach((key, value) -> {
+                    XPathExpression expr = (XPathExpression) value;
                     defined.addExtra(key, FunctionUtils.toString(expr.eval(ec)));
-                }
+                });
                 return defined;
             default:
                 throw new RuntimeException("Invalid step [" + elementType + "] declared when constructing a new frame step");
@@ -188,7 +192,7 @@ public class StackFrameStep implements Externalizable {
         this.id = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
         this.value = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
         this.valueIsXpath = ExtUtil.readBool(in);
-        this.extras = (Hashtable<String, Object>)ExtUtil.read(in, new ExtWrapMapPoly(String.class), pf);
+        this.extras = (Multimap<String, Object>)ExtUtil.read(in, new ExtWrapMultiMap(String.class), pf);
         this.xmlInstanceSource = (ExternalDataInstanceSource)ExtUtil.read(in, new ExtWrapNullable(ExternalDataInstanceSource.class), pf);
     }
 
@@ -198,7 +202,7 @@ public class StackFrameStep implements Externalizable {
         ExtUtil.writeString(out, ExtUtil.emptyIfNull(id));
         ExtUtil.writeString(out, ExtUtil.emptyIfNull(value));
         ExtUtil.writeBool(out, valueIsXpath);
-        ExtUtil.write(out, new ExtWrapMapPoly(extras));
+        ExtUtil.write(out, new ExtWrapMultiMap(extras));
         ExtUtil.write(out, new ExtWrapNullable(xmlInstanceSource));
     }
 

--- a/src/test/java/org/commcare/backend/session/test/SessionNavigatorTests.java
+++ b/src/test/java/org/commcare/backend/session/test/SessionNavigatorTests.java
@@ -11,6 +11,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Arrays;
+
 /**
  * Tests for SessionNavigator.java
  *
@@ -210,6 +212,7 @@ public class SessionNavigatorTests {
         session.addExtraToCurrentFrameStep(LAST_QUERY_KEY, "the lorax");
         // you can store any externalizable object in the extras of a frame step
         session.addExtraToCurrentFrameStep(COLOR_KEY, 253);
+        session.addExtraToCurrentFrameStep(COLOR_KEY, 153);
         triggerSessionStepAndCheckResultCode(SessionNavigator.GET_COMMAND);
 
         // set forward again, set more extras
@@ -223,7 +226,7 @@ public class SessionNavigatorTests {
         triggerSessionStepAndCheckResultCode(SessionNavigator.GET_COMMAND);
         Assert.assertEquals("m0", session.getCommand());
         Assert.assertEquals("the lorax", session.getCurrentFrameStepExtra(LAST_QUERY_KEY));
-        Assert.assertEquals(253, session.getCurrentFrameStepExtra(COLOR_KEY));
+        Assert.assertEquals(Arrays.asList(253, 153), session.getCurrentFrameStepExtras().get(COLOR_KEY));
 
         // step back and then forward into frame w/ same command and
         // assert that extras are no longer present

--- a/src/test/java/org/commcare/backend/suite/model/test/StackFrameStepTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/StackFrameStepTests.java
@@ -1,23 +1,24 @@
 package org.commcare.backend.suite.model.test;
 
+import com.google.common.collect.ImmutableMultimap;
 import org.commcare.modern.session.SessionWrapper;
+import org.commcare.session.SessionFrame;
 import org.commcare.suite.model.Action;
 import org.commcare.suite.model.EntityDatum;
 import org.commcare.suite.model.StackFrameStep;
 import org.commcare.test.utilities.MockApp;
 import org.commcare.test.utilities.PersistableSandbox;
-import org.commcare.session.SessionFrame;
-
+import org.commcare.util.mocks.MockQueryClient;
+import org.commcare.util.screen.QueryScreen;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.util.Vector;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * Created by amstone326 on 8/7/15.
@@ -61,6 +62,7 @@ public class StackFrameStepTests {
         // or anything that implements Externalizable
         stepWithExtras = new StackFrameStep(SessionFrame.STATE_DATUM_COMPUTED, "datum_val_id", "datum_val2");
         stepWithExtras.addExtra("key", 123);
+        stepWithExtras.addExtra("key", 234);
 
         // Demonstrate how frame steps can't store non-externalizable data in extras
         stepWithBadExtras = new StackFrameStep(SessionFrame.STATE_DATUM_COMPUTED, "datum_val_id", "datum_val2");
@@ -132,5 +134,52 @@ public class StackFrameStepTests {
         assertEquals(5, session.getFrame().getSteps().size());
         session.stepBack();
         assertEquals(1, session.getFrame().getSteps().size());
+    }
+
+    /**
+     * Test that stacks with queries in them work and preserve all the data elements they contain
+     * even if they have duplicate keys.
+     */
+    @Test
+    public void stackWithQueries() throws Exception {
+        MockApp mApp = new MockApp("/queries_in_entry_and_stack/");
+        SessionWrapper session = mApp.getSession();
+        session.setCommand("m0-f0");
+
+        // check that session datum requirement is satisfied
+        assertEquals(SessionFrame.STATE_DATUM_VAL, session.getNeededData());
+        assertEquals("case_id", session.getNeededDatum().getDataId());
+        session.setDatum("case_id", "case_one");
+
+        assertEquals(SessionFrame.STATE_QUERY_REQUEST, session.getNeededData());
+        // construct the screen
+        QueryScreen screen = new QueryScreen("username", "password", System.out);
+        screen.init(session);
+
+        // mock the query response
+        InputStream response = this.getClass().getResourceAsStream("/case_claim_example/query_response.xml");
+        screen.setClient(new MockQueryClient(response));
+
+        // perform the query
+        boolean success = screen.handleInputAndUpdateSession(session, "", false);
+        Assert.assertTrue(success);
+
+        assertNull(session.getNeededDatum());
+
+        // execute entry stack
+        session.finishExecuteAndPop(session.getEvaluationContext());
+
+        // validate that the query step has all the correct entries (including 2 case_id entries)
+        Vector<StackFrameStep> steps = session.getFrame().getSteps();
+        assertEquals(4, steps.size());
+        StackFrameStep queryFrame = steps.get(2);
+        assertEquals(SessionFrame.STATE_QUERY_REQUEST, queryFrame.getElementType());
+
+        ImmutableMultimap.Builder<String, Object> builder = ImmutableMultimap.builder();
+        builder.put("case_type", "patient");
+        builder.put("x_commcare_data_registry", "test");
+        builder.put("case_id", "case_one");
+        builder.put("case_id", "dupe1");
+        assertEquals(builder.build(), queryFrame.getExtras());
     }
 }

--- a/src/test/resources/queries_in_entry_and_stack/app_strings.txt
+++ b/src/test/resources/queries_in_entry_and_stack/app_strings.txt
@@ -1,0 +1,10 @@
+m0.case_short.title=Cases
+m0.case_long.title=Cases
+m0.case_long.case_name_1.header=Name
+forms.m0f0= ??
+forms.m0f0= ??
+forms.m3f0= ??
+modules.m0=patients
+modules.m1=visits
+case_list_form.m0=register
+search_property.m5.name=name

--- a/src/test/resources/queries_in_entry_and_stack/placeholder_form.xml
+++ b/src/test/resources/queries_in_entry_and_stack/placeholder_form.xml
@@ -1,0 +1,17 @@
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+    <h:head>
+        <h:title>Placeholder Form</h:title>
+        <model>
+            <instance>
+                <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://commcarehq.org/test/placeholder" uiVersion="1" version="1" name="Placeholder">
+                    <item/>
+                </data>
+            </instance>
+        </model>
+    </h:head>
+    <h:body>
+        <input ref="/data/item">
+            <label>placeholder</label>
+        </input>
+    </h:body>
+</h:html>

--- a/src/test/resources/queries_in_entry_and_stack/profile.ccpr
+++ b/src/test/resources/queries_in_entry_and_stack/profile.ccpr
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<profile version="36"
+         update=""
+         requiredMajor="2"
+         requiredMinor="22"
+         uniqueid="e1e6d47cda1351b38f55a84411ec7adf"
+         name="Case title loading test App"
+         descriptor="Profile File">
+ 
+    <suite><resource id="suite" version="36">
+            <location authority="local">./suite.xml</location>
+    </resource></suite>
+    
+</profile>

--- a/src/test/resources/queries_in_entry_and_stack/suite.xml
+++ b/src/test/resources/queries_in_entry_and_stack/suite.xml
@@ -1,0 +1,135 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<suite version="36" descriptor="Suite File">
+  <xform>
+    <resource id="1662072614e4dc0c3808d095c5b1cc826be7c1ec" version="28" descriptor="Placeholder">
+      <location authority="local">./placeholder_form.xml</location>
+    </resource>
+  </xform>
+
+  <locale language="default">
+    <resource id="app_default_strings" version="593" descriptor="Translations: Default Language">
+      <location authority="local">./app_strings.txt</location>
+    </resource>
+  </locale>
+
+  <detail id="m0_case_short">
+    <title>
+      <text>
+        <locale id="m0.case_short.title"/>
+      </text>
+    </title>
+    <field>
+      <header>
+        <text>
+          <locale id="m0.case_short.case_name_1.header"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </template>
+      <sort type="string" order="3" direction="ascending">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
+    </field>
+  </detail>
+
+  <detail id="m0_case_long">
+    <title>
+      <text>
+        <locale id="m0.case_long.title"/>
+      </text>
+    </title>
+    <field>
+      <header>
+        <text>
+          <locale id="m0.case_long.case_name_1.header"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </template>
+    </field>
+  </detail>
+
+  <entry>
+    <form>http://openrosa.org/formdesigner/b70b3ce04873dc38c12ded3fda45f329f768f9ed</form>
+    <command id="m0-f0">
+      <display>
+        <text>
+          <locale id="forms.m0f0"/>
+        </text>
+        <text form="image">
+          <locale id="forms.m0f0.icon"/>
+        </text>
+      </display>
+    </command>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <instance id="commcaresession" src="jr://instance/session"/>
+    <session>
+      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='patient'][@status='open']" value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
+      <query url="http://localhost:8000/a/domain/phone/registry_case/3dc223faa388dc16b8441194c001cec2/" storage-instance="registry" template="case" default_search="true">
+        <data key="x_commcare_data_registry" ref="'test'"/>
+        <data key="case_type" ref="'patient'"/>
+        <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
+        <data key="case_id" ref="instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id]/potential_duplicate_id"/>
+      </query>
+    </session>
+    <stack>
+      <create>
+        <command value="'m0'"/>
+        <datum id="case_id" value="instance('commcaresession')/session/data/case_id"/>
+        <query id="registry" value="http://localhost:8000/a/domain/phone/registry_case/3dc223faa388dc16b8441194c001cec2/">
+          <data key="x_commcare_data_registry" ref="'test'"/>
+          <data key="case_type" ref="'patient'"/>
+          <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
+          <data key="case_id" ref="instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id]/potential_duplicate_id"/>
+        </query>
+        <command value="'m0-f1'"/>
+      </create>
+    </stack>
+  </entry>
+
+  <entry>
+    <form>http://openrosa.org/formdesigner/E5E690D1-B846-4EAB-8EE0-A9B3085B9E8D</form>
+    <command id="m0-f1">
+      <display>
+        <text>
+          <locale id="forms.m0f1"/>
+        </text>
+        <text form="image">
+          <locale id="forms.m0f1.icon"/>
+        </text>
+      </display>
+    </command>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <instance id="commcaresession" src="jr://instance/session"/>
+    <session>
+      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='patient'][@status='open']" value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
+      <query url="http://localhost:8000/a/skelly-1/phone/registry_case/3dc223faa388dc16b8441194c001cec2/" storage-instance="registry" template="case" default_search="true">
+        <data key="x_commcare_data_registry" ref="'test'"/>
+        <data key="case_type" ref="'patient'"/>
+        <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
+        <data key="case_id" ref="instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id]/potential_duplicate_id"/>
+      </query>
+    </session>
+  </entry>
+
+  <menu id="m0">
+    <display>
+      <text>
+        <locale id="modules.m0"/>
+      </text>
+      <text form="image">
+        <locale id="modules.m0.icon"/>
+      </text>
+    </display>
+    <command id="m0-f0"/>
+    <command id="m0-f1"/>
+  </menu>
+</suite>

--- a/src/test/resources/queries_in_entry_and_stack/user_restore.xml
+++ b/src/test/resources/queries_in_entry_and_stack/user_restore.xml
@@ -1,0 +1,25 @@
+<OpenRosaResponse>
+    <message nature="ota_restore_success">Successfully restored account test!</message>
+    <Sync xmlns="http://commcarehq.org/sync">
+        <restore_id>sync_token</restore_id>
+    </Sync>
+    <Registration xmlns="http://openrosa.org/user/registration">
+        <username>test</username>
+        <password>sha1$60441$53cf77c2ac3608a944db96af177a6dfe1579e4ba</password>
+        <uuid>test_user</uuid>
+        <date>2012-04-30</date>
+    </Registration>
+    <case case_id="case_one"
+          date_modified="2014-08-04T21:09:07.000000Z"
+          user_id="test_user"
+          xmlns="http://commcarehq.org/case/transaction/v2">
+        <create>
+            <case_type>adult</case_type>
+            <case_name>Saul</case_name>
+            <owner_id>test_user</owner_id>
+        </create>
+        <update>
+            <potential_duplicate_id>dupe1</potential_duplicate_id>
+        </update>
+    </case>
+</OpenRosaResponse>


### PR DESCRIPTION
This converts `StackFrameStep.extras` from a single value map to a multi-map allowing it to contain multiple entries with the same key. This is needed for instances where the stack query contains duplicate data keys:

```xml
<query url="http://localhost:8000/a/skelly-1/phone/registry_case/3dc223faa388dc16b8441194c001cec2/" storage-instance="registry" template="case" default_search="true">
  <data key="case_type" ref="'patient'"/>
  <data key="case_type" ref="'contact'"/>
  <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
  <data key="case_id" ref="instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id]/potential_duplicate_id"/>
</query>
```

This will break all serialised sessions.