### PR TITLE
Support for Post Relevancy based on post body params

### DIFF
--- a/src/cli/java/org/commcare/util/screen/SyncScreen.java
+++ b/src/cli/java/org/commcare/util/screen/SyncScreen.java
@@ -95,7 +95,7 @@ public class SyncScreen extends Screen {
     }
 
     private Response makeSyncRequest(PostRequest syncPost) throws CommCareSessionException, IOException {
-        Multimap<String, String> params = syncPost.getEvaluatedParams(sessionWrapper.getEvaluationContext());
+        Multimap<String, String> params = syncPost.getEvaluatedParams(sessionWrapper.getEvaluationContext(), false);
         String url = buildUrl(syncPost.getUrl().toString());
         printStream.println(String.format("Syncing with url %s and parameters %s", url, params));
         MultipartBody postBody = buildPostBody(params);

--- a/src/main/java/org/commcare/suite/model/PostRequest.java
+++ b/src/main/java/org/commcare/suite/model/PostRequest.java
@@ -45,13 +45,19 @@ public class PostRequest implements Externalizable {
         return url;
     }
 
-    public Multimap<String, String> getEvaluatedParams(EvaluationContext evalContext) {
+    /**
+     * Evalulates parameteres for post request
+     * @param evalContext Context params needs to be evaluated in
+     * @param includeBlankValues whether to include blank values in the return map
+     * @return Evaluated params
+     */
+    public Multimap<String, String> getEvaluatedParams(EvaluationContext evalContext, boolean includeBlankValues) {
         Multimap<String, String> evaluatedParams = ArrayListMultimap.create();
         for (QueryData queryData : params) {
             Iterable<String> val = queryData.getValues(evalContext);
             if (val.iterator().hasNext()) {
                 evaluatedParams.putAll(queryData.getKey(), val);
-            } else {
+            } else if (includeBlankValues) {
                 evaluatedParams.put(queryData.getKey(), "");
             }
         }
@@ -63,7 +69,7 @@ public class PostRequest implements Externalizable {
             return true;
         } else {
             EvaluationContext localEvalContext = evalContext.spawnWithCleanLifecycle();
-            Multimap<String, String> evaluatedParams = getEvaluatedParams(localEvalContext);
+            Multimap<String, String> evaluatedParams = getEvaluatedParams(localEvalContext, true);
             evaluatedParams.keySet().forEach(key ->
                     localEvalContext.setVariable(key, String.join(" ", evaluatedParams.get(key)))
             );

--- a/src/main/java/org/commcare/suite/model/PostRequest.java
+++ b/src/main/java/org/commcare/suite/model/PostRequest.java
@@ -65,7 +65,7 @@ public class PostRequest implements Externalizable {
             EvaluationContext localEvalContext = evalContext.spawnWithCleanLifecycle();
             Multimap<String, String> evaluatedParams = getEvaluatedParams(localEvalContext);
             evaluatedParams.keySet().forEach(key ->
-                    localEvalContext.setVariable(key, String.join(",", evaluatedParams.get(key)))
+                    localEvalContext.setVariable(key, String.join(" ", evaluatedParams.get(key)))
             );
             String result = RemoteQuerySessionManager.evalXpathExpression(relevantExpr, localEvalContext);
             return "true".equals(result);

--- a/src/test/java/org/commcare/backend/session/test/BasicSessionNavigationTests.java
+++ b/src/test/java/org/commcare/backend/session/test/BasicSessionNavigationTests.java
@@ -186,5 +186,11 @@ public class BasicSessionNavigationTests {
 
         session.setCommand("relevant-remote-request");
         Assert.assertEquals(SessionFrame.STATE_SYNC_REQUEST, session.getNeededData());
+
+        session.setCommand("dynamic-relevancy-remote-request");
+        session.setEntityDatum("case_id","");
+        Assert.assertNull(session.getNeededData());
+        session.setEntityDatum("case_id","case_one");
+        Assert.assertEquals(SessionFrame.STATE_SYNC_REQUEST, session.getNeededData());
     }
 }

--- a/src/test/java/org/commcare/backend/session/test/BasicSessionNavigationTests.java
+++ b/src/test/java/org/commcare/backend/session/test/BasicSessionNavigationTests.java
@@ -130,7 +130,9 @@ public class BasicSessionNavigationTests {
     }
 
     @Test
-    public void testStepToSyncRequest() throws UnfullfilledRequirementsException, XmlPullParserException, IOException, InvalidStructureException {
+    public void testStepToSyncRequest()
+            throws UnfullfilledRequirementsException, XmlPullParserException, IOException,
+            InvalidStructureException {
         session.setCommand("patient-case-search");
         Assert.assertEquals(SessionFrame.STATE_QUERY_REQUEST, session.getNeededData());
 
@@ -152,7 +154,9 @@ public class BasicSessionNavigationTests {
      * Try selecting case already in local case db
      */
     @Test
-    public void testStepToIrrelevantSyncRequest() throws UnfullfilledRequirementsException, XmlPullParserException, IOException, InvalidStructureException {
+    public void testStepToIrrelevantSyncRequest()
+            throws UnfullfilledRequirementsException, XmlPullParserException, IOException,
+            InvalidStructureException {
         session.setCommand("patient-case-search");
         Assert.assertEquals(SessionFrame.STATE_QUERY_REQUEST, session.getNeededData());
 
@@ -188,9 +192,9 @@ public class BasicSessionNavigationTests {
         Assert.assertEquals(SessionFrame.STATE_SYNC_REQUEST, session.getNeededData());
 
         session.setCommand("dynamic-relevancy-remote-request");
-        session.setEntityDatum("case_id","");
+        session.setEntityDatum("case_id", "");
         Assert.assertNull(session.getNeededData());
-        session.setEntityDatum("case_id","case_one");
+        session.setEntityDatum("case_id", "case_one");
         Assert.assertEquals(SessionFrame.STATE_SYNC_REQUEST, session.getNeededData());
     }
 }

--- a/src/test/java/org/commcare/xml/RemoteRequestEntryParserTest.java
+++ b/src/test/java/org/commcare/xml/RemoteRequestEntryParserTest.java
@@ -1,13 +1,17 @@
 package org.commcare.xml;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
 
 import org.commcare.suite.model.PostRequest;
 import org.commcare.suite.model.QueryData;
 import org.commcare.suite.model.RemoteRequestEntry;
 import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.test_utils.ReflectionUtils;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
@@ -15,8 +19,8 @@ import org.junit.Test;
 import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.util.Arrays;
+import java.util.Hashtable;
 import java.util.List;
 
 /**
@@ -30,6 +34,10 @@ public class RemoteRequestEntryParserTest {
         String query = "<remote-request>\n"
                 + "  <post url=\"https://www.fake.com/claim_patient/\">\n"
                 + "    <data key=\"case_id\" ref=\"instance('session')/session/case_id\"/>\n"
+                + "    <data key=\"case_id_list\""
+                + "         nodeset=\"instance('selected-cases')/session-data/value\""
+                + "         exclude=\"count(instance('casedb')/casedb/case[@case_id = current()/.]) = 1\""
+                + "         ref=\".\"/>"
                 + "  </post>\n"
                 + "  <command id=\"search\">\n"
                 + "    <display>\n"
@@ -39,12 +47,21 @@ public class RemoteRequestEntryParserTest {
                 + "</remote-request>";
         PostRequest post = getRemoteRequestPost(query);
         List<QueryData> params = (List<QueryData>) ReflectionUtils.getField(post, "params");
-        assertEquals(1, params.size());
+        assertEquals(2, params.size());
         assertEquals("case_id", params.get(0).getKey());
+        assertEquals("case_id_list", params.get(1).getKey());
 
-        EvaluationContext evalContext = new EvaluationContext(null, TestInstances.getInstances());
-        Multimap<String, String> evaluatedParams = post.getEvaluatedParams(evalContext);
+        Hashtable<String, DataInstance> instances = TestInstances.getInstances();
+        instances.put(TestInstances.CASEDB, TestInstances.buildCaseDb(ImmutableList.of("123", "456", "789")));
+        EvaluationContext evalContext = new EvaluationContext(null, instances);
+
+        Multimap<String, String> evaluatedParams = post.getEvaluatedParams(evalContext, false);
         assertEquals(Arrays.asList("bang"), evaluatedParams.get("case_id"));
+        assertFalse(evaluatedParams.containsKey("case_id_list"));
+
+        evaluatedParams = post.getEvaluatedParams(evalContext, true);
+        assertEquals(Arrays.asList("bang"), evaluatedParams.get("case_id"));
+        assertTrue(evaluatedParams.containsKey("case_id_list"));
     }
 
     private PostRequest getRemoteRequestPost(String xml)

--- a/src/test/java/org/commcare/xml/TestInstances.java
+++ b/src/test/java/org/commcare/xml/TestInstances.java
@@ -9,6 +9,7 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.instance.VirtualDataInstance;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Hashtable;
 import java.util.List;
@@ -20,7 +21,7 @@ public class TestInstances {
 
     private static final String SELECTED_CASES = "selected-cases";
     private static final String SESSION = "session";
-    private static final String CASEDB = "casedb";
+    public static final String CASEDB = "casedb";
 
     public static Hashtable<String, DataInstance> getInstances() {
         Hashtable<String, DataInstance> instances = new Hashtable<>();
@@ -52,6 +53,15 @@ public class TestInstances {
         List<SimpleNode> nodes = ImmutableList.of(
                 SimpleNode.textNode("case", ImmutableMap.of("case_id", "123"), "123")
         );
+        TreeElement root = TreeBuilder.buildTree(CASEDB, CASEDB, nodes);
+        return new VirtualDataInstance(CASEDB, root);
+    }
+
+    public static VirtualDataInstance buildCaseDb(List<String> caseIds) {
+        List<SimpleNode> nodes = new ArrayList<>();
+        caseIds.forEach(caseId -> {
+            nodes.add(SimpleNode.textNode("case", ImmutableMap.of("case_id", caseId), caseId));
+        });
         TreeElement root = TreeBuilder.buildTree(CASEDB, CASEDB, nodes);
         return new VirtualDataInstance(CASEDB, root);
     }

--- a/src/test/resources/session-tests-template/suite.xml
+++ b/src/test/resources/session-tests-template/suite.xml
@@ -271,6 +271,19 @@
     <session/>
   </remote-request>
 
+  <remote-request>
+    <post url="http://fake.com/claim_patient/" relevant="$selected_case_id != ''">
+      <data key="selected_case_id" ref="instance('session')/session/data/case_id"/>
+    </post>
+    <instance id="session" src="jr://instance/session"/>
+    <command id="dynamic-relevancy-remote-request">
+      <display>
+        <text>Global search for person</text>
+      </display>
+    </command>
+    <session/>
+  </remote-request>
+
   <menu id="m0">
     <text>
       <locale id="modules.m0"/>


### PR DESCRIPTION
Adds ability to reference post params in the relevancy condition for post. This allows us to not fire case claim request when all selected cases are owned by the user. Example - 

````
<remote-request>
    <post url="http://localhost:8000/a/test-3/phone/claim-case/"  relevant="$case_id != ‘’”>
      <data key=”case_id”
      nodeset=”instance(‘search_cases’)/results/value” exclude=”count(instance(‘casedb’)/casedb/case[@case_id = current()/.]) = 1” ref=”.”/>
      </data>
   </post>
````
formplayer: https://github.com/dimagi/formplayer/pull/1122/commits/b996aed2562b36482dcfe0b2e0d1de976f0a43d1