### PR TITLE
Replaces use of internal `sun.*` APIs

### DIFF
--- a/src/main/java/org/commcare/cases/instance/CaseInstanceTreeElement.java
+++ b/src/main/java/org/commcare/cases/instance/CaseInstanceTreeElement.java
@@ -28,8 +28,6 @@ import java.util.Vector;
 
 import javax.annotation.Nullable;
 
-import sun.rmi.runtime.Log;
-
 /**
  * The root element for the <casedb> abstract type. All children are
  * nodes in the case database. Depending on instantiation, the <casedb>

--- a/src/test/java/org/commcare/util/XmlUtilTest.java
+++ b/src/test/java/org/commcare/util/XmlUtilTest.java
@@ -1,5 +1,6 @@
 package org.commcare.util;
 
+import org.javarosa.core.io.StreamsUtil;
 import org.javarosa.engine.xml.XmlUtil;
 import org.junit.Assert;
 import org.junit.Test;
@@ -9,8 +10,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import sun.misc.IOUtils;
-
 /**
  * @author $|-|!˅@M
  */
@@ -19,9 +18,8 @@ public class XmlUtilTest {
     @Test
     public void testPrettifyXml() throws IOException {
         try (InputStream inputStream = getClass().getResourceAsStream("/minified_xml.xml")) {
-            byte[] bytes = IOUtils.readAllBytes(inputStream);
+            byte[] bytes = StreamsUtil.inputStreamToByteArray(inputStream);
             String actualOutput = XmlUtil.getPrettyXml(bytes);
-
             String expectedOutput = getPrettyXml();
             Assert.assertEquals(expectedOutput, actualOutput);
         }


### PR DESCRIPTION
I am no longer able to resolve `sun.misc.IOUtils.readAllBytes` on my machine. So replacing it with an alternate implementation of ours. 