### PR TITLE
Revert "Add formVersion in readExternal and writeExternal FormInstance methods"

### DIFF
--- a/src/main/java/org/javarosa/core/model/instance/FormInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/FormInstance.java
@@ -176,8 +176,6 @@ public class FormInstance extends DataInstance<TreeElement> implements Persistab
         super.readExternal(in, pf);
         schema = (String)ExtUtil.read(in, new ExtWrapNullable(String.class), pf);
         dateSaved = (Date)ExtUtil.read(in, new ExtWrapNullable(Date.class), pf);
-        uiVersion = (String)ExtUtil.read(in, new ExtWrapNullable(String.class), pf);
-        formVersion = (String)ExtUtil.read(in, new ExtWrapNullable(String.class), pf);
 
         namespaces = (Hashtable<String, String>)ExtUtil.read(in, new ExtWrapMap(String.class, String.class), pf);
         setRoot((TreeElement)ExtUtil.read(in, TreeElement.class, pf));
@@ -188,8 +186,6 @@ public class FormInstance extends DataInstance<TreeElement> implements Persistab
         super.writeExternal(out);
         ExtUtil.write(out, new ExtWrapNullable(schema));
         ExtUtil.write(out, new ExtWrapNullable(dateSaved));
-        ExtUtil.write(out, new ExtWrapNullable(uiVersion));
-        ExtUtil.write(out, new ExtWrapNullable(formVersion));
         ExtUtil.write(out, new ExtWrapMap(namespaces));
 
         ExtUtil.write(out, getRoot());


### PR DESCRIPTION
Reverts dimagi/commcare-core#1079

This causes failing tests in formplayer. Until I can get time to look into it, it is best to revert this for now.