### PR TITLE
Refactors VirtualDataInstance to extend from ExternalDataInstance

### DIFF
--- a/src/cli/java/org/commcare/util/screen/EntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreen.java
@@ -370,4 +370,8 @@ public class EntityScreen extends CompoundScreenHost {
         }
         return false;
     }
+
+    public void updateDatum(CommCareSession session, String input) {
+        session.setEntityDatum(session.getNeededDatum(), input);
+    }
 }

--- a/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
@@ -7,6 +7,8 @@ import org.commcare.data.xml.VirtualInstances;
 import org.commcare.modern.session.SessionWrapper;
 import org.commcare.session.CommCareSession;
 import org.commcare.suite.model.MultiSelectEntityDatum;
+import org.javarosa.core.model.instance.ExternalDataInstanceSource;
+import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.model.instance.VirtualDataInstance;
 
@@ -24,6 +26,7 @@ public class MultiSelectEntityScreen extends EntityScreen {
 
     private final VirtualDataInstanceCache virtualDataInstanceCache;
     private UUID storageReferenceId;
+    private VirtualDataInstance selectedValuesInstance;
 
     public MultiSelectEntityScreen(boolean handleCaseIndex, boolean full,
             SessionWrapper session,
@@ -74,7 +77,7 @@ public class MultiSelectEntityScreen extends EntityScreen {
                 }
                 evaluatedValues[i] = getReturnValueFromSelection(currentReference);
             }
-            VirtualDataInstance selectedValuesInstance =
+            selectedValuesInstance =
                     VirtualInstances.buildSelectedValuesInstance(getSession().getNeededDatum().getDataId(),
                             selectedValues);
             UUID guid = virtualDataInstanceCache.write(selectedValuesInstance);
@@ -94,7 +97,14 @@ public class MultiSelectEntityScreen extends EntityScreen {
             return;
         }
         if (storageReferenceId != null) {
-            session.setDatum(STATE_MULTIPLE_DATUM_VAL, mNeededDatum.getDataId(), storageReferenceId.toString());
+            ExternalDataInstanceSource externalDataInstanceSource = ExternalDataInstanceSource.buildStorageBackedDataInstanceSource(
+                    selectedValuesInstance.getInstanceId(),
+                    (TreeElement)selectedValuesInstance.getRoot(),
+                    VirtualInstances.JR_SELECTED_VALUES_REFERENCE,
+                    selectedValuesInstance.useCaseTemplate(),
+                    storageReferenceId);
+            session.setDatum(STATE_MULTIPLE_DATUM_VAL, mNeededDatum.getDataId(),
+                    storageReferenceId.toString(), externalDataInstanceSource);
         }
     }
 

--- a/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
@@ -7,10 +7,10 @@ import org.commcare.data.xml.VirtualInstances;
 import org.commcare.modern.session.SessionWrapper;
 import org.commcare.session.CommCareSession;
 import org.commcare.suite.model.MultiSelectEntityDatum;
+import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.ExternalDataInstanceSource;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.instance.TreeReference;
-import org.javarosa.core.model.instance.VirtualDataInstance;
 
 import java.util.UUID;
 
@@ -26,7 +26,7 @@ public class MultiSelectEntityScreen extends EntityScreen {
 
     private final VirtualDataInstanceCache virtualDataInstanceCache;
     private UUID storageReferenceId;
-    private VirtualDataInstance selectedValuesInstance;
+    private ExternalDataInstance selectedValuesInstance;
 
     public MultiSelectEntityScreen(boolean handleCaseIndex, boolean full,
             SessionWrapper session,
@@ -54,7 +54,7 @@ public class MultiSelectEntityScreen extends EntityScreen {
             processSelectedValues(selectedValues);
         } else {
             UUID inputId = UUID.fromString(input);
-            VirtualDataInstance cachedInstance = virtualDataInstanceCache.read(inputId);
+            ExternalDataInstance cachedInstance = virtualDataInstanceCache.read(inputId);
             if (cachedInstance == null) {
                 throw new CommCareSessionException(
                         "Could not make selection with reference id " + input + " on this screen. " +
@@ -97,6 +97,9 @@ public class MultiSelectEntityScreen extends EntityScreen {
             return;
         }
         if (storageReferenceId != null) {
+            if (selectedValuesInstance == null) {
+                selectedValuesInstance = virtualDataInstanceCache.read(storageReferenceId);
+            }
             ExternalDataInstanceSource externalDataInstanceSource = ExternalDataInstanceSource.buildStorageBackedDataInstanceSource(
                     selectedValuesInstance.getInstanceId(),
                     (TreeElement)selectedValuesInstance.getRoot(),

--- a/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
@@ -139,8 +139,8 @@ public class MultiSelectEntityScreen extends EntityScreen {
         return virtualDataInstanceCache.contains(UUID.fromString(stepValue));
     }
 
-    public VirtualDataInstance getVirtualInstance() {
-        return virtualDataInstanceCache.read(getStorageReferenceId());
+    public ExternalDataInstance getVirtualInstance() {
+        return selectedValuesInstance;
     }
 
     public int getMaxSelectValue() {

--- a/src/cli/java/org/commcare/util/screen/QueryScreen.java
+++ b/src/cli/java/org/commcare/util/screen/QueryScreen.java
@@ -11,8 +11,8 @@ import org.commcare.session.RemoteQuerySessionManager;
 import org.commcare.suite.model.QueryPrompt;
 import org.commcare.suite.model.RemoteQueryDatum;
 import org.javarosa.core.model.SelectChoice;
-import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.ExternalDataInstanceSource;
+import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.util.NoLocalizedTextException;
@@ -174,10 +174,9 @@ public class QueryScreen extends Screen {
         try {
             String instanceID = getQueryDatum().getDataId();
             TreeElement root = ExternalDataInstance.parseExternalTree(responseData, instanceID);
-            ExternalDataInstanceSource instanceSource = new ExternalDataInstanceSource(
-                    instanceID, root, url.toString(), requestData, getQueryDatum().useCaseTemplate()
-            );
-            ExternalDataInstance instance = ExternalDataInstance.buildFromRemote(getQueryDatum().getDataId(), instanceSource);
+            ExternalDataInstanceSource instanceSource = ExternalDataInstanceSource.buildRemoteDataInstanceSource(
+                    instanceID, root, getQueryDatum().useCaseTemplate(), url.toString(), requestData);
+            ExternalDataInstance instance = ExternalDataInstance.buildInstance(instanceSource);
             instanceOrError = new Pair<>(instance, "");
         } catch (InvalidStructureException | IOException
                 | XmlPullParserException | UnfullfilledRequirementsException e) {

--- a/src/main/java/org/commcare/core/interfaces/RemoteInstanceFetcher.java
+++ b/src/main/java/org/commcare/core/interfaces/RemoteInstanceFetcher.java
@@ -2,21 +2,20 @@ package org.commcare.core.interfaces;
 
 import org.javarosa.core.model.instance.ExternalDataInstanceSource;
 import org.javarosa.core.model.instance.TreeElement;
-import org.javarosa.xml.util.InvalidStructureException;
-import org.javarosa.xml.util.UnfullfilledRequirementsException;
-import org.xmlpull.v1.XmlPullParserException;
-
-import java.io.IOException;
 
 /**
  * Fetches remote instance definitions from cache or by making a remote web call
  */
 public interface RemoteInstanceFetcher {
 
-    TreeElement getExternalRoot(String instanceId, ExternalDataInstanceSource source)
-            throws UnfullfilledRequirementsException, XmlPullParserException, InvalidStructureException, IOException;
+    TreeElement getExternalRoot(String instanceId, ExternalDataInstanceSource source) throws RemoteInstanceException;
 
     class RemoteInstanceException extends Exception {
+
+        public RemoteInstanceException(String message) {
+            super(message);
+        }
+
         public RemoteInstanceException(String message, Throwable cause) {
             super(message, cause);
         }

--- a/src/main/java/org/commcare/core/interfaces/VirtualDataInstanceCache.java
+++ b/src/main/java/org/commcare/core/interfaces/VirtualDataInstanceCache.java
@@ -1,5 +1,6 @@
 package org.commcare.core.interfaces;
 
+import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.VirtualDataInstance;
 
 import java.sql.SQLException;
@@ -12,9 +13,9 @@ import javax.annotation.Nullable;
  */
 public interface VirtualDataInstanceCache {
 
-    UUID write(VirtualDataInstance dataInstance);
+    UUID write(ExternalDataInstance dataInstance);
 
-    VirtualDataInstance read(UUID key);
+    ExternalDataInstance read(UUID key);
 
     boolean contains(UUID key);
 }

--- a/src/main/java/org/commcare/data/xml/VirtualInstances.java
+++ b/src/main/java/org/commcare/data/xml/VirtualInstances.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 
 public class VirtualInstances {
+
     public static final String SEARCH_INSTANCE_ID = "search-input";
     public static final String SEARCH_INSTANCE_ROOT_NAME = "input";
     public static final String SEARCH_INSTANCE_NODE_NAME = "field";
@@ -19,6 +20,9 @@ public class VirtualInstances {
     public static final String SELCTED_CASES_INSTANCE_ROOT_NAME = "results";
     public static final String SELCTED_CASES_INSTANCE_NODE_NAME = "value";
 
+    public final static String JR_SEARCH_INPUT_REFERENCE = "jr://instance/search_input";
+    public final static String JR_SELECTED_VALUES_REFERENCE = "jr://instance/selected_cases";
+
     public static VirtualDataInstance buildSearchInputInstance(Map<String, String> userInputValues) {
         List<SimpleNode> nodes = new ArrayList<>();
         userInputValues.forEach((key, value) -> {
@@ -26,7 +30,7 @@ public class VirtualInstances {
             nodes.add(SimpleNode.textNode(SEARCH_INSTANCE_NODE_NAME, attributes, value));
         });
         TreeElement root = TreeBuilder.buildTree(SEARCH_INSTANCE_ID, SEARCH_INSTANCE_ROOT_NAME, nodes);
-        return new VirtualDataInstance(SEARCH_INSTANCE_ID, root);
+        return new VirtualDataInstance(JR_SEARCH_INPUT_REFERENCE, SEARCH_INSTANCE_ID, root);
     }
 
     public static VirtualDataInstance buildSelectedValuesInstance(
@@ -37,6 +41,6 @@ public class VirtualInstances {
         }
         TreeElement root = TreeBuilder.buildTree(instanceId, SELCTED_CASES_INSTANCE_ROOT_NAME,
                 nodes);
-        return new VirtualDataInstance(instanceId, root);
+        return new VirtualDataInstance(JR_SELECTED_VALUES_REFERENCE, instanceId, root);
     }
 }

--- a/src/main/java/org/commcare/data/xml/VirtualInstances.java
+++ b/src/main/java/org/commcare/data/xml/VirtualInstances.java
@@ -23,7 +23,7 @@ public class VirtualInstances {
     public final static String JR_SEARCH_INPUT_REFERENCE = "jr://instance/search_input";
     public final static String JR_SELECTED_VALUES_REFERENCE = "jr://instance/selected_cases";
 
-    public static VirtualDataInstance buildSearchInputInstance(Map<String, String> userInputValues) {
+    public static ExternalDataInstance buildSearchInputInstance(Map<String, String> userInputValues) {
         List<SimpleNode> nodes = new ArrayList<>();
         userInputValues.forEach((key, value) -> {
             Map<String, String> attributes = ImmutableMap.of(SEARCH_INPUT_NODE_NAME_ATTR, key);
@@ -33,7 +33,7 @@ public class VirtualInstances {
         return new VirtualDataInstance(JR_SEARCH_INPUT_REFERENCE, SEARCH_INSTANCE_ID, root);
     }
 
-    public static VirtualDataInstance buildSelectedValuesInstance(
+    public static ExternalDataInstance buildSelectedValuesInstance(
             String instanceId, String[] selectedValues) {
         List<SimpleNode> nodes = new ArrayList<>();
         for (String selectedValue : selectedValues) {

--- a/src/main/java/org/commcare/session/CommCareSession.java
+++ b/src/main/java/org/commcare/session/CommCareSession.java
@@ -20,6 +20,7 @@ import org.commcare.suite.model.Text;
 import org.commcare.util.CommCarePlatform;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.DataInstance;
+import org.javarosa.core.model.instance.ExternalDataInstanceSource;
 import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.InstanceInitializationFactory;
 import org.javarosa.core.services.locale.Localizer;
@@ -463,6 +464,11 @@ public class CommCareSession {
         syncState();
     }
 
+    public void setDatum(String action, String keyId, String value, ExternalDataInstanceSource source) {
+        frame.pushStep(new StackFrameStep(action, keyId, value, source));
+        syncState();
+    }
+
     /**
      * Set a (xml) data instance as the result to a session query datum.
      * The instance is available in session's evaluation context until the corresponding query frame is removed
@@ -616,8 +622,9 @@ public class CommCareSession {
                                        InstanceInitializationFactory iif) {
         for (StackFrameStep step : frame.getSteps()) {
             if (step.hasXmlInstance()) {
-                ExternalDataInstance instance = ExternalDataInstance.buildFromRemote(step.getId(), step.getXmlInstanceSource());
-                instanceMap.put(step.getId(), instance.initialize(iif, instance.getSource().getInstanceId()));
+                ExternalDataInstanceSource instanceSource = step.getXmlInstanceSource();
+                ExternalDataInstance instance = ExternalDataInstance.buildInstance(instanceSource);
+                instanceMap.put(step.getId(), instance.initialize(iif, instanceSource.getInstanceId()));
             }
         }
     }

--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -12,6 +12,7 @@ import org.commcare.suite.model.RemoteQueryDatum;
 import org.commcare.suite.model.SessionDatum;
 import org.javarosa.core.model.ItemsetBinding;
 import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.VirtualDataInstance;
 import org.javarosa.core.model.utils.ItemSetUtils;
 import org.javarosa.core.util.OrderedHashtable;
@@ -142,7 +143,7 @@ public class RemoteQuerySessionManager {
 
     private EvaluationContext getEvaluationContextWithUserInputInstance() {
         Map<String, String> userQueryValues = getUserQueryValues(false);
-        VirtualDataInstance userInputInstance = VirtualInstances.buildSearchInputInstance(userQueryValues);
+        ExternalDataInstance userInputInstance = VirtualInstances.buildSearchInputInstance(userQueryValues);
         return evaluationContext.spawnWithCleanLifecycle(
                 ImmutableMap.of(userInputInstance.getInstanceId(), userInputInstance)
         );

--- a/src/main/java/org/javarosa/core/model/instance/ExternalDataInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/ExternalDataInstance.java
@@ -1,9 +1,11 @@
 package org.javarosa.core.model.instance;
 
 import org.commcare.cases.instance.CaseInstanceTreeElement;
+import org.commcare.resources.model.ResourceInstaller;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.ExtWrapNullable;
+import org.javarosa.core.util.externalizable.ExtWrapTagged;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.xml.ElementParser;
 import org.javarosa.xml.TreeElementParser;
@@ -123,6 +125,7 @@ public class ExternalDataInstance extends DataInstance {
         super.readExternal(in, pf);
         reference = ExtUtil.readString(in);
         source = (ExternalDataInstanceSource)ExtUtil.read(in, new ExtWrapNullable(ExternalDataInstanceSource.class), pf);
+        root = (AbstractTreeElement)ExtUtil.read(in, new ExtWrapNullable(new ExtWrapTagged()), pf);
     }
 
     @Override
@@ -130,6 +133,7 @@ public class ExternalDataInstance extends DataInstance {
         super.writeExternal(out);
         ExtUtil.writeString(out, reference);
         ExtUtil.write(out, new ExtWrapNullable(source));
+        ExtUtil.write(out, new ExtWrapNullable(root == null ? null : new ExtWrapTagged(root)));
     }
 
     @Override

--- a/src/main/java/org/javarosa/core/model/instance/ExternalDataInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/ExternalDataInstance.java
@@ -125,7 +125,6 @@ public class ExternalDataInstance extends DataInstance {
         super.readExternal(in, pf);
         reference = ExtUtil.readString(in);
         source = (ExternalDataInstanceSource)ExtUtil.read(in, new ExtWrapNullable(ExternalDataInstanceSource.class), pf);
-        root = (AbstractTreeElement)ExtUtil.read(in, new ExtWrapNullable(new ExtWrapTagged()), pf);
     }
 
     @Override
@@ -133,7 +132,6 @@ public class ExternalDataInstance extends DataInstance {
         super.writeExternal(out);
         ExtUtil.writeString(out, reference);
         ExtUtil.write(out, new ExtWrapNullable(source));
-        ExtUtil.write(out, new ExtWrapNullable(root == null ? null : new ExtWrapTagged(root)));
     }
 
     @Override

--- a/src/main/java/org/javarosa/core/model/instance/ExternalDataInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/ExternalDataInstance.java
@@ -23,16 +23,13 @@ import javax.annotation.Nullable;
  * @author ctsims
  */
 public class ExternalDataInstance extends DataInstance {
+
     private String reference;
-
-
     private AbstractTreeElement root;
     private InstanceBase base;
 
     @Nullable
     private ExternalDataInstanceSource source;
-
-    public final static String JR_REMOTE_REFERENCE = "jr://instance/remote";
 
     public ExternalDataInstance() {
     }
@@ -55,7 +52,7 @@ public class ExternalDataInstance extends DataInstance {
         this.source = instance.getSource();
     }
 
-    private ExternalDataInstance(String reference, String instanceId,
+    protected ExternalDataInstance(String reference, String instanceId,
                                  TreeElement topLevel, ExternalDataInstanceSource source) {
         this(reference, instanceId);
         base = new InstanceBase(instanceId);
@@ -66,15 +63,14 @@ public class ExternalDataInstance extends DataInstance {
         base.setChild(root);
     }
 
+    public static ExternalDataInstance buildInstance(ExternalDataInstanceSource source) {
+        return new ExternalDataInstance(source.getReference(), source.getInstanceId(), source.getRoot(), source);
+    }
+
     public static TreeElement parseExternalTree(InputStream stream, String instanceId) throws IOException, UnfullfilledRequirementsException, XmlPullParserException, InvalidStructureException {
         KXmlParser baseParser = ElementParser.instantiateParser(stream);
         TreeElement root = new TreeElementParser(baseParser, 0, instanceId).parse();
         return root;
-    }
-
-    public static ExternalDataInstance buildFromRemote(String instanceId,
-                                                       ExternalDataInstanceSource source) {
-        return new ExternalDataInstance(JR_REMOTE_REFERENCE, instanceId, source.getRoot(), source);
     }
 
     public boolean useCaseTemplate() {

--- a/src/main/java/org/javarosa/core/model/instance/VirtualDataInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/VirtualDataInstance.java
@@ -11,50 +11,27 @@ import java.io.IOException;
 /**
  * Data instance that is created during execution based on user input of other live data
  */
-public class VirtualDataInstance extends DataInstance {
+public class VirtualDataInstance extends ExternalDataInstance {
+
     private TreeElement root = new TreeElement();
-    private InstanceBase base;
 
     public VirtualDataInstance() {
     }
 
-    public VirtualDataInstance(String instanceid) {
-        super(instanceid);
+    public VirtualDataInstance(String reference, String instanceid) {
+        super(reference, instanceid);
     }
 
     /**
      * Copy constructor
      */
     public VirtualDataInstance(VirtualDataInstance instance) {
-        super(instance.getInstanceId());
-        this.base = instance.getBase();
-        //Copy constructor avoids check.
-        this.root = instance.root;
-        this.mCacheHost = instance.getCacheHost();
+        super(instance);
     }
 
-    public VirtualDataInstance(String instanceId, TreeElement topLevel) {
-        this(instanceId);
-        base = new InstanceBase(instanceId);
-        topLevel.setInstanceName(instanceId);
-        topLevel.setParent(base);
-        this.root = topLevel;
-        base.setChild(root);
-    }
-
-    @Override
-    public boolean isRuntimeEvaluated() {
-        return true;
-    }
-
-    @Override
-    public InstanceBase getBase() {
-        return base;
-    }
-
-    @Override
-    public AbstractTreeElement getRoot() {
-        return root;
+    public VirtualDataInstance(String reference, String instanceId, TreeElement topLevel) {
+        super(reference, instanceId, topLevel, null);
+        this.root = (TreeElement)getRoot();
     }
 
     @Override
@@ -68,12 +45,5 @@ public class VirtualDataInstance extends DataInstance {
     public void writeExternal(DataOutputStream out) throws IOException {
         super.writeExternal(out);
         ExtUtil.write(out, getRoot());
-    }
-
-    @Override
-    public DataInstance initialize(InstanceInitializationFactory initializer, String instanceId) {
-        this.instanceid = instanceId;
-        root.setInstanceName(instanceId);
-        return this;
     }
 }

--- a/src/main/java/org/javarosa/core/model/instance/VirtualDataInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/VirtualDataInstance.java
@@ -13,8 +13,6 @@ import java.io.IOException;
  */
 public class VirtualDataInstance extends ExternalDataInstance {
 
-    private TreeElement root = new TreeElement();
-
     public VirtualDataInstance() {
     }
 
@@ -31,19 +29,5 @@ public class VirtualDataInstance extends ExternalDataInstance {
 
     public VirtualDataInstance(String reference, String instanceId, TreeElement topLevel) {
         super(reference, instanceId, topLevel, null);
-        this.root = (TreeElement)getRoot();
-    }
-
-    @Override
-    public void readExternal(DataInputStream in, PrototypeFactory pf)
-            throws IOException, DeserializationException {
-        super.readExternal(in, pf);
-        root = (TreeElement)ExtUtil.read(in, TreeElement.class, pf);
-    }
-
-    @Override
-    public void writeExternal(DataOutputStream out) throws IOException {
-        super.writeExternal(out);
-        ExtUtil.write(out, getRoot());
     }
 }

--- a/src/main/java/org/javarosa/core/services/locale/LocalizerManager.java
+++ b/src/main/java/org/javarosa/core/services/locale/LocalizerManager.java
@@ -51,4 +51,9 @@ public class LocalizerManager {
     public static void setUseThreadLocalStrategy(boolean useThreadLocal) {
         LocalizerManager.useThreadLocal = useThreadLocal;
     }
+
+    public static void clearInstance() {
+        threadLocalLocalizer.set(null);
+        staticLocalizer = null;
+    }
 }

--- a/src/test/java/org/commcare/backend/session/test/SessionStackTests.java
+++ b/src/test/java/org/commcare/backend/session/test/SessionStackTests.java
@@ -1,5 +1,7 @@
 package org.commcare.backend.session.test;
 
+import com.google.common.collect.ArrayListMultimap;
+
 import org.commcare.modern.session.SessionWrapper;
 import org.commcare.session.RemoteQuerySessionManager;
 import org.commcare.session.SessionFrame;
@@ -9,8 +11,8 @@ import org.commcare.suite.model.RemoteQueryDatum;
 import org.commcare.test.utilities.CaseTestUtils;
 import org.commcare.test.utilities.MockApp;
 import org.javarosa.core.model.condition.EvaluationContext;
-import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.ExternalDataInstanceSource;
+import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.test_utils.ExprEvalUtils;
 import org.javarosa.xml.util.InvalidStructureException;
@@ -371,10 +373,11 @@ public class SessionStackTests {
         InputStream is = cls.getResourceAsStream(resourcePath);
         RemoteQueryDatum queryDatum = remoteQuerySessionManager.getQueryDatum();
         TreeElement root = ExternalDataInstance.parseExternalTree(is, queryDatum.getDataId());
-        ExternalDataInstanceSource source = new ExternalDataInstanceSource(
-                queryDatum.getDataId(), root, resourcePath, queryDatum.useCaseTemplate()
+        ExternalDataInstanceSource source = ExternalDataInstanceSource.buildRemoteDataInstanceSource(
+                queryDatum.getDataId(), root, queryDatum.useCaseTemplate(),
+                resourcePath, ArrayListMultimap.create()
         );
-        ExternalDataInstance instance = ExternalDataInstance.buildFromRemote(queryDatum.getDataId(), source);
+        ExternalDataInstance instance = ExternalDataInstance.buildInstance(source);
         assertNotNull(instance);
         return instance;
     }

--- a/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Multimap;
 
 import org.commcare.data.xml.SimpleNode;
 import org.commcare.data.xml.TreeBuilder;
+import org.commcare.data.xml.VirtualInstances;
 import org.commcare.modern.session.SessionWrapper;
 import org.commcare.session.RemoteQuerySessionManager;
 import org.commcare.suite.model.QueryPrompt;
@@ -128,6 +129,6 @@ public class CaseClaimModelTests {
         );
 
         TreeElement root = TreeBuilder.buildTree("district", "district_list", nodes);
-        return new VirtualDataInstance("district", root);
+        return new VirtualDataInstance(VirtualInstances.JR_SEARCH_INPUT_REFERENCE,"district", root);
     }
 }

--- a/src/test/java/org/commcare/data/xml/VirtualInstancesTest.java
+++ b/src/test/java/org/commcare/data/xml/VirtualInstancesTest.java
@@ -21,7 +21,7 @@ public class VirtualInstancesTest {
     public void testBuildSearchInputRoot()
             throws UnfullfilledRequirementsException, XmlPullParserException,
             InvalidStructureException, IOException {
-        VirtualDataInstance instance = VirtualInstances.buildSearchInputInstance(ImmutableMap.of(
+        ExternalDataInstance instance = VirtualInstances.buildSearchInputInstance(ImmutableMap.of(
                 "key0", "val0",
                 "key1", "val1",
                 "key2", "val2"

--- a/src/test/java/org/commcare/xml/TestInstances.java
+++ b/src/test/java/org/commcare/xml/TestInstances.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableMap;
 
 import org.commcare.data.xml.SimpleNode;
 import org.commcare.data.xml.TreeBuilder;
+import org.commcare.data.xml.VirtualInstances;
 import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.instance.VirtualDataInstance;
@@ -36,7 +37,7 @@ public class TestInstances {
                 SimpleNode.textNode("case_id", Collections.emptyMap(), "bang")
         );
         TreeElement root = TreeBuilder.buildTree(SESSION, SESSION, nodes);
-        return new VirtualDataInstance(SESSION, root);
+        return new VirtualDataInstance("jr://instance/session", SESSION, root);
     }
 
     public static VirtualDataInstance buildSelectedCases() {
@@ -46,7 +47,7 @@ public class TestInstances {
                 SimpleNode.textNode("value", Collections.emptyMap(), "789")
         );
         TreeElement root = TreeBuilder.buildTree(SELECTED_CASES, "session-data", nodes);
-        return new VirtualDataInstance(SELECTED_CASES, root);
+        return new VirtualDataInstance(VirtualInstances.JR_SELECTED_VALUES_REFERENCE, SELECTED_CASES, root);
     }
 
     public static VirtualDataInstance buildCaseDb() {
@@ -54,7 +55,7 @@ public class TestInstances {
                 SimpleNode.textNode("case", ImmutableMap.of("case_id", "123"), "123")
         );
         TreeElement root = TreeBuilder.buildTree(CASEDB, CASEDB, nodes);
-        return new VirtualDataInstance(CASEDB, root);
+        return new VirtualDataInstance("jr://instance/casedb", CASEDB, root);
     }
 
     public static VirtualDataInstance buildCaseDb(List<String> caseIds) {
@@ -63,6 +64,6 @@ public class TestInstances {
             nodes.add(SimpleNode.textNode("case", ImmutableMap.of("case_id", caseId), caseId));
         });
         TreeElement root = TreeBuilder.buildTree(CASEDB, CASEDB, nodes);
-        return new VirtualDataInstance(CASEDB, root);
+        return new VirtualDataInstance("jr://instance/casedb", CASEDB, root);
     }
 }


### PR DESCRIPTION
- VirtualDataInstance now extends from `ExternalDataInstance` 
- Bunch of changes are initialising instance from ExternalDataInstanceSource
- Instance initialisation for selected cases instance now is similar to the case search results instance initialisation aka they both makes use of stack frame's 'xmlInstanceSource' object to initialise the instance from. 


Better to review PR as a whole as there is some back and forth between commits. 