### PR TITLE
make case search user input available to default filters

### DIFF
--- a/src/cli/java/org/commcare/util/screen/QueryScreen.java
+++ b/src/cli/java/org/commcare/util/screen/QueryScreen.java
@@ -225,7 +225,7 @@ public class QueryScreen extends Screen {
     }
 
     public void refreshItemSetChoices() {
-        remoteQuerySessionManager.refreshItemSetChoices(remoteQuerySessionManager.getUserAnswers());
+        remoteQuerySessionManager.refreshItemSetChoices();
     }
 
     public URL getBaseUrl() {

--- a/src/main/java/org/commcare/data/xml/SimpleNode.java
+++ b/src/main/java/org/commcare/data/xml/SimpleNode.java
@@ -1,0 +1,57 @@
+package org.commcare.data.xml;
+
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * Metadata class used in conjunction with {@link TreeBuilder} to allow creating simple
+ * {@link org.javarosa.core.model.instance.TreeElement} trees.
+ *
+ * SimpleNode.parentNode("node", ImmutableMap.of("attr1", "v1"), ImmutableList.of(
+ *     SimpleNode.textNode("child", Collections.emptyMap(), "some text"),
+ *     SimpleNode.textNode("child", Collections.emptyMap(), "other text")
+ * ))
+ */
+public class SimpleNode {
+    private String name;
+    private Map<String, String> attributes;
+    private List<SimpleNode> children;
+    private String text;
+
+    public static SimpleNode textNode(String name, Map<String, String> attributes, String text) {
+        return new SimpleNode(name, attributes, text);
+    }
+
+    public static SimpleNode parentNode(String name, Map<String, String> attributes, List<SimpleNode> children) {
+        return new SimpleNode(name, attributes, children);
+    }
+
+    private SimpleNode(String name, Map<String, String> attributes, String text) {
+        this.name = name;
+        this.attributes = attributes;
+        this.text = text;
+    }
+
+    private SimpleNode(String name, Map<String, String> attributes, List<SimpleNode> children) {
+        this.name = name;
+        this.attributes = attributes;
+        this.children = children;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Map<String, String> getAttributes() {
+        return attributes;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public List<SimpleNode> getChildren() {
+        return children;
+    }
+}

--- a/src/main/java/org/commcare/data/xml/SimpleNode.java
+++ b/src/main/java/org/commcare/data/xml/SimpleNode.java
@@ -17,7 +17,7 @@ public class SimpleNode {
     private String name;
     private Map<String, String> attributes;
     private List<SimpleNode> children;
-    private String text;
+    private String value;
 
     public static SimpleNode textNode(String name, Map<String, String> attributes, String text) {
         return new SimpleNode(name, attributes, text);
@@ -30,7 +30,7 @@ public class SimpleNode {
     private SimpleNode(String name, Map<String, String> attributes, String text) {
         this.name = name;
         this.attributes = attributes;
-        this.text = text;
+        this.value = text;
     }
 
     private SimpleNode(String name, Map<String, String> attributes, List<SimpleNode> children) {
@@ -47,8 +47,8 @@ public class SimpleNode {
         return attributes;
     }
 
-    public String getText() {
-        return text;
+    public String getValue() {
+        return value;
     }
 
     public List<SimpleNode> getChildren() {

--- a/src/main/java/org/commcare/data/xml/SimpleNode.java
+++ b/src/main/java/org/commcare/data/xml/SimpleNode.java
@@ -9,8 +9,8 @@ import java.util.Map;
  * {@link org.javarosa.core.model.instance.TreeElement} trees.
  *
  * SimpleNode.parentNode("node", ImmutableMap.of("attr1", "v1"), ImmutableList.of(
- *     SimpleNode.textNode("child", Collections.emptyMap(), "some text"),
- *     SimpleNode.textNode("child", Collections.emptyMap(), "other text")
+ * SimpleNode.textNode("child", Collections.emptyMap(), "some text"),
+ * SimpleNode.textNode("child", Collections.emptyMap(), "other text")
  * ))
  */
 public class SimpleNode {

--- a/src/main/java/org/commcare/data/xml/TreeBuilder.java
+++ b/src/main/java/org/commcare/data/xml/TreeBuilder.java
@@ -1,0 +1,50 @@
+package org.commcare.data.xml;
+
+import org.javarosa.core.model.data.UncastData;
+import org.javarosa.core.model.instance.TreeElement;
+
+import java.util.Hashtable;
+import java.util.List;
+
+/**
+ * Class to build a TreeElement tree for use with DataInstance classes
+ */
+public class TreeBuilder {
+
+    /**
+     * Build a TreeElement populated with children
+     */
+    public static TreeElement buildTree(String instanceId, String rootElementName, List<SimpleNode> nodes) {
+        TreeElement root = new TreeElement(rootElementName, 0);
+        root.setInstanceName(instanceId);
+        root.setAttribute(null, "id", instanceId);
+        addChildren(instanceId, root, nodes);
+        return root;
+    }
+
+    private static void addChildren(String instanceId, TreeElement parent, List<SimpleNode> nodes) {
+        Hashtable<String, Integer> multiplicities = new Hashtable<>();
+        for (SimpleNode node : nodes) {
+            int val;
+            String name = node.getName();
+            if (multiplicities.containsKey(name)) {
+                val = multiplicities.get(name) + 1;
+            } else {
+                val = 0;
+            }
+            multiplicities.put(name, val);
+
+            TreeElement element = new TreeElement(name, val);
+            element.setInstanceName(instanceId);
+            node.getAttributes().forEach((attributeName, value) -> {
+                element.setAttribute(null, attributeName, value);
+            });
+            if (node.getText() != null) {
+                element.setValue(new UncastData(node.getText()));
+            } else if (node.getChildren() != null) {
+                addChildren(instanceId, element, node.getChildren());
+            }
+            parent.addChild(element);
+        }
+    }
+}

--- a/src/main/java/org/commcare/data/xml/TreeBuilder.java
+++ b/src/main/java/org/commcare/data/xml/TreeBuilder.java
@@ -14,17 +14,17 @@ public class TreeBuilder {
     /**
      * Build a TreeElement populated with children
      */
-    public static TreeElement buildTree(String instanceId, String rootElementName, List<SimpleNode> nodes) {
+    public static TreeElement buildTree(String instanceId, String rootElementName, List<SimpleNode> children) {
         TreeElement root = new TreeElement(rootElementName, 0);
         root.setInstanceName(instanceId);
         root.setAttribute(null, "id", instanceId);
-        addChildren(instanceId, root, nodes);
+        addChildren(instanceId, root, children);
         return root;
     }
 
-    private static void addChildren(String instanceId, TreeElement parent, List<SimpleNode> nodes) {
+    private static void addChildren(String instanceId, TreeElement parent, List<SimpleNode> children) {
         Hashtable<String, Integer> multiplicities = new Hashtable<>();
-        for (SimpleNode node : nodes) {
+        for (SimpleNode node : children) {
             int val;
             String name = node.getName();
             if (multiplicities.containsKey(name)) {

--- a/src/main/java/org/commcare/data/xml/TreeBuilder.java
+++ b/src/main/java/org/commcare/data/xml/TreeBuilder.java
@@ -39,8 +39,8 @@ public class TreeBuilder {
             node.getAttributes().forEach((attributeName, value) -> {
                 element.setAttribute(null, attributeName, value);
             });
-            if (node.getText() != null) {
-                element.setValue(new UncastData(node.getText()));
+            if (node.getValue() != null) {
+                element.setValue(new UncastData(node.getValue()));
             } else if (node.getChildren() != null) {
                 addChildren(instanceId, element, node.getChildren());
             }

--- a/src/main/java/org/commcare/data/xml/VirtualInstances.java
+++ b/src/main/java/org/commcare/data/xml/VirtualInstances.java
@@ -1,0 +1,25 @@
+package org.commcare.data.xml;
+
+import com.google.common.collect.ImmutableMap;
+import org.javarosa.core.model.instance.TreeElement;
+import org.javarosa.core.model.instance.VirtualDataInstance;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class VirtualInstances {
+    public static final String SEARCH_INSTANCE_ID = "search-input";
+    public static final String SEARCH_INSTANCE_ROOT_NAME = "input";
+    public static final String SEARCH_INSTANCE_NODE_NAME = "field";
+    public static final String SEARCH_INPUT_NODE_NAME_ATTR = "name";
+
+    public static TreeElement buildSearchInputRoot(Map<String, String> userInputValues) {
+        List<SimpleNode> nodes = new ArrayList<>();
+        userInputValues.forEach((key, value) -> {
+            Map<String, String> attributes = ImmutableMap.of(SEARCH_INPUT_NODE_NAME_ATTR, key);
+            nodes.add(SimpleNode.textNode(SEARCH_INSTANCE_NODE_NAME, attributes, value));
+        });
+        return TreeBuilder.buildTree(SEARCH_INSTANCE_ID, SEARCH_INSTANCE_ROOT_NAME, nodes);
+    }
+}

--- a/src/main/java/org/commcare/data/xml/VirtualInstances.java
+++ b/src/main/java/org/commcare/data/xml/VirtualInstances.java
@@ -1,6 +1,7 @@
 package org.commcare.data.xml;
 
 import com.google.common.collect.ImmutableMap;
+
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.instance.VirtualDataInstance;
 

--- a/src/main/java/org/commcare/data/xml/VirtualInstances.java
+++ b/src/main/java/org/commcare/data/xml/VirtualInstances.java
@@ -14,12 +14,13 @@ public class VirtualInstances {
     public static final String SEARCH_INSTANCE_NODE_NAME = "field";
     public static final String SEARCH_INPUT_NODE_NAME_ATTR = "name";
 
-    public static TreeElement buildSearchInputRoot(Map<String, String> userInputValues) {
+    public static VirtualDataInstance buildSearchInputInstance(Map<String, String> userInputValues) {
         List<SimpleNode> nodes = new ArrayList<>();
         userInputValues.forEach((key, value) -> {
             Map<String, String> attributes = ImmutableMap.of(SEARCH_INPUT_NODE_NAME_ATTR, key);
             nodes.add(SimpleNode.textNode(SEARCH_INSTANCE_NODE_NAME, attributes, value));
         });
-        return TreeBuilder.buildTree(SEARCH_INSTANCE_ID, SEARCH_INSTANCE_ROOT_NAME, nodes);
+        TreeElement root = TreeBuilder.buildTree(SEARCH_INSTANCE_ID, SEARCH_INSTANCE_ROOT_NAME, nodes);
+        return new VirtualDataInstance(SEARCH_INSTANCE_ID, root);
     }
 }

--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -153,7 +153,7 @@ public class RemoteQuerySessionManager {
     }
 
     // loops over query prompts and validates selection until all selections are valid
-    public void refreshItemSetChoices(Hashtable<String, String> userAnswers) {
+    public void refreshItemSetChoices() {
         OrderedHashtable<String, QueryPrompt> userInputDisplays = getNeededUserInputDisplays();
         if (userInputDisplays.size() == 0) {
             return;

--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -1,14 +1,17 @@
 package org.commcare.session;
 
 import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
 
 import org.commcare.cases.util.StringUtils;
+import org.commcare.data.xml.VirtualInstances;
 import org.commcare.suite.model.QueryPrompt;
 import org.commcare.suite.model.RemoteQueryDatum;
 import org.commcare.suite.model.SessionDatum;
 import org.javarosa.core.model.ItemsetBinding;
 import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.model.instance.VirtualDataInstance;
 import org.javarosa.core.model.utils.ItemSetUtils;
 import org.javarosa.core.util.OrderedHashtable;
 import org.javarosa.xpath.XPathException;
@@ -112,11 +115,13 @@ public class RemoteQuerySessionManager {
      * @return filters to be applied to case search uri as query params
      */
     public Multimap<String, String> getRawQueryParams(boolean skipDefaultPromptValues) {
+        EvaluationContext evalContextWithAnswers = getEvaluationContextWithUserInputInstance();
+
         Multimap<String, String> params = ArrayListMultimap.create();
         Multimap<String, XPathExpression> hiddenQueryValues = queryDatum.getHiddenQueryValues();
         for (String key : hiddenQueryValues.keySet()) {
             for (XPathExpression xpathExpression : hiddenQueryValues.get(key)) {
-                String evaluatedExpr = evalXpathExpression(xpathExpression, evaluationContext);
+                String evaluatedExpr = evalXpathExpression(xpathExpression, evalContextWithAnswers);
                 params.put(key, evaluatedExpr);
             }
         }
@@ -135,6 +140,14 @@ public class RemoteQuerySessionManager {
         return params;
     }
 
+    private EvaluationContext getEvaluationContextWithUserInputInstance() {
+        Map<String, String> userQueryValues = getUserQueryValues();
+        VirtualDataInstance userInputInstance = VirtualInstances.buildSearchInputInstance(userQueryValues);
+        return evaluationContext.spawnWithCleanLifecycle(
+            ImmutableMap.of(userInputInstance.getInstanceId(), userInputInstance)
+        );
+    }
+
     public static String evalXpathExpression(XPathExpression expr,
                                              EvaluationContext evaluationContext) {
         return FunctionUtils.toString(expr.eval(evaluationContext));
@@ -142,7 +155,7 @@ public class RemoteQuerySessionManager {
 
     public void populateItemSetChoices(QueryPrompt queryPrompt) {
         EvaluationContext evalContextWithAnswers = evaluationContext.spawnWithCleanLifecycle();
-        Map<String, Object> userQueryValues = getUserQueryValues();
+        Map<String, String> userQueryValues = getUserQueryValues();
         userQueryValues.forEach((promptId, value) -> {
             evalContextWithAnswers.setVariable(promptId, userAnswers.get(promptId));
         });
@@ -150,8 +163,8 @@ public class RemoteQuerySessionManager {
         ItemSetUtils.populateDynamicChoices(queryPrompt.getItemsetBinding(), evalContextWithAnswers);
     }
 
-    private Map<String, Object> getUserQueryValues() {
-        Map<String, Object> values = new HashMap<>();
+    private Map<String, String> getUserQueryValues() {
+        Map<String, String> values = new HashMap<>();
         OrderedHashtable<String, QueryPrompt> queryPrompts = queryDatum.getUserQueryPrompts();
         for (Enumeration en = queryPrompts.keys(); en.hasMoreElements(); ) {
             String promptId = (String)en.nextElement();

--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -169,7 +169,10 @@ public class RemoteQuerySessionManager {
         for (Enumeration en = queryPrompts.keys(); en.hasMoreElements(); ) {
             String promptId = (String)en.nextElement();
             if (isPromptSupported(queryPrompts.get(promptId))) {
-                values.put(promptId, userAnswers.get(promptId));
+                String answer = userAnswers.get(promptId);
+                if (answer != null) {
+                    values.put(promptId, answer);
+                }
             }
         }
         return values;

--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -44,8 +44,8 @@ public class RemoteQuerySessionManager {
     private final ArrayList<String> supportedPrompts;
 
     private RemoteQuerySessionManager(RemoteQueryDatum queryDatum,
-                                      EvaluationContext evaluationContext,
-                                      ArrayList<String> supportedPrompts) throws XPathException {
+            EvaluationContext evaluationContext,
+            ArrayList<String> supportedPrompts) throws XPathException {
         this.queryDatum = queryDatum;
         this.evaluationContext = evaluationContext;
         this.supportedPrompts = supportedPrompts;
@@ -59,15 +59,16 @@ public class RemoteQuerySessionManager {
             QueryPrompt prompt = queryPrompts.get(promptId);
 
             if (isPromptSupported(prompt) && prompt.getDefaultValueExpr() != null) {
-                userAnswers.put(prompt.getKey(), FunctionUtils.toString(prompt.getDefaultValueExpr().eval(evaluationContext)));
+                userAnswers.put(prompt.getKey(),
+                        FunctionUtils.toString(prompt.getDefaultValueExpr().eval(evaluationContext)));
             }
 
         }
     }
 
     public static RemoteQuerySessionManager buildQuerySessionManager(CommCareSession session,
-                                                                     EvaluationContext sessionContext,
-                                                                     ArrayList<String> supportedPrompts) throws XPathException {
+            EvaluationContext sessionContext,
+            ArrayList<String> supportedPrompts) throws XPathException {
         SessionDatum datum;
         try {
             datum = session.getNeededDatum();
@@ -144,12 +145,12 @@ public class RemoteQuerySessionManager {
         Map<String, String> userQueryValues = getUserQueryValues();
         VirtualDataInstance userInputInstance = VirtualInstances.buildSearchInputInstance(userQueryValues);
         return evaluationContext.spawnWithCleanLifecycle(
-            ImmutableMap.of(userInputInstance.getInstanceId(), userInputInstance)
+                ImmutableMap.of(userInputInstance.getInstanceId(), userInputInstance)
         );
     }
 
     public static String evalXpathExpression(XPathExpression expr,
-                                             EvaluationContext evaluationContext) {
+            EvaluationContext evaluationContext) {
         return FunctionUtils.toString(expr.eval(evaluationContext));
     }
 
@@ -209,7 +210,8 @@ public class RemoteQuerySessionManager {
                         }
                     }
                     if (validSelectedChoices.size() > 0) {
-                        userAnswers.put(promptId, String.join(RemoteQuerySessionManager.ANSWER_DELIMITER, validSelectedChoices));
+                        userAnswers.put(promptId,
+                                String.join(RemoteQuerySessionManager.ANSWER_DELIMITER, validSelectedChoices));
                     } else {
                         // no value
                         userAnswers.remove(promptId);

--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -19,6 +19,8 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Hashtable;
+import java.util.Map;
+import java.util.HashMap;
 
 import javax.annotation.Nullable;
 
@@ -140,16 +142,24 @@ public class RemoteQuerySessionManager {
 
     public void populateItemSetChoices(QueryPrompt queryPrompt) {
         EvaluationContext evalContextWithAnswers = evaluationContext.spawnWithCleanLifecycle();
+        Map<String, Object> userQueryValues = getUserQueryValues();
+        userQueryValues.forEach((promptId, value) -> {
+            evalContextWithAnswers.setVariable(promptId, userAnswers.get(promptId));
+        });
 
+        ItemSetUtils.populateDynamicChoices(queryPrompt.getItemsetBinding(), evalContextWithAnswers);
+    }
+
+    private Map<String, Object> getUserQueryValues() {
+        Map<String, Object> values = new HashMap<>();
         OrderedHashtable<String, QueryPrompt> queryPrompts = queryDatum.getUserQueryPrompts();
         for (Enumeration en = queryPrompts.keys(); en.hasMoreElements(); ) {
             String promptId = (String)en.nextElement();
             if (isPromptSupported(queryPrompts.get(promptId))) {
-                evalContextWithAnswers.setVariable(promptId, userAnswers.get(promptId));
+                values.put(promptId, userAnswers.get(promptId));
             }
         }
-
-        ItemSetUtils.populateDynamicChoices(queryPrompt.getItemsetBinding(), evalContextWithAnswers);
+        return values;
     }
 
     // loops over query prompts and validates selection until all selections are valid

--- a/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
+++ b/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
@@ -748,10 +748,10 @@ public class EvaluationContext {
         return spawnWithCleanLifecycle(null);
     }
 
-    public EvaluationContext spawnWithCleanLifecycle(Map<String, DataInstance> additionalInstance) {
+    public EvaluationContext spawnWithCleanLifecycle(Map<String, DataInstance> additionalInstances) {
         EvaluationContext ec = new EvaluationContext(this, this.getContextRef());
-        if (additionalInstance != null) {
-            additionalInstance.forEach((name, instance) -> {
+        if (additionalInstances != null) {
+            additionalInstances.forEach((name, instance) -> {
                 if (!ec.formInstances.containsKey(name)) {
                     ec.formInstances.put(name, instance);
                 }

--- a/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
+++ b/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
@@ -27,6 +27,7 @@ import java.util.Date;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.List;
+import java.util.Map;
 import java.util.Vector;
 
 
@@ -744,7 +745,18 @@ public class EvaluationContext {
      * capacity to abandon requests
      */
     public EvaluationContext spawnWithCleanLifecycle() {
+        return spawnWithCleanLifecycle(null);
+    }
+
+    public EvaluationContext spawnWithCleanLifecycle(Map<String, DataInstance> additionalInstance) {
         EvaluationContext ec = new EvaluationContext(this, this.getContextRef());
+        if (additionalInstance != null) {
+            additionalInstance.forEach((name, instance) -> {
+                if (!ec.formInstances.containsKey(name)) {
+                    ec.formInstances.put(name, instance);
+                }
+            });
+        }
         QueryContext qc = ec.getCurrentQueryContext().forceNewChildContext();
         ec.setQueryContext(qc);
         return ec;

--- a/src/main/java/org/javarosa/core/model/instance/VirtualDataInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/VirtualDataInstance.java
@@ -1,0 +1,79 @@
+package org.javarosa.core.model.instance;
+
+import org.javarosa.core.util.externalizable.DeserializationException;
+import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+/**
+ * Data instance that is created during execution based on user input of other live data
+ */
+public class VirtualDataInstance extends DataInstance {
+    private TreeElement root = new TreeElement();
+    private InstanceBase base;
+
+    public VirtualDataInstance() {
+    }
+
+    public VirtualDataInstance(String instanceid) {
+        super(instanceid);
+    }
+
+    /**
+     * Copy constructor
+     */
+    public VirtualDataInstance(VirtualDataInstance instance) {
+        super(instance.getInstanceId());
+        this.base = instance.getBase();
+        //Copy constructor avoids check.
+        this.root = instance.root;
+        this.mCacheHost = instance.getCacheHost();
+    }
+
+    public VirtualDataInstance(String instanceId, TreeElement topLevel) {
+        this(instanceId);
+        base = new InstanceBase(instanceId);
+        topLevel.setInstanceName(instanceId);
+        topLevel.setParent(base);
+        this.root = topLevel;
+        base.setChild(root);
+    }
+
+    @Override
+    public boolean isRuntimeEvaluated() {
+        return true;
+    }
+
+    @Override
+    public InstanceBase getBase() {
+        return base;
+    }
+
+    @Override
+    public AbstractTreeElement getRoot() {
+        return root;
+    }
+
+    @Override
+    public void readExternal(DataInputStream in, PrototypeFactory pf)
+            throws IOException, DeserializationException {
+        super.readExternal(in, pf);
+        root = (TreeElement)ExtUtil.read(in, TreeElement.class, pf);
+    }
+
+    @Override
+    public void writeExternal(DataOutputStream out) throws IOException {
+        super.writeExternal(out);
+        ExtUtil.write(out, getRoot());
+    }
+
+    @Override
+    public DataInstance initialize(InstanceInitializationFactory initializer, String instanceId) {
+        this.instanceid = instanceId;
+        root.setInstanceName(instanceId);
+        return this;
+    }
+}

--- a/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
@@ -3,6 +3,7 @@ package org.commcare.backend.suite.model.test;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
+
 import org.commcare.modern.session.SessionWrapper;
 import org.commcare.session.RemoteQuerySessionManager;
 import org.commcare.suite.model.RemoteQueryDatum;
@@ -47,7 +48,8 @@ public class CaseClaimModelTests {
         testGetRawQueryParamsWithUserInput(ImmutableMap.of(), ImmutableList.of(""));
     }
 
-    private void testGetRawQueryParamsWithUserInput(Map<String, String> userInput, List<String> expected) throws Exception {
+    private void testGetRawQueryParamsWithUserInput(Map<String, String> userInput, List<String> expected)
+            throws Exception {
         MockApp mApp = new MockApp("/case_claim_example/");
 
         SessionWrapper session = mApp.getSession();

--- a/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
@@ -1,6 +1,7 @@
 package org.commcare.backend.suite.model.test;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
 import org.commcare.modern.session.SessionWrapper;
 import org.commcare.session.RemoteQuerySessionManager;
@@ -12,6 +13,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Tests for basic app models for case claim
@@ -34,6 +36,18 @@ public class CaseClaimModelTests {
 
     @Test
     public void testRemoteRequestSessionManager_getRawQueryParamsWithUserInput() throws Exception {
+        testGetRawQueryParamsWithUserInput(
+                ImmutableMap.of("patient_id", "123"),
+                ImmutableList.of("external_id = 123")
+        );
+    }
+
+    @Test
+    public void testRemoteRequestSessionManager_getRawQueryParamsWithUserInput_missing() throws Exception {
+        testGetRawQueryParamsWithUserInput(ImmutableMap.of(), ImmutableList.of(""));
+    }
+
+    private void testGetRawQueryParamsWithUserInput(Map<String, String> userInput, List<String> expected) throws Exception {
         MockApp mApp = new MockApp("/case_claim_example/");
 
         SessionWrapper session = mApp.getSession();
@@ -42,10 +56,10 @@ public class CaseClaimModelTests {
         RemoteQuerySessionManager remoteQuerySessionManager = RemoteQuerySessionManager.buildQuerySessionManager(
                 session, session.getEvaluationContext(), new ArrayList<>());
 
-        remoteQuerySessionManager.answerUserPrompt("patient_id", "123");
+        userInput.forEach(remoteQuerySessionManager::answerUserPrompt);
+
         Multimap<String, String> rawQueryParams = remoteQuerySessionManager.getRawQueryParams(true);
 
-        List<String> expected = ImmutableList.of("123");
-        Assert.assertEquals(expected, rawQueryParams.get("patient_id_from_input"));
+        Assert.assertEquals(expected, rawQueryParams.get("_xpath_query"));
     }
 }

--- a/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
@@ -1,11 +1,17 @@
 package org.commcare.backend.suite.model.test;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Multimap;
 import org.commcare.modern.session.SessionWrapper;
+import org.commcare.session.RemoteQuerySessionManager;
 import org.commcare.suite.model.RemoteQueryDatum;
 import org.commcare.suite.model.SessionDatum;
 import org.commcare.test.utilities.MockApp;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Tests for basic app models for case claim
@@ -24,5 +30,22 @@ public class CaseClaimModelTests {
         SessionDatum datum = session.getNeededDatum();
 
         Assert.assertTrue("Didn't find Remote Query datum definition", datum instanceof RemoteQueryDatum);
+    }
+
+    @Test
+    public void testRemoteRequestSessionManager_getRawQueryParamsWithUserInput() throws Exception {
+        MockApp mApp = new MockApp("/case_claim_example/");
+
+        SessionWrapper session = mApp.getSession();
+        session.setCommand("patient-search");
+
+        RemoteQuerySessionManager remoteQuerySessionManager = RemoteQuerySessionManager.buildQuerySessionManager(
+                session, session.getEvaluationContext(), new ArrayList<>());
+
+        remoteQuerySessionManager.answerUserPrompt("patient_id", "123");
+        Multimap<String, String> rawQueryParams = remoteQuerySessionManager.getRawQueryParams(true);
+
+        List<String> expected = ImmutableList.of("123");
+        Assert.assertEquals(expected, rawQueryParams.get("patient_id_from_input"));
     }
 }

--- a/src/test/java/org/commcare/data/xml/TreeBuilderTest.java
+++ b/src/test/java/org/commcare/data/xml/TreeBuilderTest.java
@@ -2,6 +2,7 @@ package org.commcare.data.xml;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+
 import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.xml.util.InvalidStructureException;
@@ -20,34 +21,36 @@ import static org.junit.Assert.assertEquals;
 public class TreeBuilderTest {
 
     @Test
-    public void testBuildTree() throws UnfullfilledRequirementsException, XmlPullParserException, InvalidStructureException, IOException {
+    public void testBuildTree() throws UnfullfilledRequirementsException, XmlPullParserException,
+            InvalidStructureException, IOException {
         List<SimpleNode> nodes = ImmutableList.of(
-            SimpleNode.textNode("node", ImmutableMap.of("a1", "x1", "b1", "y1"), "text1"),
-            SimpleNode.textNode("node", ImmutableMap.of("a2", "x2"), "text2"),
-            SimpleNode.parentNode("node", Collections.emptyMap(), ImmutableList.of(
-                SimpleNode.parentNode("child", Collections.emptyMap(), ImmutableList.of(
-                    SimpleNode.textNode("grandchild", Collections.emptyMap(), "text3"),
-                    SimpleNode.textNode("grandchild", Collections.emptyMap(), "text4")
+                SimpleNode.textNode("node", ImmutableMap.of("a1", "x1", "b1", "y1"), "text1"),
+                SimpleNode.textNode("node", ImmutableMap.of("a2", "x2"), "text2"),
+                SimpleNode.parentNode("node", Collections.emptyMap(), ImmutableList.of(
+                        SimpleNode.parentNode("child", Collections.emptyMap(), ImmutableList.of(
+                                SimpleNode.textNode("grandchild", Collections.emptyMap(), "text3"),
+                                SimpleNode.textNode("grandchild", Collections.emptyMap(), "text4")
+                        ))
                 ))
-            ))
         );
         TreeElement test = TreeBuilder.buildTree("test-instance", "test", nodes);
 
         String expectedXml = String.join(
-            "",
-            "<test id=\"test-instance\">",
+                "",
+                "<test id=\"test-instance\">",
                 "<node a1=\"x1\" b1=\"y1\">text1</node>",
                 "<node a2=\"x2\">text2</node>",
                 "<node>",
-                    "<child>",
-                        "<grandchild>text3</grandchild>",
-                        "<grandchild>text4</grandchild>",
-                    "</child>",
+                "<child>",
+                "<grandchild>text3</grandchild>",
+                "<grandchild>text4</grandchild>",
+                "</child>",
                 "</node>",
-            "</test>"
+                "</test>"
         );
         TreeElement expected = ExternalDataInstance.parseExternalTree(
-                new ByteArrayInputStream(expectedXml.getBytes(StandardCharsets.UTF_8)), "test-instance"
+                new ByteArrayInputStream(expectedXml.getBytes(StandardCharsets.UTF_8)),
+                "test-instance"
         );
         assertEquals(expected, test);
     }

--- a/src/test/java/org/commcare/data/xml/TreeBuilderTest.java
+++ b/src/test/java/org/commcare/data/xml/TreeBuilderTest.java
@@ -1,0 +1,54 @@
+package org.commcare.data.xml;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.javarosa.core.model.instance.ExternalDataInstance;
+import org.javarosa.core.model.instance.TreeElement;
+import org.javarosa.xml.util.InvalidStructureException;
+import org.javarosa.xml.util.UnfullfilledRequirementsException;
+import org.junit.Test;
+import org.xmlpull.v1.XmlPullParserException;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class TreeBuilderTest {
+
+    @Test
+    public void testBuildTree() throws UnfullfilledRequirementsException, XmlPullParserException, InvalidStructureException, IOException {
+        List<SimpleNode> nodes = ImmutableList.of(
+            SimpleNode.textNode("node", ImmutableMap.of("a1", "x1", "b1", "y1"), "text1"),
+            SimpleNode.textNode("node", ImmutableMap.of("a2", "x2"), "text2"),
+            SimpleNode.parentNode("node", Collections.emptyMap(), ImmutableList.of(
+                SimpleNode.parentNode("child", Collections.emptyMap(), ImmutableList.of(
+                    SimpleNode.textNode("grandchild", Collections.emptyMap(), "text3"),
+                    SimpleNode.textNode("grandchild", Collections.emptyMap(), "text4")
+                ))
+            ))
+        );
+        TreeElement test = TreeBuilder.buildTree("test-instance", "test", nodes);
+
+        String expectedXml = String.join(
+            "",
+            "<test id=\"test-instance\">",
+                "<node a1=\"x1\" b1=\"y1\">text1</node>",
+                "<node a2=\"x2\">text2</node>",
+                "<node>",
+                    "<child>",
+                        "<grandchild>text3</grandchild>",
+                        "<grandchild>text4</grandchild>",
+                    "</child>",
+                "</node>",
+            "</test>"
+        );
+        TreeElement expected = ExternalDataInstance.parseExternalTree(
+                new ByteArrayInputStream(expectedXml.getBytes(StandardCharsets.UTF_8)), "test-instance"
+        );
+        assertEquals(expected, test);
+    }
+}

--- a/src/test/java/org/commcare/data/xml/VirtualInstancesTest.java
+++ b/src/test/java/org/commcare/data/xml/VirtualInstancesTest.java
@@ -1,0 +1,38 @@
+package org.commcare.data.xml;
+
+import com.google.common.collect.ImmutableMap;
+import org.javarosa.core.model.instance.ExternalDataInstance;
+import org.javarosa.core.model.instance.TreeElement;
+import org.javarosa.xml.util.InvalidStructureException;
+import org.javarosa.xml.util.UnfullfilledRequirementsException;
+import org.junit.Test;
+import org.xmlpull.v1.XmlPullParserException;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+
+public class VirtualInstancesTest {
+    @Test
+    public void testBuildSearchInputRoot() throws UnfullfilledRequirementsException, XmlPullParserException, InvalidStructureException, IOException {
+        TreeElement root = VirtualInstances.buildSearchInputRoot(ImmutableMap.of(
+            "key0", "val0",
+            "key1", "val1",
+            "key2", "val2"
+        ));
+        String expectedXml = String.join(
+            "",
+            "<input id=\"search-input\">",
+                "<field name=\"key0\">val0</field>",
+                "<field name=\"key1\">val1</field>",
+                "<field name=\"key2\">val2</field>",
+            "</input>"
+        );
+        TreeElement expected = ExternalDataInstance.parseExternalTree(
+                new ByteArrayInputStream(expectedXml.getBytes(StandardCharsets.UTF_8)), VirtualInstances.SEARCH_INSTANCE_ID
+        );
+        assertEquals(expected, root);
+    }
+}

--- a/src/test/java/org/commcare/data/xml/VirtualInstancesTest.java
+++ b/src/test/java/org/commcare/data/xml/VirtualInstancesTest.java
@@ -1,6 +1,7 @@
 package org.commcare.data.xml;
 
 import com.google.common.collect.ImmutableMap;
+
 import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.instance.VirtualDataInstance;
@@ -17,22 +18,25 @@ import static org.junit.Assert.assertEquals;
 
 public class VirtualInstancesTest {
     @Test
-    public void testBuildSearchInputRoot() throws UnfullfilledRequirementsException, XmlPullParserException, InvalidStructureException, IOException {
+    public void testBuildSearchInputRoot()
+            throws UnfullfilledRequirementsException, XmlPullParserException,
+            InvalidStructureException, IOException {
         VirtualDataInstance instance = VirtualInstances.buildSearchInputInstance(ImmutableMap.of(
-            "key0", "val0",
-            "key1", "val1",
-            "key2", "val2"
+                "key0", "val0",
+                "key1", "val1",
+                "key2", "val2"
         ));
         String expectedXml = String.join(
-            "",
-            "<input id=\"search-input\">",
+                "",
+                "<input id=\"search-input\">",
                 "<field name=\"key0\">val0</field>",
                 "<field name=\"key1\">val1</field>",
                 "<field name=\"key2\">val2</field>",
-            "</input>"
+                "</input>"
         );
         TreeElement expected = ExternalDataInstance.parseExternalTree(
-                new ByteArrayInputStream(expectedXml.getBytes(StandardCharsets.UTF_8)), VirtualInstances.SEARCH_INSTANCE_ID
+                new ByteArrayInputStream(expectedXml.getBytes(StandardCharsets.UTF_8)),
+                VirtualInstances.SEARCH_INSTANCE_ID
         );
         assertEquals(expected, instance.getRoot());
     }

--- a/src/test/java/org/commcare/data/xml/VirtualInstancesTest.java
+++ b/src/test/java/org/commcare/data/xml/VirtualInstancesTest.java
@@ -3,6 +3,7 @@ package org.commcare.data.xml;
 import com.google.common.collect.ImmutableMap;
 import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.TreeElement;
+import org.javarosa.core.model.instance.VirtualDataInstance;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
 import org.junit.Test;
@@ -17,7 +18,7 @@ import static org.junit.Assert.assertEquals;
 public class VirtualInstancesTest {
     @Test
     public void testBuildSearchInputRoot() throws UnfullfilledRequirementsException, XmlPullParserException, InvalidStructureException, IOException {
-        TreeElement root = VirtualInstances.buildSearchInputRoot(ImmutableMap.of(
+        VirtualDataInstance instance = VirtualInstances.buildSearchInputInstance(ImmutableMap.of(
             "key0", "val0",
             "key1", "val1",
             "key2", "val2"
@@ -33,6 +34,6 @@ public class VirtualInstancesTest {
         TreeElement expected = ExternalDataInstance.parseExternalTree(
                 new ByteArrayInputStream(expectedXml.getBytes(StandardCharsets.UTF_8)), VirtualInstances.SEARCH_INSTANCE_ID
         );
-        assertEquals(expected, root);
+        assertEquals(expected, instance.getRoot());
     }
 }

--- a/src/test/resources/case_claim_example/suite.xml
+++ b/src/test/resources/case_claim_example/suite.xml
@@ -57,7 +57,7 @@
     <session>
       <query url="https://www.fake.com/patient_search/" storage-instance="patients">
         <data key="device_id" ref="instance('session')/session/context/deviceid"/>
-        <data key="patient_id_from_input" ref="instance('search-input')/input/field[@name='patient_id']"/>
+        <data key="_xpath_query" ref="if(count(instance('search-input')/input/field[@name='patient_id']) > 0, concat('external_id = ', instance('search-input')/input/field[@name='patient_id']), '')"/>
         <prompt key="name" default="instance('session')/session/context/deviceid">
           <display>
             <text>

--- a/src/test/resources/case_claim_example/suite.xml
+++ b/src/test/resources/case_claim_example/suite.xml
@@ -57,6 +57,7 @@
     <session>
       <query url="https://www.fake.com/patient_search/" storage-instance="patients">
         <data key="device_id" ref="instance('session')/session/context/deviceid"/>
+        <data key="patient_id_from_input" ref="instance('search-input')/input/field[@name='patient_id']"/>
         <prompt key="name" default="instance('session')/session/context/deviceid">
           <display>
             <text>


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/USH-1749

These changes make the user input from case search available to the xpath expressions contained in the default filters.

The user input is made available via the `search-input` instance: `instance('search-input')/input/field[@name='patient_id']`

**Contrived example**
The `_xpath_query` data element references the value from the `patient_id` prompt:

```
<query url="https://www.fake.com/patient_search/" storage-instance="patients">
  <data key="_xpath_query" ref="if(count(instance('search-input')/input/field[@name='patient_id']) > 0, concat('external_id = ', instance('search-input')/input/field[@name='patient_id']), '')"/>
  <prompt key="patient_id">
    <display>
      <text>
        <locale id="query.name"/>
      </text>
    </display>
  </prompt>
</query>
```

* If the value of `patient_id` is "123" the XPath evaluates to `external_id = 123`
* If the value of `patient_id` is `null` the XPath evaluates to and empty string

**Notes for reviewer**
In addition to normal review I'm particularly interested in how I've set up the new `VirtualDataInstance` class. I'm also interested in figuring out how we could make this instance available in the case list / detail screen that results from the search (See https://dimagi-dev.atlassian.net/browse/USH-1754).