### PR TITLE
CLI - dont sync if case claim request returns 204 

### DIFF
--- a/src/cli/java/org/commcare/util/screen/SyncScreen.java
+++ b/src/cli/java/org/commcare/util/screen/SyncScreen.java
@@ -64,14 +64,18 @@ public class SyncScreen extends Screen {
                 return;
             }
             syncSuccessful = true;
-            SessionUtils.restoreUserToSandbox(sessionWrapper.getSandbox(),
+            if (response.code() != 204) {
+                SessionUtils.restoreUserToSandbox(sessionWrapper.getSandbox(),
                     sessionWrapper,
                     sessionWrapper.getPlatform(),
                     username,
                     password,
                     printStream);
 
-            printStream.println(String.format("Sync successful with response %s", response));
+                printStream.println(String.format("Sync successful with response %s", response));
+            } else {
+                printStream.println("Did not sync because case was already claimed.");
+            }
             printStream.println("Press 'enter' to continue.");
         } catch (IOException e) {
             e.printStackTrace();


### PR DESCRIPTION
Per this [Jira ticket ](https://dimagi-dev.atlassian.net/browse/USH-1833) and some conversation in this [PR](https://github.com/dimagi/formplayer/pull/1117).

When the CLI sends a request to HQ to claim a case, HQ will return a 204 status if no cases were claimed and the user's restore file already contains the case. This code prevents the CLI from syncing if it gets back that 204 status, because it doesn't need to.

Tested locally. Currently only planning to merge into the formplayer branch because the build of the CLI on master is broken for me.
