### PR TITLE
Only create new storage if needed (formplayer)

### DIFF
--- a/src/main/java/org/javarosa/core/services/storage/IStorageUtilityIndexed.java
+++ b/src/main/java/org/javarosa/core/services/storage/IStorageUtilityIndexed.java
@@ -267,4 +267,9 @@ public interface IStorageUtilityIndexed<E extends Externalizable> {
      * required for the fields to be retrieved from storage again.
      */
     void bulkReadMetadata(LinkedHashSet<Integer> recordIds, String[] metaFieldNames, HashMap<Integer, String[]> metadataMap);
+
+    /**
+     * Provide public accessor to the inner class that is stored
+     */
+    Class<?> getPrototype();
 }

--- a/src/main/java/org/javarosa/core/services/storage/StorageManager.java
+++ b/src/main/java/org/javarosa/core/services/storage/StorageManager.java
@@ -46,7 +46,7 @@ public class StorageManager {
             throw new RuntimeException("No storage factory has been set; I don't know what kind of storage utility to create. Either set a storage factory, or register your StorageUtilitys directly.");
         }
         if (storageRegistry.containsKey(key)) {
-            if (storageRegistry.get(key).getClass() == type) {
+            if (storageRegistry.get(key).getPrototype() == type) {
                 return;
             } else {
                 throw new RuntimeException("Attempting to change storage type for key " + key + " from type " + storageRegistry.get(key).getClass() + " to type " + type + ".");

--- a/src/main/java/org/javarosa/core/services/storage/StorageManager.java
+++ b/src/main/java/org/javarosa/core/services/storage/StorageManager.java
@@ -49,7 +49,11 @@ public class StorageManager {
             if (storageRegistry.get(key).getPrototype() == type) {
                 return;
             } else {
-                throw new RuntimeException("Attempting to change storage type for key " + key + " from type " + storageRegistry.get(key).getClass() + " to type " + type + ".");
+                throw new RuntimeException(
+                        String.format("Attempting to change storage type for key %s from type %s to type %s.",
+                                key, storageRegistry.get(key).getPrototype().getName(), type.getName()
+                        )
+                );
             }
         } 
 

--- a/src/main/java/org/javarosa/core/services/storage/StorageManager.java
+++ b/src/main/java/org/javarosa/core/services/storage/StorageManager.java
@@ -45,6 +45,13 @@ public class StorageManager {
         if (storageFactory == null) {
             throw new RuntimeException("No storage factory has been set; I don't know what kind of storage utility to create. Either set a storage factory, or register your StorageUtilitys directly.");
         }
+        if (storageRegistry.containsKey(key)) {
+            if (storageRegistry.get(key).getClass() == type) {
+                return;
+            } else {
+                Logger.log("Warning", "Overwriting storage type " + storageRegistry.get(key).getClass() + " with type " + type + " for key " + key + ".");
+            }
+        } 
 
         storageRegistry.put(key, storageFactory.newStorage(key, type));
     }

--- a/src/main/java/org/javarosa/core/services/storage/StorageManager.java
+++ b/src/main/java/org/javarosa/core/services/storage/StorageManager.java
@@ -49,7 +49,7 @@ public class StorageManager {
             if (storageRegistry.get(key).getClass() == type) {
                 return;
             } else {
-                Logger.log("Warning", "Overwriting storage type " + storageRegistry.get(key).getClass() + " with type " + type + " for key " + key + ".");
+                throw new RuntimeException("Attempting to change storage type for key " + key + " from type " + storageRegistry.get(key).getClass() + " to type " + type + ".");
             }
         } 
 

--- a/src/main/java/org/javarosa/core/services/storage/util/DummyIndexedStorageUtility.java
+++ b/src/main/java/org/javarosa/core/services/storage/util/DummyIndexedStorageUtility.java
@@ -366,4 +366,9 @@ public class DummyIndexedStorageUtility<T extends Persistable> implements IStora
             metadataMap.put(i, getMetaDataForRecord(i, metaDataIds));
         }
     }
+
+    @Override
+    public Class<?> getPrototype() {
+        return prototype;
+    }
 }


### PR DESCRIPTION
Probably a better way to go about doing this, but these are the same commits found in https://github.com/dimagi/commcare-core/pull/1111. It seems that the formplayer and master branches have diverged so creating 2 PRs with the same content is the only way to push changes to both.