### PR TITLE
Updates for new Java Runtimes

### DIFF
--- a/src/main/java/org/javarosa/core/reference/ResourceReference.java
+++ b/src/main/java/org/javarosa/core/reference/ResourceReference.java
@@ -31,7 +31,7 @@ public class ResourceReference implements Reference {
     public boolean doesBinaryExist() throws IOException {
         //Figure out if there's a file by trying to open
         //a stream to it and determining if it's null.
-        InputStream is = System.class.getResourceAsStream(URI);
+        InputStream is = this.getClass().getResourceAsStream(URI);
         if (is == null) {
             return false;
         } else {
@@ -42,7 +42,7 @@ public class ResourceReference implements Reference {
 
     @Override
     public InputStream getStream() throws IOException {
-        InputStream is = System.class.getResourceAsStream(URI);
+        InputStream is = this.getClass().getResourceAsStream(URI);
         if (is == null) {
             throw new FileNotFoundException("File not found when opening resource as stream");
         }

--- a/src/test/resources/pretty_printed_xml.xml
+++ b/src/test/resources/pretty_printed_xml.xml
@@ -1,15 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<h:html xmlns="http://www.w3.org/2002/xforms"
-  xmlns:h="http://www.w3.org/1999/xhtml"
-  xmlns:jr="http://openrosa.org/javarosa"
-  xmlns:orx="http://openrosa.org/jr/xforms"
-  xmlns:vellum="http://commcarehq.org/xforms/vellum" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/jr/xforms" xmlns:vellum="http://commcarehq.org/xforms/vellum" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <h:head>
     <h:title>Basic Form</h:title>
     <model>
       <instance>
-        <data name="Basic Form" uiVersion="1" version="1"
-          xmlns="http://openrosa.org/formdesigner/02FD4762-52FB-404C-9AF1-5F67894D1521" xmlns:jrm="http://dev.commcarehq.org/jr/xforms">
+        <data xmlns="http://openrosa.org/formdesigner/02FD4762-52FB-404C-9AF1-5F67894D1521" xmlns:jrm="http://dev.commcarehq.org/jr/xforms" name="Basic Form" uiVersion="1" version="1">
           <q_name/>
           <orx:meta xmlns:cc="http://commcarehq.org/xforms">
             <orx:deviceID/>

--- a/src/translate/java/org/javarosa/engine/xml/XmlUtil.java
+++ b/src/translate/java/org/javarosa/engine/xml/XmlUtil.java
@@ -1,8 +1,5 @@
 package org.javarosa.engine.xml;
 
-import com.sun.org.apache.xml.internal.serialize.OutputFormat;
-import com.sun.org.apache.xml.internal.serialize.XMLSerializer;
-
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -15,10 +12,16 @@ import java.io.Writer;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
 
 /**
  * Basic static methods for manipulating raw XML
- * 
+ *
  * @author ctsims
  *
  */
@@ -28,17 +31,21 @@ public class XmlUtil {
         try {
             String unformattedXml = new String(xml);
             final Document document = parseXmlFile(unformattedXml);
+            document.setXmlStandalone(true);
 
-            OutputFormat format = new OutputFormat(document);
-            format.setLineWidth(65);
-            format.setIndenting(true);
-            format.setIndent(2);
+            TransformerFactory transformerFactory = TransformerFactory.newInstance();
+            transformerFactory.setAttribute("indent-number", 2);
+            Transformer transformer = transformerFactory.newTransformer();
+            transformer.setOutputProperty(OutputKeys.METHOD, "xml");
+            transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+            transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION,"no");
+            transformer.setOutputProperty(OutputKeys.DOCTYPE_PUBLIC, "");
+            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+
             Writer out = new StringWriter();
-            XMLSerializer serializer = new XMLSerializer(out, format);
-            serializer.serialize(document);
-
+            transformer.transform(new DOMSource(document), new StreamResult(out));
             return out.toString();
-        } catch (IOException e) {
+        } catch (TransformerException e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/translate/java/org/javarosa/engine/xml/XmlUtil.java
+++ b/src/translate/java/org/javarosa/engine/xml/XmlUtil.java
@@ -38,7 +38,7 @@ public class XmlUtil {
             Transformer transformer = transformerFactory.newTransformer();
             transformer.setOutputProperty(OutputKeys.METHOD, "xml");
             transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
-            transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION,"no");
+            transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "no");
             transformer.setOutputProperty(OutputKeys.DOCTYPE_PUBLIC, "");
             transformer.setOutputProperty(OutputKeys.INDENT, "yes");
 


### PR DESCRIPTION
When updating my Android Studio environment to Bumblebee I ran across a few issues that seem to be associated with updated Java runtimes

1) Resource Context Issues

When running tests from a fresh checkout, tests which relied on Resources were failing with FileNotFoundExceptions

```
logger> resources: Install attempt unsuccessful from: jr://resource/app_for_text_tests/profile.ccpr|File not found when opening resource as stream
```
After some digging it looks like the default static classloader in the runtime can end up not being connected, so this change redirects from the static (`System.class`) classloader to the class specific one.

2) PrettyXML issues

We have a helper method in a little-used library for pretty printing XML which has relied on deprecated XML libraries for a long time. This just updates to use modern built-in xml transforms, and replaces the associated test output.
