### PR TITLE
store case search user input in the session for later access

### DIFF
--- a/src/cli/java/org/commcare/util/cli/ApplicationHost.java
+++ b/src/cli/java/org/commcare/util/cli/ApplicationHost.java
@@ -2,7 +2,9 @@ package org.commcare.util.cli;
 
 import org.commcare.cases.util.CasePurgeFilter;
 import org.commcare.cases.util.InvalidCaseGraphException;
+import org.commcare.core.interfaces.MemoryVirtualDataInstanceStorage;
 import org.commcare.core.interfaces.UserSandbox;
+import org.commcare.core.interfaces.VirtualDataInstanceStorage;
 import org.commcare.core.parse.CommCareTransactionParserFactory;
 import org.commcare.core.parse.ParseUtils;
 import org.commcare.core.sandbox.SandboxUtils;
@@ -79,6 +81,8 @@ public class ApplicationHost {
     private String password;
     private String mRestoreFile;
     private String mRestoreStrategy = null;
+
+    private VirtualDataInstanceStorage virtualInstanceStorage = new MemoryVirtualDataInstanceStorage();
 
     public ApplicationHost(CommCareConfigEngine engine,
                            PrototypeFactory prototypeFactory,
@@ -433,7 +437,7 @@ public class ApplicationHost {
             return new EntityScreen(true);
         } else if (next.equals(SessionFrame.STATE_QUERY_REQUEST)) {
             checkUsernamePasswordValid();
-            return new QueryScreen(qualifiedUsername, password, System.out);
+            return new QueryScreen(qualifiedUsername, password, System.out, virtualInstanceStorage);
         } else if (next.equals(SessionFrame.STATE_SYNC_REQUEST)) {
             checkUsernamePasswordValid();
             return new SyncScreen(qualifiedUsername, password, System.out);

--- a/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
@@ -85,7 +85,7 @@ public class MultiSelectEntityScreen extends EntityScreen {
             storageReferenceId = guid;
 
             // rebuild instance with the source
-            ExternalDataInstanceSource instanceSource = buildSelectedValuesInstanceSource(instance,
+            ExternalDataInstanceSource instanceSource = ExternalDataInstanceSource.buildVirtual(instance,
                     storageReferenceId);
             selectedValuesInstance = instanceSource.toInstance();
         }
@@ -106,7 +106,7 @@ public class MultiSelectEntityScreen extends EntityScreen {
             if (selectedValuesInstance == null) {
                 selectedValuesInstance = virtualDataInstanceStorage.read(storageReferenceId);
             }
-            ExternalDataInstanceSource externalDataInstanceSource = buildSelectedValuesInstanceSource(
+            ExternalDataInstanceSource externalDataInstanceSource = ExternalDataInstanceSource.buildVirtual(
                     selectedValuesInstance, storageReferenceId);
             session.setDatum(STATE_MULTIPLE_DATUM_VAL, mNeededDatum.getDataId(),
                     storageReferenceId.toString(), externalDataInstanceSource);
@@ -117,20 +117,10 @@ public class MultiSelectEntityScreen extends EntityScreen {
     public void updateDatum(CommCareSession session, String input) {
         storageReferenceId = input;
         selectedValuesInstance = virtualDataInstanceStorage.read(storageReferenceId);
-        ExternalDataInstanceSource externalDataInstanceSource = buildSelectedValuesInstanceSource(
+        ExternalDataInstanceSource externalDataInstanceSource = ExternalDataInstanceSource.buildVirtual(
                 selectedValuesInstance, storageReferenceId);
         session.setDatum(STATE_MULTIPLE_DATUM_VAL, session.getNeededDatum().getDataId(),
                 input, externalDataInstanceSource);
-    }
-
-    private static ExternalDataInstanceSource buildSelectedValuesInstanceSource(
-            ExternalDataInstance selectedValuesInstance, String storageReferenceId) {
-        return ExternalDataInstanceSource.buildVirtual(
-                selectedValuesInstance.getInstanceId(),
-                (TreeElement)selectedValuesInstance.getRoot(),
-                selectedValuesInstance.getReference(),
-                selectedValuesInstance.useCaseTemplate(),
-                storageReferenceId);
     }
 
     @Override

--- a/src/cli/java/org/commcare/util/screen/QueryScreen.java
+++ b/src/cli/java/org/commcare/util/screen/QueryScreen.java
@@ -191,7 +191,7 @@ public class QueryScreen extends Screen {
         return instanceOrError;
     }
 
-    public void setQueryDatum(ExternalDataInstance dataInstance) {
+    public void updateSession(ExternalDataInstance dataInstance) {
         if (dataInstance != null) {
             sessionWrapper.setQueryDatum(dataInstance);
         }
@@ -278,7 +278,7 @@ public class QueryScreen extends Screen {
         Multimap<String, String> requestData = getRequestData(false);
         InputStream response = makeQueryRequestReturnStream(url, requestData);
         Pair<ExternalDataInstance, String> instanceOrError = processResponse(response, url, requestData);
-        setQueryDatum(instanceOrError.first);
+        updateSession(instanceOrError.first);
         if (currentMessage != null) {
             out.println(currentMessage);
         }

--- a/src/cli/java/org/commcare/util/screen/QueryScreen.java
+++ b/src/cli/java/org/commcare/util/screen/QueryScreen.java
@@ -111,6 +111,7 @@ public class QueryScreen extends Screen {
         for (Map.Entry<String, QueryPrompt> queryPromptEntry : userInputDisplays.entrySet()) {
             fields[count] = queryPromptEntry.getValue().getDisplay().getText().evaluate(
                     sessionWrapper.getEvaluationContext());
+            count++;
         }
 
         try {

--- a/src/cli/java/org/commcare/util/screen/QueryScreen.java
+++ b/src/cli/java/org/commcare/util/screen/QueryScreen.java
@@ -206,20 +206,23 @@ public class QueryScreen extends Screen {
     }
 
     private ExternalDataInstance getUserInputInstance() {
+        String instanceID = VirtualInstances.makeSearchInputInstanceID(getQueryDatum().getDataId());
         Map<String, String> userQueryValues = remoteQuerySessionManager.getUserQueryValues(false);
-        String key = getInstanceKey(userQueryValues);
+        String key = getInstanceKey(instanceID, userQueryValues);
         if (instanceStorage.contains(key)) {
             return instanceStorage.read(key);
         }
 
-        ExternalDataInstance userInputInstance = VirtualInstances.buildSearchInputInstance(userQueryValues);
+        ExternalDataInstance userInputInstance = VirtualInstances.buildSearchInputInstance(
+                instanceID, userQueryValues);
         instanceStorage.write(key, userInputInstance);
         // rebuild the instance with source
         return ExternalDataInstanceSource.buildVirtual(userInputInstance, key).toInstance();
     }
 
-    private String getInstanceKey(Map<String, String> values) {
-        StringBuilder builder = new StringBuilder();
+    private String getInstanceKey(String instanceId, Map<String, String> values) {
+        StringBuilder builder = new StringBuilder(instanceId);
+        builder.append("/");
         for (Map.Entry<String, String> entry : values.entrySet()) {
             builder.append(entry.getKey()).append("=").append(entry.getValue()).append("|");
         }

--- a/src/main/java/org/commcare/core/encryption/CryptUtil.java
+++ b/src/main/java/org/commcare/core/encryption/CryptUtil.java
@@ -5,6 +5,7 @@ import org.javarosa.core.io.StreamsUtil;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.KeyFactory;
 import java.security.MessageDigest;
@@ -83,6 +84,21 @@ public class CryptUtil {
             e.printStackTrace();
         }
         return null;
+    }
+
+    public static String sha256(String value) {
+        MessageDigest digest = null;
+        try {
+            digest = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+        byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+        StringBuilder sb = new StringBuilder();
+        for (byte b : hash) {
+            sb.append(String.format("%x", b));
+        }
+        return sb.toString();
     }
 
     private static byte[] append(byte[] one, byte[] two) {

--- a/src/main/java/org/commcare/core/interfaces/MemoryVirtualDataInstanceStorage.java
+++ b/src/main/java/org/commcare/core/interfaces/MemoryVirtualDataInstanceStorage.java
@@ -1,0 +1,33 @@
+package org.commcare.core.interfaces;
+
+import org.javarosa.core.model.instance.ExternalDataInstance;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * In memory implementation of VirtualDataInstanceStorage for use in the CLI and tests.
+ */
+public class MemoryVirtualDataInstanceStorage implements
+        VirtualDataInstanceStorage {
+
+    private Map<String, ExternalDataInstance> storage = new HashMap<>();
+
+    @Override
+    public String write(ExternalDataInstance dataInstance) {
+        String key = UUID.randomUUID().toString();
+        storage.put(key, dataInstance);
+        return key;
+    }
+
+    @Override
+    public ExternalDataInstance read(String key) {
+        return storage.get(key);
+    }
+
+    @Override
+    public boolean contains(String key) {
+        return storage.containsKey(key);
+    }
+}

--- a/src/main/java/org/commcare/core/interfaces/MemoryVirtualDataInstanceStorage.java
+++ b/src/main/java/org/commcare/core/interfaces/MemoryVirtualDataInstanceStorage.java
@@ -4,6 +4,7 @@ import org.javarosa.core.model.instance.ExternalDataInstance;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -22,6 +23,15 @@ public class MemoryVirtualDataInstanceStorage implements
     }
 
     @Override
+    public String write(String key, ExternalDataInstance dataInstance) {
+        if (contains(key)) {
+            throw new RuntimeException(key);
+        }
+        storage.put(key, dataInstance);
+        return key;
+    }
+
+    @Override
     public ExternalDataInstance read(String key) {
         return storage.get(key);
     }
@@ -29,5 +39,13 @@ public class MemoryVirtualDataInstanceStorage implements
     @Override
     public boolean contains(String key) {
         return storage.containsKey(key);
+    }
+
+    public Set<String> getKeys() {
+        return storage.keySet();
+    }
+
+    public void clear() {
+        storage.clear();
     }
 }

--- a/src/main/java/org/commcare/core/interfaces/MemoryVirtualDataInstanceStorage.java
+++ b/src/main/java/org/commcare/core/interfaces/MemoryVirtualDataInstanceStorage.java
@@ -25,7 +25,7 @@ public class MemoryVirtualDataInstanceStorage implements
     @Override
     public String write(String key, ExternalDataInstance dataInstance) {
         if (contains(key)) {
-            throw new RuntimeException(key);
+            throw new RuntimeException(String.format("Virtual instance with key '%s' already exists", key));
         }
         storage.put(key, dataInstance);
         return key;

--- a/src/main/java/org/commcare/core/interfaces/MemoryVirtualDataInstanceStorage.java
+++ b/src/main/java/org/commcare/core/interfaces/MemoryVirtualDataInstanceStorage.java
@@ -41,10 +41,6 @@ public class MemoryVirtualDataInstanceStorage implements
         return storage.containsKey(key);
     }
 
-    public Set<String> getKeys() {
-        return storage.keySet();
-    }
-
     public void clear() {
         storage.clear();
     }

--- a/src/main/java/org/commcare/core/interfaces/VirtualDataInstanceStorage.java
+++ b/src/main/java/org/commcare/core/interfaces/VirtualDataInstanceStorage.java
@@ -8,8 +8,9 @@ import java.util.UUID;
  * Read and write operations for entity selections made on a mult-select Entity Screen
  */
 public interface VirtualDataInstanceStorage {
-
     String write(ExternalDataInstance dataInstance);
+
+    String write(String key, ExternalDataInstance dataInstance);
 
     ExternalDataInstance read(String key);
 

--- a/src/main/java/org/commcare/core/process/CommCareInstanceInitializer.java
+++ b/src/main/java/org/commcare/core/process/CommCareInstanceInitializer.java
@@ -200,8 +200,8 @@ public class CommCareInstanceInitializer extends InstanceInitializationFactory {
 
     protected InstanceRoot getExternalDataInstanceSource(ExternalDataInstance instance, String stepType) {
         for (StackFrameStep step : session.getFrame().getSteps()) {
-            if (step.getId().equals(instance.getInstanceId()) && step.getType().equals(stepType)) {
-                return step.getXmlInstanceSource();
+            if (step.getType().equals(stepType) && step.hasDataInstanceSource(instance.getInstanceId())) {
+                return step.getDataInstanceSource(instance.getInstanceId());
             }
         }
         return instance.getSource() == null ? ConcreteInstanceRoot.NULL : instance.getSource();

--- a/src/main/java/org/commcare/core/process/CommCareInstanceInitializer.java
+++ b/src/main/java/org/commcare/core/process/CommCareInstanceInitializer.java
@@ -1,5 +1,6 @@
 package org.commcare.core.process;
 
+import static org.javarosa.core.model.instance.ExternalDataInstance.JR_SEARCH_INPUT_REFERENCE;
 import static org.javarosa.core.model.instance.ExternalDataInstance.JR_SELECTED_ENTITIES_REFERENCE;
 
 import org.commcare.cases.instance.CaseDataInstance;
@@ -92,6 +93,8 @@ public class CommCareInstanceInitializer extends InstanceInitializationFactory {
             return setupMigrationData(instance);
         } else if (ref.contentEquals(JR_SELECTED_ENTITIES_REFERENCE)) {
             return setupSelectedEntities(instance);
+        } else if (ref.contentEquals(JR_SEARCH_INPUT_REFERENCE)) {
+            return getExternalDataInstanceSource(instance, SessionFrame.STATE_QUERY_REQUEST);
         }
         return ConcreteInstanceRoot.NULL;
     }

--- a/src/main/java/org/commcare/data/xml/VirtualInstances.java
+++ b/src/main/java/org/commcare/data/xml/VirtualInstances.java
@@ -14,7 +14,6 @@ import java.util.Map;
 
 public class VirtualInstances {
 
-    public static final String SEARCH_INSTANCE_ID = "search-input";
     public static final String SEARCH_INSTANCE_ROOT_NAME = "input";
     public static final String SEARCH_INSTANCE_NODE_NAME = "field";
     public static final String SEARCH_INPUT_NODE_NAME_ATTR = "name";
@@ -22,15 +21,18 @@ public class VirtualInstances {
     public static final String SELCTED_CASES_INSTANCE_ROOT_NAME = "results";
     public static final String SELCTED_CASES_INSTANCE_NODE_NAME = "value";
 
+    public static String makeSearchInputInstanceID(String suffix) {
+        return String.format("search-input:%s", suffix);
+    }
 
-    public static ExternalDataInstance buildSearchInputInstance(Map<String, String> userInputValues) {
+    public static ExternalDataInstance buildSearchInputInstance(String instanceID, Map<String, String> userInputValues) {
         List<SimpleNode> nodes = new ArrayList<>();
         userInputValues.forEach((key, value) -> {
             Map<String, String> attributes = ImmutableMap.of(SEARCH_INPUT_NODE_NAME_ATTR, key);
             nodes.add(SimpleNode.textNode(SEARCH_INSTANCE_NODE_NAME, attributes, value));
         });
-        TreeElement root = TreeBuilder.buildTree(SEARCH_INSTANCE_ID, SEARCH_INSTANCE_ROOT_NAME, nodes);
-        return new ExternalDataInstance(JR_SEARCH_INPUT_REFERENCE, SEARCH_INSTANCE_ID, root);
+        TreeElement root = TreeBuilder.buildTree(instanceID, SEARCH_INSTANCE_ROOT_NAME, nodes);
+        return new ExternalDataInstance(JR_SEARCH_INPUT_REFERENCE, instanceID, root);
     }
 
     public static ExternalDataInstance buildSelectedValuesInstance(

--- a/src/main/java/org/commcare/modern/session/SessionWrapper.java
+++ b/src/main/java/org/commcare/modern/session/SessionWrapper.java
@@ -74,9 +74,7 @@ public class SessionWrapper extends CommCareSession implements SessionWrapperInt
 
     public void prepareExternalSources(RemoteInstanceFetcher remoteInstanceFetcher) throws RemoteInstanceFetcher.RemoteInstanceException {
         for(StackFrameStep step : frame.getSteps()) {
-            if (step.hasXmlInstance() && step.getXmlInstanceSource().needsInit()) {
-                step.getXmlInstanceSource().remoteInit(remoteInstanceFetcher);
-            }
+            step.initDataInstanceSources(remoteInstanceFetcher);
         }
     }
 

--- a/src/main/java/org/commcare/session/CommCareSession.java
+++ b/src/main/java/org/commcare/session/CommCareSession.java
@@ -37,7 +37,6 @@ import org.javarosa.xpath.parser.XPathSyntaxException;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.List;
@@ -467,7 +466,7 @@ public class CommCareSession {
 
     public void setDatum(String action, String keyId, String value, ExternalDataInstanceSource source) {
         StackFrameStep step = new StackFrameStep(action, keyId, value);
-        step.addDataInstanceSources(source);
+        step.addDataInstanceSource(source);
         frame.pushStep(step);
         syncState();
     }
@@ -481,9 +480,9 @@ public class CommCareSession {
         if (datum instanceof RemoteQueryDatum) {
             StackFrameStep step = new StackFrameStep(
                     SessionFrame.STATE_QUERY_REQUEST, datum.getDataId(), datum.getValue());
-            step.addDataInstanceSources(queryResultInstance.getSource());
+            step.addDataInstanceSource(queryResultInstance.getSource());
             for (ExternalDataInstance instance : extras) {
-                step.addDataInstanceSources(instance.getSource());
+                step.addDataInstanceSource(instance.getSource());
             }
             frame.pushStep(step);
             syncState();

--- a/src/main/java/org/commcare/session/CommCareSession.java
+++ b/src/main/java/org/commcare/session/CommCareSession.java
@@ -465,7 +465,9 @@ public class CommCareSession {
     }
 
     public void setDatum(String action, String keyId, String value, ExternalDataInstanceSource source) {
-        frame.pushStep(new StackFrameStep(action, keyId, value, source));
+        StackFrameStep step = new StackFrameStep(action, keyId, value);
+        step.addDataInstanceSources(source);
+        frame.pushStep(step);
         syncState();
     }
 
@@ -476,9 +478,9 @@ public class CommCareSession {
     public void setQueryDatum(ExternalDataInstance queryResultInstance) {
         SessionDatum datum = getNeededDatum();
         if (datum instanceof RemoteQueryDatum) {
-            StackFrameStep step =
-                    new StackFrameStep(SessionFrame.STATE_QUERY_REQUEST,
-                            datum.getDataId(), datum.getValue(), queryResultInstance.getSource());
+            StackFrameStep step = new StackFrameStep(
+                    SessionFrame.STATE_QUERY_REQUEST, datum.getDataId(), datum.getValue());
+            step.addDataInstanceSources(queryResultInstance.getSource());
             frame.pushStep(step);
             syncState();
         } else {
@@ -621,11 +623,7 @@ public class CommCareSession {
     private void addInstancesFromFrame(Hashtable<String, DataInstance> instanceMap,
                                        InstanceInitializationFactory iif) {
         for (StackFrameStep step : frame.getSteps()) {
-            if (step.hasXmlInstance()) {
-                ExternalDataInstanceSource instanceSource = step.getXmlInstanceSource();
-                ExternalDataInstance instance = instanceSource.toInstance();
-                instanceMap.put(step.getId(), instance.initialize(iif, instanceSource.getInstanceId()));
-            }
+            instanceMap.putAll(step.getInstances(iif));
         }
     }
 

--- a/src/main/java/org/commcare/session/CommCareSession.java
+++ b/src/main/java/org/commcare/session/CommCareSession.java
@@ -37,6 +37,7 @@ import org.javarosa.xpath.parser.XPathSyntaxException;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.List;
@@ -475,12 +476,15 @@ public class CommCareSession {
      * Set a (xml) data instance as the result to a session query datum.
      * The instance is available in session's evaluation context until the corresponding query frame is removed
      */
-    public void setQueryDatum(ExternalDataInstance queryResultInstance) {
+    public void setQueryDatum(ExternalDataInstance queryResultInstance, ExternalDataInstance... extras) {
         SessionDatum datum = getNeededDatum();
         if (datum instanceof RemoteQueryDatum) {
             StackFrameStep step = new StackFrameStep(
                     SessionFrame.STATE_QUERY_REQUEST, datum.getDataId(), datum.getValue());
             step.addDataInstanceSources(queryResultInstance.getSource());
+            Arrays.stream(extras).forEach((instance) -> {
+                step.addDataInstanceSources(instance.getSource());
+            });
             frame.pushStep(step);
             syncState();
         } else {

--- a/src/main/java/org/commcare/session/CommCareSession.java
+++ b/src/main/java/org/commcare/session/CommCareSession.java
@@ -482,9 +482,9 @@ public class CommCareSession {
             StackFrameStep step = new StackFrameStep(
                     SessionFrame.STATE_QUERY_REQUEST, datum.getDataId(), datum.getValue());
             step.addDataInstanceSources(queryResultInstance.getSource());
-            Arrays.stream(extras).forEach((instance) -> {
+            for (ExternalDataInstance instance : extras) {
                 step.addDataInstanceSources(instance.getSource());
-            });
+            }
             frame.pushStep(step);
             syncState();
         } else {

--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -148,7 +148,11 @@ public class RemoteQuerySessionManager {
         ExternalDataInstance userInputInstance = VirtualInstances.buildSearchInputInstance(
                 instanceID, userQueryValues);
         return evaluationContext.spawnWithCleanLifecycle(
-                ImmutableMap.of(userInputInstance.getInstanceId(), userInputInstance)
+                ImmutableMap.of(
+                        userInputInstance.getInstanceId(), userInputInstance,
+                        // Temporary method to make the 'search-input' instance available using the legacy ID
+                        "search-input", userInputInstance
+                )
         );
     }
 

--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -144,7 +144,9 @@ public class RemoteQuerySessionManager {
 
     private EvaluationContext getEvaluationContextWithUserInputInstance() {
         Map<String, String> userQueryValues = getUserQueryValues(false);
-        ExternalDataInstance userInputInstance = VirtualInstances.buildSearchInputInstance(userQueryValues);
+        String instanceID = VirtualInstances.makeSearchInputInstanceID(queryDatum.getDataId());
+        ExternalDataInstance userInputInstance = VirtualInstances.buildSearchInputInstance(
+                instanceID, userQueryValues);
         return evaluationContext.spawnWithCleanLifecycle(
                 ImmutableMap.of(userInputInstance.getInstanceId(), userInputInstance)
         );

--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -143,15 +143,11 @@ public class RemoteQuerySessionManager {
     }
 
     private EvaluationContext getEvaluationContextWithUserInputInstance() {
-        ExternalDataInstance userInputInstance = getUserInputInstance();
+        Map<String, String> userQueryValues = getUserQueryValues(false);
+        ExternalDataInstance userInputInstance = VirtualInstances.buildSearchInputInstance(userQueryValues);
         return evaluationContext.spawnWithCleanLifecycle(
                 ImmutableMap.of(userInputInstance.getInstanceId(), userInputInstance)
         );
-    }
-
-    public ExternalDataInstance getUserInputInstance() {
-        Map<String, String> userQueryValues = getUserQueryValues(false);
-        return VirtualInstances.buildSearchInputInstance(userQueryValues);
     }
 
     public static String evalXpathExpression(XPathExpression expr,
@@ -169,7 +165,7 @@ public class RemoteQuerySessionManager {
         ItemSetUtils.populateDynamicChoices(queryPrompt.getItemsetBinding(), evalContextWithAnswers);
     }
 
-    private Map<String, String> getUserQueryValues(boolean includeNulls) {
+    public Map<String, String> getUserQueryValues(boolean includeNulls) {
         Map<String, String> values = new HashMap<>();
         OrderedHashtable<String, QueryPrompt> queryPrompts = queryDatum.getUserQueryPrompts();
         for (Enumeration en = queryPrompts.keys(); en.hasMoreElements(); ) {

--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -143,11 +143,15 @@ public class RemoteQuerySessionManager {
     }
 
     private EvaluationContext getEvaluationContextWithUserInputInstance() {
-        Map<String, String> userQueryValues = getUserQueryValues(false);
-        ExternalDataInstance userInputInstance = VirtualInstances.buildSearchInputInstance(userQueryValues);
+        ExternalDataInstance userInputInstance = getUserInputInstance();
         return evaluationContext.spawnWithCleanLifecycle(
                 ImmutableMap.of(userInputInstance.getInstanceId(), userInputInstance)
         );
+    }
+
+    public ExternalDataInstance getUserInputInstance() {
+        Map<String, String> userQueryValues = getUserQueryValues(false);
+        return VirtualInstances.buildSearchInputInstance(userQueryValues);
     }
 
     public static String evalXpathExpression(XPathExpression expr,

--- a/src/main/java/org/commcare/suite/model/StackFrameStep.java
+++ b/src/main/java/org/commcare/suite/model/StackFrameStep.java
@@ -29,6 +29,7 @@ import java.util.Collection;
 import java.util.Hashtable;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -101,10 +102,8 @@ public class StackFrameStep implements Externalizable {
     }
 
     public void addDataInstanceSource(ExternalDataInstanceSource source) {
-        if (source == null) {
-            throw new RuntimeException(String.format(
-                    "Unable to add null instance data source to stack frame step '%s'", getId()));
-        }
+        Objects.requireNonNull(source, String.format(
+                "Unable to add null instance data source to stack frame step '%s'", getId()));
         String instanceId = source.getInstanceId();
         if (dataInstanceSources.containsKey(instanceId)) {
             throw new RuntimeException(String.format(

--- a/src/main/java/org/commcare/suite/model/StackFrameStep.java
+++ b/src/main/java/org/commcare/suite/model/StackFrameStep.java
@@ -3,13 +3,17 @@ package org.commcare.suite.model;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 
+import org.commcare.core.interfaces.RemoteInstanceFetcher;
 import org.commcare.session.SessionFrame;
 import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.model.instance.DataInstance;
+import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.ExternalDataInstanceSource;
+import org.javarosa.core.model.instance.InstanceInitializationFactory;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.ExtWrapMap;
 import org.javarosa.core.util.externalizable.ExtWrapMultiMap;
-import org.javarosa.core.util.externalizable.ExtWrapNullable;
 import org.javarosa.core.util.externalizable.Externalizable;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.xpath.XPathException;
@@ -22,7 +26,10 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Hashtable;
+import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
 
 /**
  * @author ctsims
@@ -36,11 +43,11 @@ public class StackFrameStep implements Externalizable {
     private Multimap<String, Object> extras = ArrayListMultimap.create();
 
     /**
-     * XML instance collected during session navigation that is made available
+     * XML instances collected during session navigation that is made available
      * in the session's evaluation context. For instance, useful to store
      * results of a query command during case search and claim workflow
      */
-    private ExternalDataInstanceSource xmlInstanceSource;
+    private Hashtable<String, ExternalDataInstanceSource> dataInstanceSources = new Hashtable<>();
 
     /**
      * Serialization Only
@@ -59,22 +66,13 @@ public class StackFrameStep implements Externalizable {
         this.valueIsXpath = oldStackFrameStep.valueIsXpath;
         extras.putAll(oldStackFrameStep.getExtras());
 
-        if (oldStackFrameStep.hasXmlInstance()) {
-            this.xmlInstanceSource = new ExternalDataInstanceSource(oldStackFrameStep.xmlInstanceSource);
-        }
+        this.dataInstanceSources.putAll(oldStackFrameStep.dataInstanceSources);
     }
 
     public StackFrameStep(String type, String id, String value) {
         this.elementType = type;
         this.id = id;
         this.value = value;
-    }
-
-    public StackFrameStep(String type, String id, String value,
-                          ExternalDataInstanceSource xmlInstanceSource) {
-        this(type, id, value);
-
-        this.xmlInstanceSource = xmlInstanceSource;
     }
 
     public StackFrameStep(String type, String id,
@@ -102,12 +100,42 @@ public class StackFrameStep implements Externalizable {
         return value;
     }
 
-    public boolean hasXmlInstance() {
-        return xmlInstanceSource != null;
+    public void addDataInstanceSources(ExternalDataInstanceSource source) {
+        if (source == null) {
+            return;
+        }
+        String instanceId = source.getInstanceId();
+        if (dataInstanceSources.containsKey(instanceId)) {
+            throw new RuntimeException(String.format(
+                    "Stack frame step '%s' already contains an instance with the instance ID '%s'",
+                    getId(), instanceId
+            ));
+        }
+        dataInstanceSources.put(instanceId, source);
     }
 
-    public ExternalDataInstanceSource getXmlInstanceSource() {
-        return xmlInstanceSource;
+    public boolean hasDataInstanceSource(String instanceId) {
+        return dataInstanceSources.containsKey(instanceId);
+    }
+
+    public ExternalDataInstanceSource getDataInstanceSource(String instanceId) {
+        return dataInstanceSources.get(instanceId);
+    }
+
+    public void initDataInstanceSources(RemoteInstanceFetcher remoteInstanceFetcher)
+            throws RemoteInstanceFetcher.RemoteInstanceException {
+        for (ExternalDataInstanceSource source : dataInstanceSources.values()) {
+            if (source.needsInit()) {
+                source.remoteInit(remoteInstanceFetcher);
+            }
+        }
+    }
+
+    public Map<String, DataInstance> getInstances(InstanceInitializationFactory iif) {
+        return dataInstanceSources.values().stream().map((source) -> {
+            ExternalDataInstance instance = source.toInstance();
+            return instance.initialize(iif, source.getInstanceId());
+        }).collect(Collectors.toMap(DataInstance::getInstanceId, value -> value));
     }
 
     /**
@@ -194,7 +222,7 @@ public class StackFrameStep implements Externalizable {
         this.value = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
         this.valueIsXpath = ExtUtil.readBool(in);
         this.extras = (Multimap<String, Object>)ExtUtil.read(in, new ExtWrapMultiMap(String.class), pf);
-        this.xmlInstanceSource = (ExternalDataInstanceSource)ExtUtil.read(in, new ExtWrapNullable(ExternalDataInstanceSource.class), pf);
+        this.dataInstanceSources = (Hashtable<String, ExternalDataInstanceSource>)ExtUtil.read(in, new ExtWrapMap(String.class, ExternalDataInstanceSource.class), pf);
     }
 
     @Override
@@ -204,7 +232,7 @@ public class StackFrameStep implements Externalizable {
         ExtUtil.writeString(out, ExtUtil.emptyIfNull(value));
         ExtUtil.writeBool(out, valueIsXpath);
         ExtUtil.write(out, new ExtWrapMultiMap(extras));
-        ExtUtil.write(out, new ExtWrapNullable(xmlInstanceSource));
+        ExtUtil.write(out, new ExtWrapMap(dataInstanceSources));
     }
 
     @Override
@@ -254,4 +282,5 @@ public class StackFrameStep implements Externalizable {
     public String getElementType() {
         return elementType;
     }
+
 }

--- a/src/main/java/org/commcare/suite/model/StackFrameStep.java
+++ b/src/main/java/org/commcare/suite/model/StackFrameStep.java
@@ -100,7 +100,7 @@ public class StackFrameStep implements Externalizable {
         return value;
     }
 
-    public void addDataInstanceSources(ExternalDataInstanceSource source) {
+    public void addDataInstanceSource(ExternalDataInstanceSource source) {
         if (source == null) {
             throw new RuntimeException(String.format(
                     "Unable to add null instance data source to stack frame step '%s'", getId()));

--- a/src/main/java/org/commcare/suite/model/StackFrameStep.java
+++ b/src/main/java/org/commcare/suite/model/StackFrameStep.java
@@ -102,7 +102,8 @@ public class StackFrameStep implements Externalizable {
 
     public void addDataInstanceSources(ExternalDataInstanceSource source) {
         if (source == null) {
-            return;
+            throw new RuntimeException(String.format(
+                    "Unable to add null instance data source to stack frame step '%s'", getId()));
         }
         String instanceId = source.getInstanceId();
         if (dataInstanceSources.containsKey(instanceId)) {

--- a/src/main/java/org/javarosa/core/model/instance/ExternalDataInstanceSource.java
+++ b/src/main/java/org/javarosa/core/model/instance/ExternalDataInstanceSource.java
@@ -81,6 +81,17 @@ public class ExternalDataInstanceSource implements InstanceRoot, Externalizable 
 
 
     public static ExternalDataInstanceSource buildVirtual(
+            ExternalDataInstance instance, String storageReferenceId) {
+        return buildVirtual(
+                instance.getInstanceId(),
+                (TreeElement)instance.getRoot(),
+                instance.getReference(),
+                instance.useCaseTemplate(),
+                storageReferenceId
+        );
+    }
+
+    public static ExternalDataInstanceSource buildVirtual(
             String instanceId, @Nullable TreeElement root,
             String reference, boolean useCaseTemplate,
             String storageReferenceId) {

--- a/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
@@ -87,13 +87,28 @@ public class CaseClaimModelTests {
     public void testRemoteRequestSessionManager_getRawQueryParamsWithUserInput() throws Exception {
         testGetRawQueryParamsWithUserInput(
                 ImmutableMap.of("patient_id", "123"),
-                ImmutableList.of("external_id = 123")
+                ImmutableList.of("external_id = 123"),
+                "patient_id"
         );
     }
 
     @Test
     public void testRemoteRequestSessionManager_getRawQueryParamsWithUserInput_missing() throws Exception {
-        testGetRawQueryParamsWithUserInput(Collections.emptyMap(), ImmutableList.of(""));
+        testGetRawQueryParamsWithUserInput(Collections.emptyMap(), ImmutableList.of(""), "patient_id");
+    }
+
+    @Test
+    public void testRemoteRequestSessionManager_getRawQueryParamsWithUserInput_legacy() throws Exception {
+        testGetRawQueryParamsWithUserInput(
+                ImmutableMap.of("patient_id", "123"),
+                ImmutableList.of("external_id = 123"),
+                "patient_id_legacy"
+        );
+    }
+
+    @Test
+    public void testRemoteRequestSessionManager_getRawQueryParamsWithUserInput_missing_legacy() throws Exception {
+        testGetRawQueryParamsWithUserInput(Collections.emptyMap(), ImmutableList.of(""), "patient_id_legacy");
     }
 
     @Test
@@ -103,7 +118,7 @@ public class CaseClaimModelTests {
         );
     }
 
-    private void testGetRawQueryParamsWithUserInput(Map<String, String> userInput, List<String> expected)
+    private void testGetRawQueryParamsWithUserInput(Map<String, String> userInput, List<String> expected, String key)
             throws Exception {
         MockApp mApp = new MockApp("/case_claim_example/");
 
@@ -117,7 +132,7 @@ public class CaseClaimModelTests {
 
         Multimap<String, String> params = remoteQuerySessionManager.getRawQueryParams(true);
 
-        Assert.assertEquals(expected, params.get("_xpath_query"));
+        Assert.assertEquals(expected, params.get(key));
     }
 
     private void testGetRawQueryParamsWithUserInputExcluded(Map<String, String> userInput)

--- a/src/test/java/org/commcare/backend/suite/model/test/QueryModelTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/QueryModelTests.java
@@ -1,5 +1,6 @@
 package org.commcare.backend.suite.model.test;
 
+import org.commcare.core.interfaces.MemoryVirtualDataInstanceStorage;
 import org.commcare.modern.session.SessionWrapper;
 import org.commcare.suite.model.RemoteQueryDatum;
 import org.commcare.suite.model.SessionDatum;
@@ -28,7 +29,9 @@ public class QueryModelTests {
         Assert.assertEquals("registry1", datum.getDataId());
 
         // construct the screen
-        QueryScreen screen = new QueryScreen("username", "password", System.out);
+        QueryScreen screen = new QueryScreen(
+                "username", "password",
+                System.out, new MemoryVirtualDataInstanceStorage());
         screen.init(session);
 
         // mock the query response

--- a/src/test/java/org/commcare/backend/suite/model/test/QueryModelTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/QueryModelTests.java
@@ -1,27 +1,75 @@
 package org.commcare.backend.suite.model.test;
 
+import com.google.common.collect.ImmutableMap;
+
+import org.commcare.core.encryption.CryptUtil;
 import org.commcare.core.interfaces.MemoryVirtualDataInstanceStorage;
+import org.commcare.data.xml.VirtualInstances;
 import org.commcare.modern.session.SessionWrapper;
 import org.commcare.suite.model.RemoteQueryDatum;
 import org.commcare.suite.model.SessionDatum;
 import org.commcare.test.utilities.MockApp;
 import org.commcare.util.mocks.MockQueryClient;
+import org.commcare.util.screen.CommCareSessionException;
 import org.commcare.util.screen.QueryScreen;
+import org.javarosa.core.model.instance.ExternalDataInstance;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.InputStream;
+import java.util.Map;
 
 /**
  * Basic test for remote query as part of form entry session
  */
 public class QueryModelTests {
 
+    MemoryVirtualDataInstanceStorage virtualDataInstanceStorage = new MemoryVirtualDataInstanceStorage();
+
+    @Before
+    public void setUp() {
+        virtualDataInstanceStorage.clear();
+    }
+
     @Test
     public void testQueryEntryDatum() throws Exception {
         MockApp mApp = new MockApp("/case_claim_example/");
-
         SessionWrapper session = mApp.getSession();
+        QueryScreen screen = setupQueryScreen(session);
+
+        // perform the query
+        boolean success = screen.handleInputAndUpdateSession(session, "bob,23", false, null);
+        Assert.assertTrue(success);
+
+        // check that session datum requirement is satisfied
+        Assert.assertNull(session.getNeededDatum());
+    }
+
+    @Test
+    public void testScreenCreatesVirtualInstance() throws Exception {
+        MockApp mApp = new MockApp("/case_claim_example/");
+        SessionWrapper session = mApp.getSession();
+        QueryScreen screen = setupQueryScreen(session);
+
+        String expectedInstanceStorageKey = CryptUtil.sha256("name=bob|age=23|");
+        Assert.assertFalse(virtualDataInstanceStorage.contains(expectedInstanceStorageKey));
+
+        // perform the query
+        boolean success = screen.handleInputAndUpdateSession(session, "bob,23", false, null);
+        Assert.assertTrue(success);
+
+        // check that saved instance matches expect what we expect
+        Assert.assertTrue(virtualDataInstanceStorage.contains(expectedInstanceStorageKey));
+        Map<String, String> input = ImmutableMap.of("name", "bob", "age", "23");
+        Assert.assertEquals(
+                VirtualInstances.buildSearchInputInstance(input).getRoot(),
+                virtualDataInstanceStorage.read(expectedInstanceStorageKey).getRoot());
+    }
+
+    @NotNull
+    private QueryScreen setupQueryScreen(SessionWrapper session) throws CommCareSessionException {
         session.setCommand("m0-f0");
 
         SessionDatum datum = session.getNeededDatum();
@@ -29,20 +77,16 @@ public class QueryModelTests {
         Assert.assertEquals("registry1", datum.getDataId());
 
         // construct the screen
+
         QueryScreen screen = new QueryScreen(
                 "username", "password",
-                System.out, new MemoryVirtualDataInstanceStorage());
+                System.out, virtualDataInstanceStorage);
         screen.init(session);
+
 
         // mock the query response
         InputStream response = this.getClass().getResourceAsStream("/case_claim_example/query_response.xml");
         screen.setClient(new MockQueryClient(response));
-
-        // perform the query
-        boolean success = screen.handleInputAndUpdateSession(session, "", false, null);
-        Assert.assertTrue(success);
-
-        // check that session datum requirement is satisfied
-        assert session.getNeededDatum() == null;
+        return screen;
     }
 }

--- a/src/test/java/org/commcare/backend/suite/model/test/QueryModelTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/QueryModelTests.java
@@ -53,7 +53,8 @@ public class QueryModelTests {
         SessionWrapper session = mApp.getSession();
         QueryScreen screen = setupQueryScreen(session);
 
-        String expectedInstanceStorageKey = CryptUtil.sha256("name=bob|age=23|");
+        String instanceID = "search-input:registry1";
+        String expectedInstanceStorageKey = CryptUtil.sha256(instanceID + "/name=bob|age=23|");
         Assert.assertFalse(virtualDataInstanceStorage.contains(expectedInstanceStorageKey));
 
         // perform the query
@@ -64,7 +65,7 @@ public class QueryModelTests {
         Assert.assertTrue(virtualDataInstanceStorage.contains(expectedInstanceStorageKey));
         Map<String, String> input = ImmutableMap.of("name", "bob", "age", "23");
         Assert.assertEquals(
-                VirtualInstances.buildSearchInputInstance(input).getRoot(),
+                VirtualInstances.buildSearchInputInstance(instanceID, input).getRoot(),
                 virtualDataInstanceStorage.read(expectedInstanceStorageKey).getRoot());
     }
 

--- a/src/test/java/org/commcare/backend/suite/model/test/QueryModelTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/QueryModelTests.java
@@ -8,6 +8,7 @@ import org.commcare.data.xml.VirtualInstances;
 import org.commcare.modern.session.SessionWrapper;
 import org.commcare.suite.model.RemoteQueryDatum;
 import org.commcare.suite.model.SessionDatum;
+import org.commcare.test.utilities.CaseTestUtils;
 import org.commcare.test.utilities.MockApp;
 import org.commcare.util.mocks.MockQueryClient;
 import org.commcare.util.screen.CommCareSessionException;
@@ -67,6 +68,11 @@ public class QueryModelTests {
         Assert.assertEquals(
                 VirtualInstances.buildSearchInputInstance(instanceID, input).getRoot(),
                 virtualDataInstanceStorage.read(expectedInstanceStorageKey).getRoot());
+
+        CaseTestUtils.xpathEvalAndAssert(
+                session.getEvaluationContext(),
+                "instance('search-input:registry1')/input/field[@name='age']",
+                "23");
     }
 
     @NotNull

--- a/src/test/java/org/commcare/backend/suite/model/test/StackFrameStepTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/StackFrameStepTests.java
@@ -2,6 +2,7 @@ package org.commcare.backend.suite.model.test;
 
 import com.google.common.collect.ImmutableMultimap;
 
+import org.commcare.core.interfaces.MemoryVirtualDataInstanceStorage;
 import org.commcare.modern.session.SessionWrapper;
 import org.commcare.session.SessionFrame;
 import org.commcare.suite.model.Action;
@@ -157,7 +158,9 @@ public class StackFrameStepTests {
 
         assertEquals(SessionFrame.STATE_QUERY_REQUEST, session.getNeededData());
         // construct the screen
-        QueryScreen screen = new QueryScreen("username", "password", System.out);
+        QueryScreen screen = new QueryScreen(
+                "username", "password",
+                System.out, new MemoryVirtualDataInstanceStorage());
         screen.init(session);
 
         // mock the query response

--- a/src/test/java/org/commcare/data/xml/VirtualInstancesTest.java
+++ b/src/test/java/org/commcare/data/xml/VirtualInstancesTest.java
@@ -20,7 +20,8 @@ public class VirtualInstancesTest {
     public void testBuildSearchInputRoot()
             throws UnfullfilledRequirementsException, XmlPullParserException,
             InvalidStructureException, IOException {
-        ExternalDataInstance instance = VirtualInstances.buildSearchInputInstance(ImmutableMap.of(
+        String instanceID = "search-input";
+        ExternalDataInstance instance = VirtualInstances.buildSearchInputInstance(instanceID, ImmutableMap.of(
                 "key0", "val0",
                 "key1", "val1",
                 "key2", "val2"
@@ -35,7 +36,7 @@ public class VirtualInstancesTest {
         );
         TreeElement expected = ExternalDataInstance.parseExternalTree(
                 new ByteArrayInputStream(expectedXml.getBytes(StandardCharsets.UTF_8)),
-                VirtualInstances.SEARCH_INSTANCE_ID
+                instanceID
         );
         assertEquals(expected, instance.getRoot());
     }

--- a/src/test/resources/case_claim_example/app_strings.txt
+++ b/src/test/resources/case_claim_example/app_strings.txt
@@ -1,0 +1,2 @@
+query.name=name
+query.age=age

--- a/src/test/resources/case_claim_example/suite.xml
+++ b/src/test/resources/case_claim_example/suite.xml
@@ -62,7 +62,8 @@
     <session>
       <query url="https://www.fake.com/patient_search/" storage-instance="patients">
         <data key="device_id" ref="instance('session')/session/context/deviceid"/>
-        <data key="_xpath_query" ref="if(count(instance('search-input:patients')/input/field[@name='patient_id']) > 0, concat('external_id = ', instance('search-input:patients')/input/field[@name='patient_id']), '')"/>
+        <data key="patient_id" ref="if(count(instance('search-input:patients')/input/field[@name='patient_id']) > 0, concat('external_id = ', instance('search-input:patients')/input/field[@name='patient_id']), '')"/>
+        <data key="patient_id_legacy" ref="if(count(instance('search-input')/input/field[@name='patient_id']) > 0, concat('external_id = ', instance('search-input')/input/field[@name='patient_id']), '')"/>
         <prompt key="name" default="instance('session')/session/context/deviceid">
           <display>
             <text>

--- a/src/test/resources/case_claim_example/suite.xml
+++ b/src/test/resources/case_claim_example/suite.xml
@@ -62,7 +62,7 @@
     <session>
       <query url="https://www.fake.com/patient_search/" storage-instance="patients">
         <data key="device_id" ref="instance('session')/session/context/deviceid"/>
-        <data key="_xpath_query" ref="if(count(instance('search-input')/input/field[@name='patient_id']) > 0, concat('external_id = ', instance('search-input')/input/field[@name='patient_id']), '')"/>
+        <data key="_xpath_query" ref="if(count(instance('search-input:patients')/input/field[@name='patient_id']) > 0, concat('external_id = ', instance('search-input:patients')/input/field[@name='patient_id']), '')"/>
         <prompt key="name" default="instance('session')/session/context/deviceid">
           <display>
             <text>

--- a/src/test/resources/case_claim_example/suite.xml
+++ b/src/test/resources/case_claim_example/suite.xml
@@ -5,6 +5,11 @@
       <location authority="local">./form_placeholder.xml</location>
     </resource>
   </xform>
+  <locale language="default">
+    <resource id="default" version="1399" descriptor="Default">
+      <location authority="local">./app_strings.txt</location>
+    </resource>
+  </locale>
 
   <detail id="m0_case_short">
     <title>
@@ -127,6 +132,20 @@
     <session>
       <query url="http://www.example.com/a/domain/phone/get_case/" storage-instance="registry1" template="case" default_search="true">
         <data key="case_type" ref="'case'"/>
+        <prompt key="name">
+          <display>
+            <text>
+              <locale id="query.name"/>
+            </text>
+          </display>
+        </prompt>
+        <prompt key="age">
+          <display>
+            <text>
+              <locale id="query.age"/>
+            </text>
+          </display>
+        </prompt>
       </query>
     </session>
   </entry>


### PR DESCRIPTION
Part 2 of https://docs.google.com/document/d/1Mmx1FrYZrcEmWidqSkNjC_gWSJ6xzRFKoP3Rn_xSaj4/edit#

This builds off the virtual instance storage in https://github.com/dimagi/commcare-core/pull/1082 and adds support for:

1. storing multiple instances per stack frame step
2. saving the query prompt values as an instance and making that available via the session

Cross request: https://github.com/dimagi/formplayer/pull/1141