### PR TITLE
simplify list query data

### DIFF
--- a/src/main/java/org/commcare/suite/model/ListQueryData.java
+++ b/src/main/java/org/commcare/suite/model/ListQueryData.java
@@ -21,11 +21,12 @@ import java.util.Vector;
  * Data class for list query data elements
  *
  * <pre>{@code
- * <data key="case_id_list">
- *   <list nodeset="instance('selected-cases')/session-data/value"
- *         exclude="count(instance('casedb')/casedb/case[@case_id = current()/.]) = 1"
- *         ref="."/>
- * </data>
+ * <data
+ *   key="case_id_list">
+ *   nodeset="instance('selected-cases')/session-data/value"
+ *   exclude="count(instance('casedb')/casedb/case[@case_id = current()/.]) = 1"
+ *   ref="."
+ * />
  * }</pre>
  */
 public class ListQueryData implements QueryData {

--- a/src/main/java/org/commcare/suite/model/ListQueryData.java
+++ b/src/main/java/org/commcare/suite/model/ListQueryData.java
@@ -5,6 +5,7 @@ import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.ExtWrapNullable;
 import org.javarosa.core.util.externalizable.ExtWrapTagged;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.xpath.expr.XPathExpression;
@@ -73,12 +74,7 @@ public class ListQueryData implements QueryData {
         key = ExtUtil.readString(in);
         nodeset = (TreeReference)ExtUtil.read(in, TreeReference.class, pf);
         ref = (XPathPathExpr) ExtUtil.read(in, new ExtWrapTagged(), pf);
-        boolean excludeIsNull = ExtUtil.readBool(in);
-        if (excludeIsNull) {
-            excludeExpr = null;
-        } else {
-            excludeExpr = (XPathExpression) ExtUtil.read(in, new ExtWrapTagged(), pf);
-        }
+        excludeExpr = (XPathExpression)ExtUtil.read(in, new ExtWrapNullable(new ExtWrapTagged()), pf);
     }
 
     @Override
@@ -86,7 +82,6 @@ public class ListQueryData implements QueryData {
         ExtUtil.writeString(out, key);
         ExtUtil.write(out, nodeset);
         ExtUtil.write(out, new ExtWrapTagged(ref));
-        boolean excludeIsNull = excludeExpr == null;
-        ExtUtil.write(out, excludeIsNull);
+        ExtUtil.write(out, new ExtWrapNullable(excludeExpr == null ? null : new ExtWrapTagged(excludeExpr)));
     }
 }

--- a/src/main/java/org/commcare/suite/model/ListQueryData.java
+++ b/src/main/java/org/commcare/suite/model/ListQueryData.java
@@ -29,7 +29,7 @@ import java.util.Vector;
  *   ref="."
  * />
  * }</pre>
- *
+ * <p>
  * The {@code exclude} attribute is optional.
  */
 public class ListQueryData implements QueryData {

--- a/src/main/java/org/commcare/suite/model/ListQueryData.java
+++ b/src/main/java/org/commcare/suite/model/ListQueryData.java
@@ -28,6 +28,8 @@ import java.util.Vector;
  *   ref="."
  * />
  * }</pre>
+ *
+ * The {@code exclude} attribute is optional.
  */
 public class ListQueryData implements QueryData {
     private String key;

--- a/src/main/java/org/commcare/suite/model/ListQueryData.java
+++ b/src/main/java/org/commcare/suite/model/ListQueryData.java
@@ -72,15 +72,21 @@ public class ListQueryData implements QueryData {
             throws IOException, DeserializationException {
         key = ExtUtil.readString(in);
         nodeset = (TreeReference)ExtUtil.read(in, TreeReference.class, pf);
-        excludeExpr = (XPathExpression) ExtUtil.read(in, new ExtWrapTagged(), pf);
         ref = (XPathPathExpr) ExtUtil.read(in, new ExtWrapTagged(), pf);
+        boolean excludeIsNull = ExtUtil.readBool(in);
+        if (excludeIsNull) {
+            excludeExpr = null;
+        } else {
+            excludeExpr = (XPathExpression) ExtUtil.read(in, new ExtWrapTagged(), pf);
+        }
     }
 
     @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.writeString(out, key);
         ExtUtil.write(out, nodeset);
-        ExtUtil.write(out, new ExtWrapTagged(excludeExpr));
         ExtUtil.write(out, new ExtWrapTagged(ref));
+        boolean excludeIsNull = excludeExpr == null;
+        ExtUtil.write(out, excludeIsNull);
     }
 }

--- a/src/main/java/org/commcare/suite/model/ValueQueryData.java
+++ b/src/main/java/org/commcare/suite/model/ValueQueryData.java
@@ -40,7 +40,10 @@ public class ValueQueryData implements QueryData {
 
     @Override
     public Iterable<String> getValues(EvaluationContext context) {
-        return Collections.singletonList(FunctionUtils.toString(ref.eval(context)));
+        if (excludeExpr == null || !(boolean) excludeExpr.eval(context)) {
+            return Collections.singletonList(FunctionUtils.toString(ref.eval(context)));
+        }
+        return Collections.emptyList();
     }
 
     @Override

--- a/src/main/java/org/commcare/suite/model/ValueQueryData.java
+++ b/src/main/java/org/commcare/suite/model/ValueQueryData.java
@@ -23,7 +23,7 @@ import java.util.Collections;
  *    exclude="true()"
  * />
  * }</pre>
- *
+ * <p>
  * The {@code exclude} attribute is optional.
  */
 public class ValueQueryData implements QueryData {

--- a/src/main/java/org/commcare/suite/model/ValueQueryData.java
+++ b/src/main/java/org/commcare/suite/model/ValueQueryData.java
@@ -3,6 +3,7 @@ package org.commcare.suite.model;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.ExtWrapNullable;
 import org.javarosa.core.util.externalizable.ExtWrapTagged;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.xpath.expr.FunctionUtils;
@@ -57,12 +58,7 @@ public class ValueQueryData implements QueryData {
             throws IOException, DeserializationException {
         key = ExtUtil.readString(in);
         ref = (XPathExpression) ExtUtil.read(in, new ExtWrapTagged(), pf);
-        boolean excludeIsNull = ExtUtil.readBool(in);
-        if (excludeIsNull) {
-            excludeExpr = null;
-        } else {
-            excludeExpr = (XPathExpression) ExtUtil.read(in, new ExtWrapTagged(), pf);
-        }
+        excludeExpr = (XPathExpression)ExtUtil.read(in, new ExtWrapNullable(new ExtWrapTagged()), pf);
 
     }
 
@@ -70,8 +66,6 @@ public class ValueQueryData implements QueryData {
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.writeString(out, key);
         ExtUtil.write(out, new ExtWrapTagged(ref));
-        boolean excludeIsNull = excludeExpr == null;
-        ExtUtil.write(out, excludeIsNull);
-        ExtUtil.write(out, new ExtWrapTagged(excludeExpr));
+        ExtUtil.write(out, new ExtWrapNullable(excludeExpr == null ? null : new ExtWrapTagged(excludeExpr)));
     }
 }

--- a/src/main/java/org/commcare/suite/model/ValueQueryData.java
+++ b/src/main/java/org/commcare/suite/model/ValueQueryData.java
@@ -22,13 +22,15 @@ import java.util.Collections;
 public class ValueQueryData implements QueryData {
     private String key;
     private XPathExpression ref;
+    private XPathExpression excludeExpr;
 
     @SuppressWarnings("unused")
     public ValueQueryData() {}
 
-    public ValueQueryData(String key, XPathExpression ref) {
+    public ValueQueryData(String key, XPathExpression ref, XPathExpression excludeExpr) {
         this.key = key;
         this.ref = ref;
+        this.excludeExpr = excludeExpr;
     }
 
     @Override
@@ -46,11 +48,21 @@ public class ValueQueryData implements QueryData {
             throws IOException, DeserializationException {
         key = ExtUtil.readString(in);
         ref = (XPathExpression) ExtUtil.read(in, new ExtWrapTagged(), pf);
+        boolean excludeIsNull = ExtUtil.readBool(in);
+        if (excludeIsNull) {
+            excludeExpr = null;
+        } else {
+            excludeExpr = (XPathExpression) ExtUtil.read(in, new ExtWrapTagged(), pf);
+        }
+
     }
 
     @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.writeString(out, key);
         ExtUtil.write(out, new ExtWrapTagged(ref));
+        boolean excludeIsNull = excludeExpr == null;
+        ExtUtil.write(out, excludeIsNull);
+        ExtUtil.write(out, new ExtWrapTagged(excludeExpr));
     }
 }

--- a/src/main/java/org/commcare/suite/model/ValueQueryData.java
+++ b/src/main/java/org/commcare/suite/model/ValueQueryData.java
@@ -16,8 +16,14 @@ import java.util.Collections;
 /**
  * Data class for single value query data elements
  * <pre>{@code
- *  <data key="device_id" ref="instance('session')/session/context/deviceid"/>
+ *  <data
+ *    key="device_id"
+ *    ref="instance('session')/session/context/deviceid"
+ *    exclude="true()"
+ * />
  * }</pre>
+ *
+ * The {@code exclude} attribute is optional.
  */
 public class ValueQueryData implements QueryData {
     private String key;

--- a/src/main/java/org/commcare/xml/QueryDataParser.java
+++ b/src/main/java/org/commcare/xml/QueryDataParser.java
@@ -41,6 +41,11 @@ public class QueryDataParser extends CommCareElementParser<QueryData> {
             throw new InvalidStructureException("<data> block must define a 'ref' attribute", parser);
         }
 
+        return buildQueryData(key, ref, exclude, nodeset);
+    }
+
+    public static QueryData buildQueryData(String key, String ref, String exclude, String nodeset)
+            throws InvalidStructureException {
         XPathExpression excludeExpr = null;
         if (exclude != null) {
             excludeExpr = parseXpath(exclude);
@@ -57,12 +62,12 @@ public class QueryDataParser extends CommCareElementParser<QueryData> {
         return new ValueQueryData(key, parseXpath(ref), excludeExpr);
     }
 
-    private XPathExpression parseXpath(String ref) throws InvalidStructureException {
+    private static XPathExpression parseXpath(String ref) throws InvalidStructureException {
         try {
             return XPathParseTool.parseXPath(ref);
         } catch (XPathSyntaxException e) {
             String errorMessage = "'ref' value is not a valid xpath expression: " + ref;
-            throw new InvalidStructureException(errorMessage, this.parser);
+            throw new InvalidStructureException(errorMessage);
         }
     }
 }

--- a/src/test/java/org/commcare/suite/model/QueryDataModelTest.java
+++ b/src/test/java/org/commcare/suite/model/QueryDataModelTest.java
@@ -1,0 +1,75 @@
+package org.commcare.suite.model;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+
+import org.commcare.xml.QueryDataParser;
+import org.javarosa.core.model.utils.test.PersistableSandbox;
+import org.javarosa.test_utils.ReflectionUtils;
+import org.javarosa.xml.util.InvalidStructureException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ * Serialization tests for QueryData classes
+ */
+public class QueryDataModelTest {
+
+    private PersistableSandbox mSandbox;
+
+
+    @Before
+    public void setUp() {
+        mSandbox = new PersistableSandbox();
+    }
+
+    @Test
+    public void testSerializeValueQueryData() throws InvalidStructureException, IllegalAccessException {
+        QueryData value = QueryDataParser.buildQueryData("key", "ref", null, null);
+        checkValueData(value);
+    }
+
+    @Test
+    public void testSerializeValueQueryData_exclude() throws InvalidStructureException, IllegalAccessException {
+        QueryData value = QueryDataParser.buildQueryData("key", "ref", "true()", null);
+        checkValueData(value);
+    }
+
+    @Test
+    public void testSerializeListQueryData() throws InvalidStructureException, IllegalAccessException {
+        QueryData value = QueryDataParser.buildQueryData(
+                "key", "ref", "true()", "instance('selected-cases')/session-data/value");
+        checkListQueryData(value);
+    }
+
+    @Test
+    public void testSerializeListQueryData_nullExclude() throws InvalidStructureException, IllegalAccessException {
+        QueryData value = QueryDataParser.buildQueryData(
+                "key", "ref", null, "instance('selected-cases')/session-data/value");
+        checkListQueryData(value);
+    }
+
+    public <T extends QueryData> void checkValueData(QueryData value) throws IllegalAccessException {
+        checkSerialization(ValueQueryData.class, value, ImmutableList.of("ref", "excludeExpr"));
+    }
+
+    public <T extends QueryData> void checkListQueryData(QueryData value) throws IllegalAccessException {
+        checkSerialization(ListQueryData.class, value, ImmutableList.of("ref", "excludeExpr", "nodeset"));
+    }
+
+    public <T extends QueryData> void checkSerialization(Class<T> clazz, QueryData value, List<String> fields)
+            throws IllegalAccessException {
+        byte[] bytes = mSandbox.serialize(value);
+        T deserialized = mSandbox.deserialize(bytes, clazz);
+        assertEquals(value.getKey(), deserialized.getKey());
+        for (String fieldName : fields){
+            assertEquals(
+                    ReflectionUtils.getField(value, fieldName),
+                    ReflectionUtils.getField(deserialized, fieldName)
+            );
+        }
+    }
+}

--- a/src/test/java/org/commcare/suite/model/QueryDataModelTest.java
+++ b/src/test/java/org/commcare/suite/model/QueryDataModelTest.java
@@ -65,7 +65,7 @@ public class QueryDataModelTest {
         byte[] bytes = mSandbox.serialize(value);
         T deserialized = mSandbox.deserialize(bytes, clazz);
         assertEquals(value.getKey(), deserialized.getKey());
-        for (String fieldName : fields){
+        for (String fieldName : fields) {
             assertEquals(
                     ReflectionUtils.getField(value, fieldName),
                     ReflectionUtils.getField(deserialized, fieldName)

--- a/src/test/java/org/commcare/xml/QueryDataParserTest.java
+++ b/src/test/java/org/commcare/xml/QueryDataParserTest.java
@@ -33,10 +33,10 @@ public class QueryDataParserTest {
 
     @Test
     public void testParseListData() throws InvalidStructureException, XmlPullParserException, IOException {
-        String query = "<data key=\"case_id_list\">"
-                + "<list nodeset=\"instance('selected-cases')/session-data/value\" exclude=\"count(instance"
-                + "('casedb')/casedb/case[@case_id = current()/.]) = 1\" ref=\".\"/>"
-                + "</data>";
+        String query = "<data key=\"case_id_list\""
+                + "nodeset=\"instance('selected-cases')/session-data/value\""
+                + "exclude=\"count(instance('casedb')/casedb/case[@case_id = current()/.]) = 1\""
+                + "ref=\".\"/>";
         QueryDataParser parser = ParserTestUtils.buildParser(query, QueryDataParser.class);
         QueryData queryData = parser.parse();
         assertEquals("case_id_list", queryData.getKey());
@@ -49,9 +49,9 @@ public class QueryDataParserTest {
     @Test
     public void testParseListData_noExclude() throws InvalidStructureException, XmlPullParserException,
             IOException {
-        String query = "<data key=\"case_id_list\">"
-                + "<list nodeset=\"instance('selected-cases')/session-data/value\" ref=\".\"/>"
-                + "</data>";
+        String query = "<data key=\"case_id_list\""
+                + "nodeset=\"instance('selected-cases')/session-data/value\""
+                + "ref=\".\"/>";
         QueryDataParser parser = ParserTestUtils.buildParser(query, QueryDataParser.class);
         QueryData queryData = parser.parse();
         assertEquals("case_id_list", queryData.getKey());
@@ -59,19 +59,6 @@ public class QueryDataParserTest {
         Hashtable<String, DataInstance> instances = TestInstances.getInstances();
         EvaluationContext evalContext = new EvaluationContext(null, instances);
         assertEquals(Arrays.asList("123", "456", "789"), queryData.getValues(evalContext));
-    }
-
-    @Test
-    public void testParseQueryData_doubleList() throws XmlPullParserException, IOException {
-        String query = "<data key=\"case_id_list\">"
-                + "<list nodeset=\"instance('selected-cases')/session-data/value\" ref=\".\"/>"
-                + "<list nodeset=\"instance('selected-cases')/session-data/value\" ref=\".\"/>"
-                + "</data>";
-        QueryDataParser parser = ParserTestUtils.buildParser(query, QueryDataParser.class);
-        try {
-            parser.parse();
-            fail("Expected InvalidStructureException");
-        } catch (InvalidStructureException ignored) {}
     }
 
     @Test
@@ -86,7 +73,7 @@ public class QueryDataParserTest {
 
     @Test
     public void testParseQueryData_badNesting() throws XmlPullParserException, IOException {
-        String query = "<data key=\"case_id_list\">"
+        String query = "<data key=\"case_id_list\" ref=\"true()\">"
                 + "<data key=\"device_id\" ref=\"instance('session')/session/case_id\"/>"
                 + "</data>";
         QueryDataParser parser = ParserTestUtils.buildParser(query, QueryDataParser.class);

--- a/src/test/java/org/commcare/xml/QueryDataParserTest.java
+++ b/src/test/java/org/commcare/xml/QueryDataParserTest.java
@@ -32,7 +32,8 @@ public class QueryDataParserTest {
     }
 
     @Test
-    public void testParseValueData_withExclude() throws InvalidStructureException, XmlPullParserException, IOException {
+    public void testParseValueData_withExclude() throws InvalidStructureException, XmlPullParserException,
+            IOException {
         String query = "<data key=\"device_id\" ref=\"instance('session')/session/case_id\""
                 + "exclude=\"true()\"/>";
         QueryDataParser parser = ParserTestUtils.buildParser(query, QueryDataParser.class);

--- a/src/test/java/org/commcare/xml/QueryDataParserTest.java
+++ b/src/test/java/org/commcare/xml/QueryDataParserTest.java
@@ -32,6 +32,18 @@ public class QueryDataParserTest {
     }
 
     @Test
+    public void testParseValueData_withExclude() throws InvalidStructureException, XmlPullParserException, IOException {
+        String query = "<data key=\"device_id\" ref=\"instance('session')/session/case_id\""
+                + "exclude=\"true()\"/>";
+        QueryDataParser parser = ParserTestUtils.buildParser(query, QueryDataParser.class);
+        QueryData queryData = parser.parse();
+        assertEquals("device_id", queryData.getKey());
+
+        EvaluationContext evalContext = new EvaluationContext(null, TestInstances.getInstances());
+        assertEquals(Collections.emptyList(), queryData.getValues(evalContext));
+    }
+
+    @Test
     public void testParseListData() throws InvalidStructureException, XmlPullParserException, IOException {
         String query = "<data key=\"case_id_list\""
                 + "nodeset=\"instance('selected-cases')/session-data/value\""

--- a/src/test/java/org/commcare/xml/RemoteRequestEntryParserTest.java
+++ b/src/test/java/org/commcare/xml/RemoteRequestEntryParserTest.java
@@ -8,6 +8,7 @@ import org.commcare.suite.model.PostRequest;
 import org.commcare.suite.model.QueryData;
 import org.commcare.suite.model.RemoteRequestEntry;
 import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.test_utils.ReflectionUtils;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
 import org.junit.Test;
@@ -37,7 +38,7 @@ public class RemoteRequestEntryParserTest {
                 + "  </command>\n"
                 + "</remote-request>";
         PostRequest post = getRemoteRequestPost(query);
-        List<QueryData> params = getPostParams(post);
+        List<QueryData> params = (List<QueryData>) ReflectionUtils.getField(post, "params");
         assertEquals(1, params.size());
         assertEquals("case_id", params.get(0).getKey());
 
@@ -52,11 +53,5 @@ public class RemoteRequestEntryParserTest {
         EntryParser parser = ParserTestUtils.buildParser(xml, EntryParser::buildRemoteSyncParser);
         RemoteRequestEntry entry = (RemoteRequestEntry)parser.parse();
         return entry.getPostRequest();
-    }
-
-    private List<QueryData> getPostParams(PostRequest post) throws NoSuchFieldException, IllegalAccessException {
-        Field paramsField = PostRequest.class.getDeclaredField("params");
-        paramsField.setAccessible(true);
-        return (List<QueryData>)paramsField.get(post);
     }
 }

--- a/src/test/java/org/javarosa/test_utils/ReflectionUtils.java
+++ b/src/test/java/org/javarosa/test_utils/ReflectionUtils.java
@@ -6,7 +6,7 @@ import java.lang.reflect.Modifier;
 /**
  * ReflectionUtils is a collection of reflection-based utility methods for use in
  * unit testing scenarios.
- *
+ * <p>
  * Code adapter from org.springframework.test.util.ReflectionTestUtils
  */
 public class ReflectionUtils {
@@ -53,8 +53,7 @@ public class ReflectionUtils {
     private static Field[] getDeclaredFields(Class<?> clazz) {
         try {
             return clazz.getDeclaredFields();
-        }
-        catch (Throwable ex) {
+        } catch (Throwable ex) {
             throw new IllegalStateException("Failed to introspect Class [" + clazz.getName() +
                     "] from ClassLoader [" + clazz.getClassLoader() + "]", ex);
         }

--- a/src/test/java/org/javarosa/test_utils/ReflectionUtils.java
+++ b/src/test/java/org/javarosa/test_utils/ReflectionUtils.java
@@ -1,0 +1,62 @@
+package org.javarosa.test_utils;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+/**
+ * ReflectionUtils is a collection of reflection-based utility methods for use in
+ * unit testing scenarios.
+ *
+ * Code adapter from org.springframework.test.util.ReflectionTestUtils
+ */
+public class ReflectionUtils {
+    /**
+     * Get the value of an objects field that is not accessible via a normal getter.
+     */
+    public static Object getField(Object targetObject, String name)
+            throws IllegalAccessException {
+        Class<? extends Object> targetClass = targetObject.getClass();
+
+        Field field = ReflectionUtils.findField(targetClass, name);
+        if (field == null) {
+            throw new IllegalArgumentException(String.format(
+                    "Could not find field '%s' on %s or target class [%s]",
+                    name, String.format("target object [%s]", targetObject), targetClass));
+        }
+
+        ReflectionUtils.makeAccessible(field);
+        return field.get(targetObject);
+    }
+
+    public static void makeAccessible(Field field) {
+        if ((!Modifier.isPublic(field.getModifiers()) ||
+                !Modifier.isPublic(field.getDeclaringClass().getModifiers()) ||
+                Modifier.isFinal(field.getModifiers())) && !field.isAccessible()) {
+            field.setAccessible(true);
+        }
+    }
+
+    public static Field findField(Class<?> clazz, String name) {
+        Class<?> searchType = clazz;
+        while (Object.class != searchType && searchType != null) {
+            Field[] fields = getDeclaredFields(searchType);
+            for (Field field : fields) {
+                if (name.equals(field.getName())) {
+                    return field;
+                }
+            }
+            searchType = searchType.getSuperclass();
+        }
+        return null;
+    }
+
+    private static Field[] getDeclaredFields(Class<?> clazz) {
+        try {
+            return clazz.getDeclaredFields();
+        }
+        catch (Throwable ex) {
+            throw new IllegalStateException("Failed to introspect Class [" + clazz.getName() +
+                    "] from ClassLoader [" + clazz.getClassLoader() + "]", ex);
+        }
+    }
+}


### PR DESCRIPTION
The nested `list` element is unnecessary and makes parsing more complicated. Adding the `exclude` attribute on the `data` element also allows us to use it for other purposes.

This also adds support for the `excludes` attribute on value data elements:
```xml
<data key="external_id" ref="'abc'" exclude="instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid]/role = 'admin'" />
```