### PR TITLE
copy context instead of using fresh context

### DIFF
--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -1451,7 +1451,7 @@ public class FormDef implements IFormElement, IMetaData,
             DataInstance instance = formInstances.get(instanceId);
             formInstances.put(instanceId, instance.initialize(factory, instanceId));
         }
-        setEvaluationContext(new EvaluationContext(null));
+        setEvaluationContext(this.exprEvalContext);
 
         initLocale(locale);
 


### PR DESCRIPTION
Fixes a bug introduced here: https://github.com/dimagi/commcare-core/pull/1130/commits/d13935719dd4fb8bf3a549f349c0e553874570b2

Technically this could be left as is but then the order of initialization in formplayer would need to change: https://github.com/dimagi/formplayer/blob/38274a5c85da3c6cef36cdd81768402bdb030e7f/src/main/java/org/commcare/formplayer/session/FormSession.java#L125-L130