### PR TITLE
return TreeElement directly for session instance

### DIFF
--- a/src/main/java/org/commcare/core/process/CommCareInstanceInitializer.java
+++ b/src/main/java/org/commcare/core/process/CommCareInstanceInitializer.java
@@ -172,7 +172,7 @@ public class CommCareInstanceInitializer extends InstanceInitializationFactory {
         TreeElement root =
                 SessionInstanceBuilder.getSessionInstance(session.getFrame(), getDeviceId(),
                         getVersionString(), getCurrentDrift(), u.getUsername(), u.getUniqueId(),
-                        u.getProperties()).getRoot();
+                        u.getProperties());
         root.setParent(instance.getBase());
         return new ConcreteInstanceRoot(root);
     }

--- a/src/main/java/org/commcare/session/SessionInstanceBuilder.java
+++ b/src/main/java/org/commcare/session/SessionInstanceBuilder.java
@@ -14,7 +14,7 @@ public class SessionInstanceBuilder {
     public static final String KEY_LAST_QUERY_STRING = "LAST_QUERY_STRING";
     public static final String KEY_ENTITY_LIST_EXTRA_DATA = "entity-list-data";
 
-    public static FormInstance getSessionInstance(SessionFrame frame, String deviceId,
+    public static TreeElement getSessionInstance(SessionFrame frame, String deviceId,
                                                   String appversion, long drift,
                                                   String username, String userId,
                                                   Hashtable<String, String> userFields) {
@@ -24,7 +24,7 @@ public class SessionInstanceBuilder {
         addMetadata(sessionRoot, deviceId, appversion, username, userId, drift);
         addUserProperties(sessionRoot, userFields);
 
-        return new FormInstance(sessionRoot, "session");
+        return sessionRoot;
     }
 
     private static void addSessionNavData(TreeElement sessionRoot, SessionFrame frame) {


### PR DESCRIPTION
Wrapping in `FormInstance` doesn't appear to serve any purpose.