### PR TITLE
include null inputs when populating itemset choices

### DIFF
--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Hashtable;
+import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
 
@@ -41,11 +42,11 @@ public class RemoteQuerySessionManager {
     private final EvaluationContext evaluationContext;
     private final Hashtable<String, String> userAnswers =
             new Hashtable<>();
-    private final ArrayList<String> supportedPrompts;
+    private final List<String> supportedPrompts;
 
     private RemoteQuerySessionManager(RemoteQueryDatum queryDatum,
             EvaluationContext evaluationContext,
-            ArrayList<String> supportedPrompts) throws XPathException {
+            List<String> supportedPrompts) throws XPathException {
         this.queryDatum = queryDatum;
         this.evaluationContext = evaluationContext;
         this.supportedPrompts = supportedPrompts;
@@ -68,7 +69,7 @@ public class RemoteQuerySessionManager {
 
     public static RemoteQuerySessionManager buildQuerySessionManager(CommCareSession session,
             EvaluationContext sessionContext,
-            ArrayList<String> supportedPrompts) throws XPathException {
+            List<String> supportedPrompts) throws XPathException {
         SessionDatum datum;
         try {
             datum = session.getNeededDatum();

--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -142,7 +142,7 @@ public class RemoteQuerySessionManager {
     }
 
     private EvaluationContext getEvaluationContextWithUserInputInstance() {
-        Map<String, String> userQueryValues = getUserQueryValues();
+        Map<String, String> userQueryValues = getUserQueryValues(false);
         VirtualDataInstance userInputInstance = VirtualInstances.buildSearchInputInstance(userQueryValues);
         return evaluationContext.spawnWithCleanLifecycle(
                 ImmutableMap.of(userInputInstance.getInstanceId(), userInputInstance)
@@ -156,7 +156,7 @@ public class RemoteQuerySessionManager {
 
     public void populateItemSetChoices(QueryPrompt queryPrompt) {
         EvaluationContext evalContextWithAnswers = evaluationContext.spawnWithCleanLifecycle();
-        Map<String, String> userQueryValues = getUserQueryValues();
+        Map<String, String> userQueryValues = getUserQueryValues(true);
         userQueryValues.forEach((promptId, value) -> {
             evalContextWithAnswers.setVariable(promptId, userAnswers.get(promptId));
         });
@@ -164,14 +164,14 @@ public class RemoteQuerySessionManager {
         ItemSetUtils.populateDynamicChoices(queryPrompt.getItemsetBinding(), evalContextWithAnswers);
     }
 
-    private Map<String, String> getUserQueryValues() {
+    private Map<String, String> getUserQueryValues(boolean includeNulls) {
         Map<String, String> values = new HashMap<>();
         OrderedHashtable<String, QueryPrompt> queryPrompts = queryDatum.getUserQueryPrompts();
         for (Enumeration en = queryPrompts.keys(); en.hasMoreElements(); ) {
             String promptId = (String)en.nextElement();
             if (isPromptSupported(queryPrompts.get(promptId))) {
                 String answer = userAnswers.get(promptId);
-                if (answer != null) {
+                if (includeNulls || answer != null) {
                     values.put(promptId, answer);
                 }
             }

--- a/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
@@ -55,7 +55,8 @@ public class CaseClaimModelTests {
         testPopulateItemsetChoices(Collections.emptyMap(), Collections.emptyList());
     }
 
-    private void testPopulateItemsetChoices(Map<String, String> userInput, List<String> expected) throws Exception {
+    private void testPopulateItemsetChoices(Map<String, String> userInput, List<String> expected)
+            throws Exception {
         MockApp mApp = new MockApp("/case_claim_example/");
 
         SessionWrapper session = mApp.getSession();
@@ -71,7 +72,8 @@ public class CaseClaimModelTests {
 
         userInput.forEach(remoteQuerySessionManager::answerUserPrompt);
 
-        OrderedHashtable<String, QueryPrompt> inputDisplays = remoteQuerySessionManager.getNeededUserInputDisplays();
+        OrderedHashtable<String, QueryPrompt> inputDisplays =
+                remoteQuerySessionManager.getNeededUserInputDisplays();
         QueryPrompt districtPrompt = inputDisplays.get("district");
 
         remoteQuerySessionManager.populateItemSetChoices(districtPrompt);
@@ -105,9 +107,9 @@ public class CaseClaimModelTests {
 
         userInput.forEach(remoteQuerySessionManager::answerUserPrompt);
 
-        Multimap<String, String> rawQueryParams = remoteQuerySessionManager.getRawQueryParams(true);
+        Multimap<String, String> params = remoteQuerySessionManager.getRawQueryParams(true);
 
-        Assert.assertEquals(expected, rawQueryParams.get("_xpath_query"));
+        Assert.assertEquals(expected, params.get("_xpath_query"));
     }
 
     private VirtualDataInstance buildDistrictInstance() {

--- a/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
@@ -4,17 +4,27 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
 
+import org.commcare.data.xml.SimpleNode;
+import org.commcare.data.xml.TreeBuilder;
 import org.commcare.modern.session.SessionWrapper;
 import org.commcare.session.RemoteQuerySessionManager;
+import org.commcare.suite.model.QueryPrompt;
 import org.commcare.suite.model.RemoteQueryDatum;
 import org.commcare.suite.model.SessionDatum;
 import org.commcare.test.utilities.MockApp;
+import org.javarosa.core.model.SelectChoice;
+import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.model.instance.TreeElement;
+import org.javarosa.core.model.instance.VirtualDataInstance;
+import org.javarosa.core.util.OrderedHashtable;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Tests for basic app models for case claim
@@ -36,6 +46,41 @@ public class CaseClaimModelTests {
     }
 
     @Test
+    public void testPopulateItemsetChoices__inputReference() throws Exception {
+        testPopulateItemsetChoices(ImmutableMap.of("state", "ka"), ImmutableList.of("bang"));
+    }
+
+    @Test
+    public void testPopulateItemsetChoices__emptyInput() throws Exception {
+        testPopulateItemsetChoices(Collections.emptyMap(), Collections.emptyList());
+    }
+
+    private void testPopulateItemsetChoices(Map<String, String> userInput, List<String> expected) throws Exception {
+        MockApp mApp = new MockApp("/case_claim_example/");
+
+        SessionWrapper session = mApp.getSession();
+        session.setCommand("patient-search");
+
+        VirtualDataInstance districtInstance = buildDistrictInstance();
+        EvaluationContext context = session.getEvaluationContext().spawnWithCleanLifecycle(ImmutableMap.of(
+                districtInstance.getInstanceId(), districtInstance
+        ));
+
+        RemoteQuerySessionManager remoteQuerySessionManager = RemoteQuerySessionManager.buildQuerySessionManager(
+                session, context, ImmutableList.of(QueryPrompt.INPUT_TYPE_SELECT1));
+
+        userInput.forEach(remoteQuerySessionManager::answerUserPrompt);
+
+        OrderedHashtable<String, QueryPrompt> inputDisplays = remoteQuerySessionManager.getNeededUserInputDisplays();
+        QueryPrompt districtPrompt = inputDisplays.get("district");
+
+        remoteQuerySessionManager.populateItemSetChoices(districtPrompt);
+        List<String> choices = districtPrompt.getItemsetBinding().getChoices().stream().map(
+                SelectChoice::getValue).collect(Collectors.toList());
+        Assert.assertEquals(expected, choices);
+    }
+
+    @Test
     public void testRemoteRequestSessionManager_getRawQueryParamsWithUserInput() throws Exception {
         testGetRawQueryParamsWithUserInput(
                 ImmutableMap.of("patient_id", "123"),
@@ -45,7 +90,7 @@ public class CaseClaimModelTests {
 
     @Test
     public void testRemoteRequestSessionManager_getRawQueryParamsWithUserInput_missing() throws Exception {
-        testGetRawQueryParamsWithUserInput(ImmutableMap.of(), ImmutableList.of(""));
+        testGetRawQueryParamsWithUserInput(Collections.emptyMap(), ImmutableList.of(""));
     }
 
     private void testGetRawQueryParamsWithUserInput(Map<String, String> userInput, List<String> expected)
@@ -63,5 +108,24 @@ public class CaseClaimModelTests {
         Multimap<String, String> rawQueryParams = remoteQuerySessionManager.getRawQueryParams(true);
 
         Assert.assertEquals(expected, rawQueryParams.get("_xpath_query"));
+    }
+
+    private VirtualDataInstance buildDistrictInstance() {
+        Map<String, String> noAttrs = Collections.emptyMap();
+        List<SimpleNode> nodes = ImmutableList.of(
+                SimpleNode.parentNode("district", noAttrs, ImmutableList.of(
+                        SimpleNode.textNode("id", noAttrs, "bang"),
+                        SimpleNode.textNode("state_id", noAttrs, "ka"),
+                        SimpleNode.textNode("name", noAttrs, "Bangalore")
+                )),
+                SimpleNode.parentNode("district", noAttrs, ImmutableList.of(
+                        SimpleNode.textNode("id", noAttrs, "kota"),
+                        SimpleNode.textNode("state_id", noAttrs, "rj"),
+                        SimpleNode.textNode("name", noAttrs, "Kota")
+                ))
+        );
+
+        TreeElement root = TreeBuilder.buildTree("district", "district_list", nodes);
+        return new VirtualDataInstance("district", root);
     }
 }

--- a/src/test/resources/case_claim_example/suite.xml
+++ b/src/test/resources/case_claim_example/suite.xml
@@ -72,6 +72,35 @@
             </text>
           </display>
         </prompt>
+        <prompt key="state" input="select1" allow_blank_value="true">
+          <display>
+            <text>
+              <locale id="search_property.m1.state"/>
+            </text>
+            <hint>
+              <text>
+                <locale id="search_property.m1.hint"/>
+              </text>
+            </hint>
+          </display>
+          <itemset nodeset="instance('state')/state_list/state">
+            <label ref="name"/>
+            <value ref="id"/>
+            <sort ref="id"/>
+          </itemset>
+        </prompt>
+        <prompt key="district" input="select">
+          <display>
+            <text>
+              <locale id="search_property.m1.district"/>
+            </text>
+          </display>
+          <itemset nodeset="instance('district')/district_list/district[state_id = $state]">
+            <label ref="name"/>
+            <value ref="id"/>
+            <sort ref="id"/>
+          </itemset>
+        </prompt>
       </query>
       <datum id="case_id" nodeset="instance('patients')/patients/patient" value="./id" detail-select="patient_short" detail-confirm="patient_long"/>
     </session>


### PR DESCRIPTION
Followup to https://github.com/dimagi/commcare-core/pull/1074

I discovered failing tests when updating the commcare-core ref in `formplayer`.

I've added relevant tests to commcare-core and fixed the bug.