### PR TITLE
Dont wait for case detail if user selected action

### DIFF
--- a/src/cli/java/org/commcare/util/cli/ApplicationHost.java
+++ b/src/cli/java/org/commcare/util/cli/ApplicationHost.java
@@ -304,7 +304,8 @@ public class ApplicationHost {
                     // skipping the entity detail. To avoid this, flag that we want to force a redraw in this case.
                     boolean waitForCaseDetail = false;
                     if (s instanceof EntityScreen) {
-                        if (((EntityScreen) s).getCurrentScreen() instanceof EntityListSubscreen) {
+                        boolean isAction = input.startsWith("action "); // Don't wait for case detail if action
+                        if (!isAction && ((EntityScreen) s).getCurrentScreen() instanceof EntityListSubscreen) {
                             waitForCaseDetail = true;
                         }
                     }


### PR DESCRIPTION
I had a problem with the CLI on the formplayer branch where selecting an action on a case list screen wouldn't trigger the action but just show the case list again:

![image](https://user-images.githubusercontent.com/6729291/163586632-39dfbea3-2562-40d5-809d-b4f1d845dcd3.png)

This is a quick fix for a clear bug where the CLI "waits for a case detail" even if a user selects an action.

I'm using this fix to continue work on [USH-1833](https://dimagi-dev.atlassian.net/browse/USH-1833) (not-syncing on 204), but am open to comments on how to proceed with it. The CLI isn't building on master at all for me--should I make the same changes to master even though I can't test the build?

