### PR TITLE
fix loading of legacy search-input instances

### DIFF
--- a/src/main/java/org/commcare/core/process/CommCareInstanceInitializer.java
+++ b/src/main/java/org/commcare/core/process/CommCareInstanceInitializer.java
@@ -119,14 +119,14 @@ public class CommCareInstanceInitializer extends InstanceInitializationFactory {
             if (isNonUniqueReference(reference)) {
                 String referenceWithId = reference.concat("/").concat(instance.getInstanceId());
                 instanceRoot = getExternalDataInstanceSource(referenceWithId, stepType);
-            }
 
-            // last attempt to find the instance
-            // this is necessary for 'sesarch-input' instances which do not follow the convention
-            // of instance ref = base + instance Id:
-            //    <instance id="search-input:results" ref="jr://instance/search-input/results />
-            if (instanceRoot == null) {
-                instanceRoot = getExternalDataInstanceSourceById(instance.getInstanceId(), stepType);
+                // last attempt to find the instance
+                // this is necessary for 'sesarch-input' instances which do not follow the convention
+                // of instance ref = base + instance Id:
+                //    <instance id="search-input:results" ref="jr://instance/search-input/results />
+                if (instanceRoot == null) {
+                    instanceRoot = getExternalDataInstanceSourceById(instance.getInstanceId(), stepType);
+                }
             }
         }
 

--- a/src/main/java/org/commcare/core/process/CommCareInstanceInitializer.java
+++ b/src/main/java/org/commcare/core/process/CommCareInstanceInitializer.java
@@ -17,6 +17,7 @@ import org.commcare.util.CommCarePlatform;
 import org.javarosa.core.model.User;
 import org.javarosa.core.model.instance.ConcreteInstanceRoot;
 import org.javarosa.core.model.instance.ExternalDataInstance;
+import org.javarosa.core.model.instance.ExternalDataInstanceSource;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.InstanceInitializationFactory;
 import org.javarosa.core.model.instance.InstanceRoot;
@@ -119,7 +120,16 @@ public class CommCareInstanceInitializer extends InstanceInitializationFactory {
                 String referenceWithId = reference.concat("/").concat(instance.getInstanceId());
                 instanceRoot = getExternalDataInstanceSource(referenceWithId, stepType);
             }
+
+            // last attempt to find the instance
+            // this is necessary for 'sesarch-input' instances which do not follow the convention
+            // of instance ref = base + instance Id:
+            //    <instance id="search-input:results" ref="jr://instance/search-input/results />
+            if (instanceRoot == null) {
+                instanceRoot = getExternalDataInstanceSourceById(instance.getInstanceId(), stepType);
+            }
         }
+
 
         if (instanceRoot == null) {
             instanceRoot = instance.getSource();
@@ -222,6 +232,21 @@ public class CommCareInstanceInitializer extends InstanceInitializationFactory {
         for (StackFrameStep step : session.getFrame().getSteps()) {
             if (step.getType().equals(stepType) && step.hasDataInstanceSource(reference)) {
                 return step.getDataInstanceSource(reference);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Required for legacy instance support
+     */
+    protected InstanceRoot getExternalDataInstanceSourceById(String instanceId, String stepType) {
+        for (StackFrameStep step : session.getFrame().getSteps()) {
+            if (step.getType().equals(stepType)) {
+                ExternalDataInstanceSource source = step.getDataInstanceSourceById(instanceId);
+                if (source != null) {
+                    return source;
+                }
             }
         }
         return null;

--- a/src/main/java/org/commcare/suite/model/StackFrameStep.java
+++ b/src/main/java/org/commcare/suite/model/StackFrameStep.java
@@ -127,6 +127,15 @@ public class StackFrameStep implements Externalizable {
         return dataInstanceSources.get(reference);
     }
 
+    public ExternalDataInstanceSource getDataInstanceSourceById(String instanceId) {
+        for (ExternalDataInstanceSource source : dataInstanceSources.values()) {
+            if (source.getInstanceId().equals(instanceId)) {
+                return source;
+            }
+        }
+        return null;
+    }
+
     public void initDataInstanceSources(RemoteInstanceFetcher remoteInstanceFetcher)
             throws RemoteInstanceFetcher.RemoteInstanceException {
         for (ExternalDataInstanceSource source : dataInstanceSources.values()) {

--- a/src/test/java/org/commcare/backend/suite/model/test/QueryModelTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/QueryModelTests.java
@@ -76,11 +76,15 @@ public class QueryModelTests {
                 "instance('search-input:registry1')/input/field[@name='age']",
                 "23");
 
+        // test loading instance with new ref
+        ExternalDataInstance instance = new ExternalDataInstance("jr://instance/search-input/registry1",
+                "custom-id");
+        Assert.assertNotNull(session.getIIF().generateRoot(instance).getRoot());
+
         // test that we can still load instances using the legacy ref
         ExternalDataInstance legacyInstance = new ExternalDataInstance("jr://instance/search-input",
                 "search-input:registry1");
-        InstanceRoot root = session.getIIF().generateRoot(legacyInstance);
-        Assert.assertNotNull(root.getRoot());
+        Assert.assertNotNull(session.getIIF().generateRoot(legacyInstance).getRoot());
     }
 
     @NotNull

--- a/src/test/java/org/commcare/backend/suite/model/test/QueryModelTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/QueryModelTests.java
@@ -14,6 +14,7 @@ import org.commcare.test.utilities.MockApp;
 import org.commcare.util.screen.CommCareSessionException;
 import org.commcare.util.screen.QueryScreen;
 import org.javarosa.core.model.instance.ExternalDataInstance;
+import org.javarosa.core.model.instance.InstanceRoot;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.Before;
@@ -74,6 +75,12 @@ public class QueryModelTests {
                 session.getEvaluationContext(),
                 "instance('search-input:registry1')/input/field[@name='age']",
                 "23");
+
+        // test that we can still load instances using the legacy ref
+        ExternalDataInstance legacyInstance = new ExternalDataInstance("jr://instance/search-input",
+                "search-input:registry1");
+        InstanceRoot root = session.getIIF().generateRoot(legacyInstance);
+        Assert.assertNotNull(root.getRoot());
     }
 
     @NotNull


### PR DESCRIPTION
The search-input instance ref is not `base/[instanceId]` so it requires special handling.