### PR TITLE
add json property func

### DIFF
--- a/src/main/java/org/javarosa/xpath/expr/FunctionUtils.java
+++ b/src/main/java/org/javarosa/xpath/expr/FunctionUtils.java
@@ -89,6 +89,7 @@ public class FunctionUtils {
         funcList.put(XPathIndexOfFunc.NAME, XPathIndexOfFunc.class);
         funcList.put(XPathEncryptStringFunc.NAME, XPathEncryptStringFunc.class);
         funcList.put(XPathDecryptStringFunc.NAME, XPathDecryptStringFunc.class);
+        funcList.put(XPathJsonPropertyFunc.NAME, XPathJsonPropertyFunc.class);
     }
 
     private static final CacheTable<String, Double> mDoubleParseCache = new CacheTable<>();

--- a/src/main/java/org/javarosa/xpath/expr/XPathJsonPropertyFunc.java
+++ b/src/main/java/org/javarosa/xpath/expr/XPathJsonPropertyFunc.java
@@ -1,0 +1,48 @@
+package org.javarosa.xpath.expr;
+
+import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.model.instance.DataInstance;
+import org.javarosa.xpath.parser.XPathSyntaxException;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/** Utility for hidden values as geocoder receivers
+ *
+ * @author rcostello
+ * @return A String value for the property name passed in if that property exists else a blank String
+ */
+
+public class XPathJsonPropertyFunc extends XPathFuncExpr {
+    public static final String NAME = "json-property";
+    private static final int EXPECTED_ARG_COUNT = 2;
+
+    public XPathJsonPropertyFunc() {
+        name = NAME;
+        expectedArgCount = EXPECTED_ARG_COUNT;
+    }
+
+    public XPathJsonPropertyFunc(XPathExpression[] args) throws XPathSyntaxException {
+        super(NAME, args, EXPECTED_ARG_COUNT, true);
+    }
+
+    @Override
+    public Object evalBody(DataInstance model, EvaluationContext evalContext, Object[] evaluatedArgs) {
+        return getJsonProperty(FunctionUtils.toString(evaluatedArgs[0]), FunctionUtils.toString(evaluatedArgs[1]));
+    }
+
+    /**
+     * Returns the value of the property name passed in from the stringified json object passed in.
+     * Returns a blank string if the property does not exist on the stringified json object.
+     */
+    public static String getJsonProperty(String stringifiedJsonObject, String propertyName) throws JSONException {
+        String value = "";
+        try {
+            JSONObject parsedObject = new JSONObject(stringifiedJsonObject);
+            value = parsedObject.getString(propertyName);
+        } catch (JSONException e) {
+            return value;
+        }
+
+        return value;
+    }
+}

--- a/src/test/java/org/javarosa/xpath/expr/test/XPathJsonPropertyFuncTest.java
+++ b/src/test/java/org/javarosa/xpath/expr/test/XPathJsonPropertyFuncTest.java
@@ -1,0 +1,37 @@
+package org.javarosa.xpath.expr.test;
+
+import org.javarosa.xpath.expr.XPathJsonPropertyFunc;
+import org.json.JSONException;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**Tests for the XPathJsonProperty
+ *
+ * @author rcostello
+ */
+
+public class XPathJsonPropertyFuncTest {
+
+    @Test
+    public void getJsonProperty() {
+        String testObj1 = "{\"name\":\"Sam\"}";
+        String testVal1 = XPathJsonPropertyFunc.getJsonProperty(testObj1, "name");
+        String testVal2 = XPathJsonPropertyFunc.getJsonProperty(testObj1, "city");
+        Assert.assertEquals(testVal1, "Sam");
+        Assert.assertEquals(testVal2, "");
+
+        String testObj2 = "{city: New York}";
+        String testVal3 = XPathJsonPropertyFunc.getJsonProperty(testObj2, "city");
+        String testVal4 = XPathJsonPropertyFunc.getJsonProperty(testObj2, "state");
+        Assert.assertEquals(testVal3, "New York");
+        Assert.assertEquals(testVal4, "");
+
+        String testInvalidObj = "{\"name\"}: \"Sam\"}";
+        String testVal5 = XPathJsonPropertyFunc.getJsonProperty(testInvalidObj, "name");  
+        Assert.assertEquals(testVal5, "");
+        
+        String testEmptyStrObj = "";
+        String testVal6 = XPathJsonPropertyFunc.getJsonProperty(testEmptyStrObj, "name");  
+        Assert.assertEquals(testVal6, "");
+    }
+}


### PR DESCRIPTION
Same changes as https://github.com/dimagi/commcare-core/pull/1122 but for master
Adds a function to get a property from a stringified json object. To be used to support hidden values as geocoder receivers.
spec: https://docs.google.com/document/d/1v2AziWCpVI8MO8FTmEapUYwoN9rmYTQbjt-MlEWJcdU/edit#
ticket: https://dimagi-dev.atlassian.net/browse/USH-2137