### PR TITLE
Case search validation Conditions

### DIFF
--- a/src/cli/java/org/commcare/util/screen/QueryScreen.java
+++ b/src/cli/java/org/commcare/util/screen/QueryScreen.java
@@ -216,6 +216,13 @@ public class QueryScreen extends Screen {
             }
             remoteQuerySessionManager.answerUserPrompt(key, answer);
         }
+        refresh();
+    }
+
+    // Recalculates screen properties that are dependent on user input
+    public void refresh() {
+        refreshItemSetChoices();
+        remoteQuerySessionManager.validateUserAnswers();
     }
 
     public void refreshItemSetChoices() {
@@ -278,7 +285,6 @@ public class QueryScreen extends Screen {
         return instanceOrError.first != null;
     }
 
-
     public OrderedHashtable<String, QueryPrompt> getUserInputDisplays() {
         return userInputDisplays;
     }
@@ -289,6 +295,10 @@ public class QueryScreen extends Screen {
 
     public Hashtable<String, String> getCurrentAnswers() {
         return remoteQuerySessionManager.getUserAnswers();
+    }
+
+    public Hashtable<String, String> getErrors() {
+        return remoteQuerySessionManager.getErrors();
     }
 
     public boolean doDefaultSearch() {

--- a/src/cli/java/org/commcare/util/screen/QueryScreen.java
+++ b/src/cli/java/org/commcare/util/screen/QueryScreen.java
@@ -216,13 +216,7 @@ public class QueryScreen extends Screen {
             }
             remoteQuerySessionManager.answerUserPrompt(key, answer);
         }
-        refresh();
-    }
-
-    // Recalculates screen properties that are dependent on user input
-    public void refresh() {
-        refreshItemSetChoices();
-        remoteQuerySessionManager.validateUserAnswers();
+        remoteQuerySessionManager.refresh();
     }
 
     public void refreshItemSetChoices() {

--- a/src/cli/java/org/commcare/util/screen/QueryScreen.java
+++ b/src/cli/java/org/commcare/util/screen/QueryScreen.java
@@ -216,7 +216,7 @@ public class QueryScreen extends Screen {
             }
             remoteQuerySessionManager.answerUserPrompt(key, answer);
         }
-        remoteQuerySessionManager.refresh();
+        remoteQuerySessionManager.refreshInputDependentState();
     }
 
     public void refreshItemSetChoices() {

--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -8,7 +8,6 @@ import org.commcare.cases.util.StringUtils;
 import org.commcare.data.xml.VirtualInstances;
 import org.commcare.suite.model.QueryData;
 import org.commcare.suite.model.QueryPrompt;
-import org.commcare.suite.model.QueryPromptValidation;
 import org.commcare.suite.model.RemoteQueryDatum;
 import org.commcare.suite.model.SessionDatum;
 import org.javarosa.core.model.ItemsetBinding;
@@ -252,8 +251,9 @@ public class RemoteQuerySessionManager {
         for (Enumeration en = userInputDisplays.keys(); en.hasMoreElements(); ) {
             String key = (String)en.nextElement();
             QueryPrompt queryPrompt = userInputDisplays.get(key);
+            String value = userAnswers.get(key);
             TreeReference currentRef = getReferenceToInstanceNode(instanceId, key);
-            if (queryPrompt.isInvalidInput(new EvaluationContext(ec, currentRef))) {
+            if (value != null && queryPrompt.isInvalidInput(new EvaluationContext(ec, currentRef))) {
                 errors.put(key, queryPrompt.getValidationMessage(ec));
             }
         }

--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -254,9 +254,8 @@ public class RemoteQuerySessionManager {
             QueryPrompt queryPrompt = userInputDisplays.get(key);
             QueryPromptValidation validation = queryPrompt.getValidation();
             TreeReference currentRef = getReferenceToInstanceNode(instanceId, key);
-            if (validation != null && !((Boolean)validation.getTest().eval(
-                    new EvaluationContext(ec, currentRef)))) {
-                errors.put(key, validation.getMessage().evaluate(ec));
+            if (queryPrompt.isInvalidInput(new EvaluationContext(ec, currentRef))) {
+                errors.put(key, queryPrompt.getValidationMessage(ec));
             }
         }
     }

--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -231,8 +231,13 @@ public class RemoteQuerySessionManager {
         }
     }
 
+    // Recalculates screen properties that are dependent on user input
+    public void refresh() {
+        refreshItemSetChoices();
+        validateUserAnswers();
+    }
 
-    public void validateUserAnswers() {
+    private void validateUserAnswers() {
         OrderedHashtable<String, QueryPrompt> userInputDisplays = getNeededUserInputDisplays();
         EvaluationContext ec = getEvaluationContextWithUserInputInstance();
         for (Enumeration en = userInputDisplays.keys(); en.hasMoreElements(); ) {

--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -239,7 +239,7 @@ public class RemoteQuerySessionManager {
     }
 
     // Recalculates screen properties that are dependent on user input
-    public void refresh() {
+    public void refreshInputDependentState() {
         refreshItemSetChoices();
         validateUserAnswers();
     }

--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -140,7 +140,7 @@ public class RemoteQuerySessionManager {
                 QueryPrompt prompt = queryDatum.getUserQueryPrompts().get(key);
                 XPathExpression excludeExpr = prompt.getExclude();
                 if (!(params.containsKey(key) && params.get(key).contains(value))) {
-                    if (value != null && (excludeExpr == null || !(boolean) excludeExpr.eval(evaluationContext))) {
+                    if (value != null && (excludeExpr == null || !(boolean)excludeExpr.eval(evaluationContext))) {
                         params.put(key, userAnswers.get(key));
                     }
                 }
@@ -206,7 +206,8 @@ public class RemoteQuerySessionManager {
         while (dirty) {
             if (index == userInputDisplays.size()) {
                 // loop has already run as many times as no of questions and we are still dirty
-                throw new RuntimeException("Invalid itemset state encountered while trying to refresh itemset choices");
+                throw new RuntimeException(
+                        "Invalid itemset state encountered while trying to refresh itemset choices");
             }
             dirty = false;
             for (Enumeration en = userInputDisplays.keys(); en.hasMoreElements(); ) {
@@ -253,7 +254,8 @@ public class RemoteQuerySessionManager {
             QueryPrompt queryPrompt = userInputDisplays.get(key);
             QueryPromptValidation validation = queryPrompt.getValidation();
             TreeReference currentRef = getReferenceToInstanceNode(instanceId, key);
-            if (validation != null && !((Boolean)validation.getTest().eval(new EvaluationContext(ec, currentRef)))) {
+            if (validation != null && !((Boolean)validation.getTest().eval(
+                    new EvaluationContext(ec, currentRef)))) {
                 errors.put(key, validation.getMessage().evaluate(ec));
             }
         }

--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -252,7 +252,6 @@ public class RemoteQuerySessionManager {
         for (Enumeration en = userInputDisplays.keys(); en.hasMoreElements(); ) {
             String key = (String)en.nextElement();
             QueryPrompt queryPrompt = userInputDisplays.get(key);
-            QueryPromptValidation validation = queryPrompt.getValidation();
             TreeReference currentRef = getReferenceToInstanceNode(instanceId, key);
             if (queryPrompt.isInvalidInput(new EvaluationContext(ec, currentRef))) {
                 errors.put(key, queryPrompt.getValidationMessage(ec));

--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -253,8 +253,8 @@ public class RemoteQuerySessionManager {
             QueryPrompt queryPrompt = userInputDisplays.get(key);
             QueryPromptValidation validation = queryPrompt.getValidation();
             TreeReference currentRef = getReferenceToInstanceNode(instanceId, key);
-            if (validation != null && !((Boolean)validation.getXpath().eval(new EvaluationContext(ec, currentRef)))) {
-                errors.put(key, validation.getMessage());
+            if (validation != null && !((Boolean)validation.getTest().eval(new EvaluationContext(ec, currentRef)))) {
+                errors.put(key, validation.getMessage().evaluate(ec));
             }
         }
     }

--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -8,6 +8,7 @@ import org.commcare.cases.util.StringUtils;
 import org.commcare.data.xml.VirtualInstances;
 import org.commcare.suite.model.QueryData;
 import org.commcare.suite.model.QueryPrompt;
+import org.commcare.suite.model.QueryPromptValidation;
 import org.commcare.suite.model.RemoteQueryDatum;
 import org.commcare.suite.model.SessionDatum;
 import org.javarosa.core.model.ItemsetBinding;
@@ -41,8 +42,8 @@ public class RemoteQuerySessionManager {
 
     private final RemoteQueryDatum queryDatum;
     private final EvaluationContext evaluationContext;
-    private final Hashtable<String, String> userAnswers =
-            new Hashtable<>();
+    private final Hashtable<String, String> userAnswers = new Hashtable<>();
+    private final Hashtable<String, String> errors = new Hashtable<>();
     private final List<String> supportedPrompts;
 
     private RemoteQuerySessionManager(RemoteQueryDatum queryDatum,
@@ -223,6 +224,20 @@ public class RemoteQuerySessionManager {
                 }
             }
             index++;
+        }
+    }
+
+
+    public void validateUserAnswers() {
+        OrderedHashtable<String, QueryPrompt> userInputDisplays = getNeededUserInputDisplays();
+        EvaluationContext ec = getEvaluationContextWithUserInputInstance();
+        for (Enumeration en = userInputDisplays.keys(); en.hasMoreElements(); ) {
+            String key = (String)en.nextElement();
+            QueryPrompt queryPrompt = userInputDisplays.get(key);
+            QueryPromptValidation validation = queryPrompt.getValidation();
+            if (validation != null && !((Boolean)validation.getXpath().eval(ec))) {
+                errors.put(key, validation.getMessage());
+            }
         }
     }
 

--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -45,7 +45,7 @@ public class RemoteQuerySessionManager {
     private final RemoteQueryDatum queryDatum;
     private final EvaluationContext evaluationContext;
     private final Hashtable<String, String> userAnswers = new Hashtable<>();
-    private final Hashtable<String, String> errors = new Hashtable<>();
+    private Hashtable<String, String> errors = new Hashtable<>();
     private final List<String> supportedPrompts;
 
     private RemoteQuerySessionManager(RemoteQueryDatum queryDatum,
@@ -244,6 +244,7 @@ public class RemoteQuerySessionManager {
     }
 
     private void validateUserAnswers() {
+        errors = new Hashtable<>();
         OrderedHashtable<String, QueryPrompt> userInputDisplays = getNeededUserInputDisplays();
         String instanceId = VirtualInstances.makeSearchInputInstanceID(getSearchInstanceReferenceId());
         EvaluationContext ec = getEvaluationContextWithUserInputInstance();

--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -94,6 +94,10 @@ public class RemoteQuerySessionManager {
         return userAnswers;
     }
 
+    public Hashtable<String, String> getErrors() {
+        return errors;
+    }
+
     public void clearAnswers() {
         userAnswers.clear();
     }

--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -253,7 +253,7 @@ public class RemoteQuerySessionManager {
             QueryPrompt queryPrompt = userInputDisplays.get(key);
             String value = userAnswers.get(key);
             TreeReference currentRef = getReferenceToInstanceNode(instanceId, key);
-            if (value != null && queryPrompt.isInvalidInput(new EvaluationContext(ec, currentRef))) {
+            if (!StringUtils.isEmpty(value) && queryPrompt.isInvalidInput(new EvaluationContext(ec, currentRef))) {
                 errors.put(key, queryPrompt.getValidationMessage(ec));
             }
         }

--- a/src/main/java/org/commcare/suite/model/QueryPrompt.java
+++ b/src/main/java/org/commcare/suite/model/QueryPrompt.java
@@ -1,6 +1,7 @@
 package org.commcare.suite.model;
 
 import org.javarosa.core.model.ItemsetBinding;
+import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.ExtWrapNullable;
@@ -174,4 +175,24 @@ public class QueryPrompt implements Externalizable {
         return getItemsetBinding() != null;
     }
 
+    /**
+     * Evalualtes validation message against given eval context
+     * @param ec eval context to evaluate the validation message
+     * @return evaluated validation message or empty string if no validation message defined
+     */
+    public String getValidationMessage(EvaluationContext ec) {
+        if (validation != null && validation.getMessage() != null) {
+            return validation.getMessage().evaluate(ec);
+        }
+        return "";
+    }
+
+    /**
+     * Evaluates the validation condition for the prompts
+     * @param ec eval context to evaluate the validation condition
+     * @return whether the input is invalid
+     */
+    public boolean isInvalidInput(EvaluationContext ec) {
+        return validation != null && !((Boolean)validation.getTest().eval(ec));
+    }
 }

--- a/src/main/java/org/commcare/suite/model/QueryPrompt.java
+++ b/src/main/java/org/commcare/suite/model/QueryPrompt.java
@@ -2,6 +2,8 @@ package org.commcare.suite.model;
 
 import org.javarosa.core.model.ItemsetBinding;
 import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.services.locale.Localization;
+import org.javarosa.core.util.NoLocalizedTextException;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.ExtWrapNullable;
@@ -24,6 +26,7 @@ public class QueryPrompt implements Externalizable {
     public static final String INPUT_TYPE_DATERANGE = "daterange";
     public static final String INPUT_TYPE_DATE = "date";
     public static final String INPUT_TYPE_ADDRESS = "address";
+    public static final String DEFAULT_VALIDATION_ERROR = "This answer is outside the allowed range";
 
     private String key;
 
@@ -181,13 +184,18 @@ public class QueryPrompt implements Externalizable {
      * Evalualtes validation message against given eval context
      *
      * @param ec eval context to evaluate the validation message
-     * @return evaluated validation message or empty string if no validation message defined
+     * @return evaluated validation message or a default text if no validation message is defined
      */
     public String getValidationMessage(EvaluationContext ec) {
         if (validation != null && validation.getMessage() != null) {
             return validation.getMessage().evaluate(ec);
         }
-        return "";
+
+        try {
+            return Localization.get("invalid_answer_error");
+        } catch (NoLocalizedTextException nlte) {
+            return DEFAULT_VALIDATION_ERROR;
+        }
     }
 
     /**

--- a/src/main/java/org/commcare/suite/model/QueryPrompt.java
+++ b/src/main/java/org/commcare/suite/model/QueryPrompt.java
@@ -26,7 +26,7 @@ public class QueryPrompt implements Externalizable {
     public static final String INPUT_TYPE_DATERANGE = "daterange";
     public static final String INPUT_TYPE_DATE = "date";
     public static final String INPUT_TYPE_ADDRESS = "address";
-    public static final String DEFAULT_VALIDATION_ERROR = "This answer is outside the allowed range";
+    public static final String DEFAULT_VALIDATION_ERROR = "Sorry, this response is invalid!";
 
     private String key;
 
@@ -192,7 +192,7 @@ public class QueryPrompt implements Externalizable {
         }
 
         try {
-            return Localization.get("invalid_answer_error");
+            return Localization.get("case.search.answer.invalid");
         } catch (NoLocalizedTextException nlte) {
             return DEFAULT_VALIDATION_ERROR;
         }

--- a/src/main/java/org/commcare/suite/model/QueryPrompt.java
+++ b/src/main/java/org/commcare/suite/model/QueryPrompt.java
@@ -63,9 +63,9 @@ public class QueryPrompt implements Externalizable {
     }
 
     public QueryPrompt(String key, String appearance, String input, String receive,
-                       String hidden, DisplayUnit display, ItemsetBinding itemsetBinding, 
-                       XPathExpression defaultValueExpr, boolean allowBlankValue, XPathExpression exclude,
-                       XPathExpression required, QueryPromptValidation validation) {
+            String hidden, DisplayUnit display, ItemsetBinding itemsetBinding,
+            XPathExpression defaultValueExpr, boolean allowBlankValue, XPathExpression exclude,
+            XPathExpression required, QueryPromptValidation validation) {
 
         this.key = key;
         this.appearance = appearance;
@@ -82,7 +82,8 @@ public class QueryPrompt implements Externalizable {
     }
 
     @Override
-    public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
+    public void readExternal(DataInputStream in, PrototypeFactory pf)
+            throws IOException, DeserializationException {
         key = (String)ExtUtil.read(in, String.class, pf);
         appearance = (String)ExtUtil.read(in, new ExtWrapNullable(String.class), pf);
         input = (String)ExtUtil.read(in, new ExtWrapNullable(String.class), pf);
@@ -106,7 +107,8 @@ public class QueryPrompt implements Externalizable {
         ExtUtil.write(out, new ExtWrapNullable(hidden));
         ExtUtil.write(out, display);
         ExtUtil.write(out, new ExtWrapNullable(itemsetBinding));
-        ExtUtil.write(out, new ExtWrapNullable(defaultValueExpr == null ? null : new ExtWrapTagged(defaultValueExpr)));
+        ExtUtil.write(out,
+                new ExtWrapNullable(defaultValueExpr == null ? null : new ExtWrapTagged(defaultValueExpr)));
         ExtUtil.writeBool(out, allowBlankValue);
         ExtUtil.write(out, new ExtWrapNullable(exclude == null ? null : new ExtWrapTagged(exclude)));
         ExtUtil.write(out, new ExtWrapNullable(required == null ? null : new ExtWrapTagged(required)));
@@ -177,6 +179,7 @@ public class QueryPrompt implements Externalizable {
 
     /**
      * Evalualtes validation message against given eval context
+     *
      * @param ec eval context to evaluate the validation message
      * @return evaluated validation message or empty string if no validation message defined
      */
@@ -189,6 +192,7 @@ public class QueryPrompt implements Externalizable {
 
     /**
      * Evaluates the validation condition for the prompts
+     *
      * @param ec eval context to evaluate the validation condition
      * @return whether the input is invalid
      */

--- a/src/main/java/org/commcare/suite/model/QueryPrompt.java
+++ b/src/main/java/org/commcare/suite/model/QueryPrompt.java
@@ -54,6 +54,9 @@ public class QueryPrompt implements Externalizable {
 
     private boolean allowBlankValue;
 
+    @Nullable
+    private QueryPromptValidation validation;
+
     @SuppressWarnings("unused")
     public QueryPrompt() {
     }
@@ -61,7 +64,7 @@ public class QueryPrompt implements Externalizable {
     public QueryPrompt(String key, String appearance, String input, String receive,
                        String hidden, DisplayUnit display, ItemsetBinding itemsetBinding, 
                        XPathExpression defaultValueExpr, boolean allowBlankValue, XPathExpression exclude,
-                       XPathExpression required) {
+                       XPathExpression required, QueryPromptValidation validation) {
 
         this.key = key;
         this.appearance = appearance;
@@ -74,6 +77,7 @@ public class QueryPrompt implements Externalizable {
         this.allowBlankValue = allowBlankValue;
         this.exclude = exclude;
         this.required = required;
+        this.validation = validation;
     }
 
     @Override
@@ -89,6 +93,7 @@ public class QueryPrompt implements Externalizable {
         allowBlankValue = ExtUtil.readBool(in);
         exclude = (XPathExpression)ExtUtil.read(in, new ExtWrapNullable(new ExtWrapTagged()), pf);
         required = (XPathExpression)ExtUtil.read(in, new ExtWrapNullable(new ExtWrapTagged()), pf);
+        validation = (QueryPromptValidation)ExtUtil.read(in, new ExtWrapNullable(QueryPromptValidation.class), pf);
     }
 
     @Override
@@ -104,6 +109,7 @@ public class QueryPrompt implements Externalizable {
         ExtUtil.writeBool(out, allowBlankValue);
         ExtUtil.write(out, new ExtWrapNullable(exclude == null ? null : new ExtWrapTagged(exclude)));
         ExtUtil.write(out, new ExtWrapNullable(required == null ? null : new ExtWrapTagged(required)));
+        ExtUtil.write(out, new ExtWrapNullable(validation));
     }
 
     public String getKey() {
@@ -154,6 +160,11 @@ public class QueryPrompt implements Externalizable {
 
     public XPathExpression getRequired() {
         return required;
+    }
+
+    @Nullable
+    public QueryPromptValidation getValidation() {
+        return validation;
     }
 
     /**

--- a/src/main/java/org/commcare/suite/model/QueryPromptValidation.java
+++ b/src/main/java/org/commcare/suite/model/QueryPromptValidation.java
@@ -11,6 +11,9 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 
+/**
+ * Model for <validation> node in {@link QueryPrompt}
+ */
 public class QueryPromptValidation implements Externalizable {
 
     private XPathExpression test;

--- a/src/main/java/org/commcare/suite/model/QueryPromptValidation.java
+++ b/src/main/java/org/commcare/suite/model/QueryPromptValidation.java
@@ -13,36 +13,36 @@ import java.io.IOException;
 
 public class QueryPromptValidation implements Externalizable {
 
-    private XPathExpression xpath;
-    private String message;
+    private XPathExpression test;
+    private Text message;
 
     @SuppressWarnings("unused")
     public QueryPromptValidation() {
     }
 
-    public QueryPromptValidation(XPathExpression xpath, String message) {
-        this.xpath = xpath;
+    public QueryPromptValidation(XPathExpression test, Text message) {
+        this.test = test;
         this.message = message;
     }
 
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf)
             throws IOException, DeserializationException {
-        xpath = (XPathExpression)ExtUtil.read(in, new ExtWrapTagged(), pf);
-        message = (String)ExtUtil.read(in, String.class, pf);
+        test = (XPathExpression)ExtUtil.read(in, new ExtWrapTagged(), pf);
+        message = (Text)ExtUtil.read(in, Text.class, pf);
     }
 
     @Override
     public void writeExternal(DataOutputStream out) throws IOException {
-        ExtUtil.write(out, new ExtWrapTagged(xpath));
+        ExtUtil.write(out, new ExtWrapTagged(test));
         ExtUtil.write(out, message);
     }
 
-    public XPathExpression getXpath() {
-        return xpath;
+    public XPathExpression getTest() {
+        return test;
     }
 
-    public String getMessage() {
+    public Text getMessage() {
         return message;
     }
 }

--- a/src/main/java/org/commcare/suite/model/QueryPromptValidation.java
+++ b/src/main/java/org/commcare/suite/model/QueryPromptValidation.java
@@ -37,4 +37,12 @@ public class QueryPromptValidation implements Externalizable {
         ExtUtil.write(out, new ExtWrapTagged(xpath));
         ExtUtil.write(out, message);
     }
+
+    public XPathExpression getXpath() {
+        return xpath;
+    }
+
+    public String getMessage() {
+        return message;
+    }
 }

--- a/src/main/java/org/commcare/suite/model/QueryPromptValidation.java
+++ b/src/main/java/org/commcare/suite/model/QueryPromptValidation.java
@@ -1,0 +1,40 @@
+package org.commcare.suite.model;
+
+import org.javarosa.core.util.externalizable.DeserializationException;
+import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.ExtWrapTagged;
+import org.javarosa.core.util.externalizable.Externalizable;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.javarosa.xpath.expr.XPathExpression;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+public class QueryPromptValidation implements Externalizable {
+
+    private XPathExpression xpath;
+    private String message;
+
+    @SuppressWarnings("unused")
+    public QueryPromptValidation() {
+    }
+
+    public QueryPromptValidation(XPathExpression xpath, String message) {
+        this.xpath = xpath;
+        this.message = message;
+    }
+
+    @Override
+    public void readExternal(DataInputStream in, PrototypeFactory pf)
+            throws IOException, DeserializationException {
+        xpath = (XPathExpression)ExtUtil.read(in, new ExtWrapTagged(), pf);
+        message = (String)ExtUtil.read(in, String.class, pf);
+    }
+
+    @Override
+    public void writeExternal(DataOutputStream out) throws IOException {
+        ExtUtil.write(out, new ExtWrapTagged(xpath));
+        ExtUtil.write(out, message);
+    }
+}

--- a/src/main/java/org/commcare/suite/model/QueryPromptValidation.java
+++ b/src/main/java/org/commcare/suite/model/QueryPromptValidation.java
@@ -2,6 +2,7 @@ package org.commcare.suite.model;
 
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.ExtWrapNullable;
 import org.javarosa.core.util.externalizable.ExtWrapTagged;
 import org.javarosa.core.util.externalizable.Externalizable;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
@@ -32,13 +33,13 @@ public class QueryPromptValidation implements Externalizable {
     public void readExternal(DataInputStream in, PrototypeFactory pf)
             throws IOException, DeserializationException {
         test = (XPathExpression)ExtUtil.read(in, new ExtWrapTagged(), pf);
-        message = (Text)ExtUtil.read(in, Text.class, pf);
+        message = (Text)ExtUtil.read(in, new ExtWrapNullable(Text.class), pf);
     }
 
     @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.write(out, new ExtWrapTagged(test));
-        ExtUtil.write(out, message);
+        ExtUtil.write(out, new ExtWrapNullable(message));
     }
 
     public XPathExpression getTest() {

--- a/src/main/java/org/commcare/xml/QueryPromptParser.java
+++ b/src/main/java/org/commcare/xml/QueryPromptParser.java
@@ -2,6 +2,7 @@ package org.commcare.xml;
 
 import org.commcare.suite.model.DisplayUnit;
 import org.commcare.suite.model.QueryPrompt;
+import org.commcare.suite.model.QueryPromptValidation;
 import org.javarosa.core.model.ItemsetBinding;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.xform.parse.ItemSetParsingUtils;
@@ -20,6 +21,7 @@ public class QueryPromptParser extends CommCareElementParser<QueryPrompt> {
     private static final String NAME_PROMPT = "prompt";
     private static final String NAME_DISPLAY = "display";
     private static final String NAME_ITEMSET = "itemset";
+    private static final String NAME_VALIDATION = "validation";
     private static final String ATTR_APPEARANCE = "appearance";
     private static final String ATTR_KEY = "key";
     private static final String ATTR_INPUT = "input";
@@ -34,6 +36,8 @@ public class QueryPromptParser extends CommCareElementParser<QueryPrompt> {
     private static final String ATTR_ALLOW_BLANK_VALUE = "allow_blank_value";
     private static final String ATTR_EXCLUDE = "exclude";
     private static final String ATTR_REQUIRED = "required";
+    private static final String ATTR_VALIDATION_XPATH = "xpath";
+    private static final String ATTR_VALIDATION_MESSAGE = "message";
 
     public QueryPromptParser(KXmlParser parser) {
         super(parser);
@@ -55,15 +59,25 @@ public class QueryPromptParser extends CommCareElementParser<QueryPrompt> {
         XPathExpression exclude = xpathPropertyValue(excludeValueString);
         XPathExpression required = xpathPropertyValue(parser.getAttributeValue(null, ATTR_REQUIRED));
 
+        QueryPromptValidation validation = null;
         while (nextTagInBlock(NAME_PROMPT)) {
-            if (NAME_DISPLAY.equals(parser.getName().toLowerCase())) {
+            if (NAME_DISPLAY.equalsIgnoreCase(parser.getName())) {
                 display = parseDisplayBlock();
-            } else if (NAME_ITEMSET.equals(parser.getName().toLowerCase())) {
+            } else if (NAME_ITEMSET.equalsIgnoreCase(parser.getName())) {
                 itemsetBinding = parseItemset();
+            } else if (NAME_VALIDATION.equalsIgnoreCase(parser.getName())) {
+                validation = parseValidationBlock();
             }
         }
         return new QueryPrompt(key, appearance, input, receive, hidden, display,
-                               itemsetBinding, defaultValue, allowBlankValue, exclude, required);
+                itemsetBinding, defaultValue, allowBlankValue, exclude, required, validation);
+    }
+
+    private QueryPromptValidation parseValidationBlock() throws InvalidStructureException {
+        String xpathStr = parser.getAttributeValue(null, ATTR_VALIDATION_XPATH);
+        XPathExpression xpath = xpathPropertyValue(xpathStr);
+        String message = parser.getAttributeValue(null, ATTR_VALIDATION_MESSAGE);
+        return new QueryPromptValidation(xpath, message);
     }
 
     private ItemsetBinding parseItemset() throws IOException, XmlPullParserException, InvalidStructureException {

--- a/src/main/java/org/commcare/xml/QueryPromptParser.java
+++ b/src/main/java/org/commcare/xml/QueryPromptParser.java
@@ -45,7 +45,8 @@ public class QueryPromptParser extends CommCareElementParser<QueryPrompt> {
     }
 
     @Override
-    public QueryPrompt parse() throws InvalidStructureException, IOException, XmlPullParserException, UnfullfilledRequirementsException {
+    public QueryPrompt parse() throws InvalidStructureException, IOException, XmlPullParserException,
+            UnfullfilledRequirementsException {
         String appearance = parser.getAttributeValue(null, ATTR_APPEARANCE);
         String key = parser.getAttributeValue(null, ATTR_KEY);
         String input = parser.getAttributeValue(null, ATTR_INPUT);
@@ -85,12 +86,14 @@ public class QueryPromptParser extends CommCareElementParser<QueryPrompt> {
         while (nextTagInBlock(NAME_VALIDATION)) {
             if (parser.getName().equals(NAME_TEXT)) {
                 message = new TextParser(parser).parse();
-            }else {
-                throw new InvalidStructureException("Unrecognised node " + parser.getName() + "in validation for key " + key);
+            } else {
+                throw new InvalidStructureException(
+                        "Unrecognised node " + parser.getName() + "in validation for key " + key);
             }
         }
         if (message == null) {
-            throw new InvalidStructureException("No validation message defined in the validation block for key " + key);
+            throw new InvalidStructureException(
+                    "No validation message defined in the validation block for key " + key);
         }
         return new QueryPromptValidation(test, message);
     }

--- a/src/main/java/org/commcare/xml/QueryPromptParser.java
+++ b/src/main/java/org/commcare/xml/QueryPromptParser.java
@@ -91,10 +91,6 @@ public class QueryPromptParser extends CommCareElementParser<QueryPrompt> {
                         "Unrecognised node " + parser.getName() + "in validation for prompt " + key);
             }
         }
-        if (message == null) {
-            throw new InvalidStructureException(
-                    "No validation message defined in the validation block for prompt " + key);
-        }
         return new QueryPromptValidation(test, message);
     }
 

--- a/src/main/java/org/commcare/xml/QueryPromptParser.java
+++ b/src/main/java/org/commcare/xml/QueryPromptParser.java
@@ -79,7 +79,7 @@ public class QueryPromptParser extends CommCareElementParser<QueryPrompt> {
             throws InvalidStructureException, XmlPullParserException, IOException {
         String testStr = parser.getAttributeValue(null, ATTR_VALIDATION_TEST);
         if (testStr == null) {
-            throw new InvalidStructureException("No test condition defined in validation for key " + key);
+            throw new InvalidStructureException("No test condition defined in validation for prompt " + key);
         }
         XPathExpression test = xpathPropertyValue(testStr);
         Text message = null;
@@ -88,12 +88,12 @@ public class QueryPromptParser extends CommCareElementParser<QueryPrompt> {
                 message = new TextParser(parser).parse();
             } else {
                 throw new InvalidStructureException(
-                        "Unrecognised node " + parser.getName() + "in validation for key " + key);
+                        "Unrecognised node " + parser.getName() + "in validation for prompt " + key);
             }
         }
         if (message == null) {
             throw new InvalidStructureException(
-                    "No validation message defined in the validation block for key " + key);
+                    "No validation message defined in the validation block for prompt " + key);
         }
         return new QueryPromptValidation(test, message);
     }

--- a/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
@@ -299,7 +299,7 @@ public class CaseClaimModelTests {
                 existingManager == null ? buildRemoteQuerySessionManager() : existingManager;
 
         userInput.forEach(remoteQuerySessionManager::answerUserPrompt);
-        remoteQuerySessionManager.refresh();
+        remoteQuerySessionManager.refreshInputDependentState();
         Hashtable<String, String> errors = remoteQuerySessionManager.getErrors();
 
         if (expectedErrors.isEmpty()) {

--- a/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
@@ -1,5 +1,7 @@
 package org.commcare.backend.suite.model.test;
 
+import static org.commcare.suite.model.QueryPrompt.DEFAULT_VALIDATION_ERROR;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
@@ -272,7 +274,7 @@ public class CaseClaimModelTests {
         testErrorsWithUserInput(
                 ImmutableMap.of(),
                 ImmutableMap.of("age", "age should be greater than 18",
-                        "another_age", "another age should be greater than 18"),
+                        "another_age", DEFAULT_VALIDATION_ERROR),
                 null
         );
     }
@@ -282,7 +284,7 @@ public class CaseClaimModelTests {
         RemoteQuerySessionManager remoteQuerySessionManager = testErrorsWithUserInput(
                 ImmutableMap.of("name", "", "age", "15", "another_age", "12"),
                 ImmutableMap.of("name", "name can't be empty", "age", "age should be greater than 18",
-                        "another_age", "another age should be greater than 18"),
+                        "another_age", DEFAULT_VALIDATION_ERROR),
                 null
         );
 

--- a/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
@@ -273,6 +273,15 @@ public class CaseClaimModelTests {
     public void testErrorsWithUserInput_noInput() throws Exception {
         testErrorsWithUserInput(
                 ImmutableMap.of(),
+                ImmutableMap.of(),
+                null
+        );
+    }
+
+    @Test
+    public void testErrorsWithUserInput_EmptyInput() throws Exception {
+        testErrorsWithUserInput(
+                ImmutableMap.of("age", "", "another_age", ""),
                 ImmutableMap.of("age", "age should be greater than 18",
                         "another_age", DEFAULT_VALIDATION_ERROR),
                 null

--- a/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
@@ -68,7 +68,8 @@ public class CaseClaimModelTests {
         testPopulateItemsetChoices(Collections.emptyMap(), Collections.emptyList(), null);
     }
 
-    private RemoteQuerySessionManager testPopulateItemsetChoices(Map<String, String> userInput, List<String> expected,
+    private RemoteQuerySessionManager testPopulateItemsetChoices(Map<String, String> userInput,
+            List<String> expected,
             RemoteQuerySessionManager existingQuerySessionManager)
             throws Exception {
         RemoteQuerySessionManager remoteQuerySessionManager =
@@ -301,8 +302,8 @@ public class CaseClaimModelTests {
         remoteQuerySessionManager.refresh();
         Hashtable<String, String> errors = remoteQuerySessionManager.getErrors();
 
-        if(expectedErrors.isEmpty()){
-           Assert.assertTrue(errors.isEmpty());
+        if (expectedErrors.isEmpty()) {
+            Assert.assertTrue(errors.isEmpty());
         }
 
         expectedErrors.forEach((key, expectedError) -> {

--- a/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
@@ -267,16 +267,6 @@ public class CaseClaimModelTests {
     }
 
     @Test
-    public void testErrorsWithUserInput_invalidInput() throws Exception {
-        testErrorsWithUserInput(
-                ImmutableMap.of("name", "", "age", "15", "another_age", "12"),
-                ImmutableMap.of("name", "name can't be empty", "age", "age should be greater than 18",
-                        "another_age", "another age should be greater than 18"),
-                null
-        );
-    }
-
-    @Test
     public void testErrorsWithUserInput_noInput() throws Exception {
         testErrorsWithUserInput(
                 ImmutableMap.of(),
@@ -287,10 +277,17 @@ public class CaseClaimModelTests {
     }
 
     @Test
-    public void testErrorsWithUserInput_validInput() throws Exception {
+    public void testErrorsWithUserInput_errorsClearWithValidInput() throws Exception {
+        RemoteQuerySessionManager remoteQuerySessionManager = testErrorsWithUserInput(
+                ImmutableMap.of("name", "", "age", "15", "another_age", "12"),
+                ImmutableMap.of("name", "name can't be empty", "age", "age should be greater than 18",
+                        "another_age", "another age should be greater than 18"),
+                null
+        );
+
         testErrorsWithUserInput(
                 ImmutableMap.of("name", "Ruth", "age", "21", "another_age", "20"),
-                ImmutableMap.of(), null
+                ImmutableMap.of(), remoteQuerySessionManager
         );
     }
 

--- a/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
@@ -282,8 +282,7 @@ public class CaseClaimModelTests {
     public void testErrorsWithUserInput_EmptyInput() throws Exception {
         testErrorsWithUserInput(
                 ImmutableMap.of("age", "", "another_age", ""),
-                ImmutableMap.of("age", "age should be greater than 18",
-                        "another_age", DEFAULT_VALIDATION_ERROR),
+                ImmutableMap.of(),
                 null
         );
     }
@@ -292,7 +291,7 @@ public class CaseClaimModelTests {
     public void testErrorsWithUserInput_errorsClearWithValidInput() throws Exception {
         RemoteQuerySessionManager remoteQuerySessionManager = testErrorsWithUserInput(
                 ImmutableMap.of("name", "", "age", "15", "another_age", "12"),
-                ImmutableMap.of("name", "name can't be empty", "age", "age should be greater than 18",
+                ImmutableMap.of( "age", "age should be greater than 18",
                         "another_age", DEFAULT_VALIDATION_ERROR),
                 null
         );

--- a/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
@@ -279,7 +279,7 @@ public class CaseClaimModelTests {
                 existingManager == null ? buildRemoteQuerySessionManager() : existingManager;
 
         userInput.forEach(remoteQuerySessionManager::answerUserPrompt);
-        remoteQuerySessionManager.validateUserAnswers();
+        remoteQuerySessionManager.refresh();
         Hashtable<String, String> errors = remoteQuerySessionManager.getErrors();
 
         if(expectedErrors.isEmpty()){

--- a/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
@@ -269,8 +269,9 @@ public class CaseClaimModelTests {
     @Test
     public void testErrorsWithUserInput_invalidInput() throws Exception {
         testErrorsWithUserInput(
-                ImmutableMap.of("name", "", "age", "15"),
-                ImmutableMap.of("name", "name can't be empty", "age", "age should be greater than 18"),
+                ImmutableMap.of("name", "", "age", "15", "another_age", "12"),
+                ImmutableMap.of("name", "name can't be empty", "age", "age should be greater than 18",
+                        "another_age", "another age should be greater than 18"),
                 null
         );
     }
@@ -279,14 +280,16 @@ public class CaseClaimModelTests {
     public void testErrorsWithUserInput_noInput() throws Exception {
         testErrorsWithUserInput(
                 ImmutableMap.of(),
-                ImmutableMap.of("age", "age should be greater than 18"), null
+                ImmutableMap.of("age", "age should be greater than 18",
+                        "another_age", "another age should be greater than 18"),
+                null
         );
     }
 
     @Test
     public void testErrorsWithUserInput_validInput() throws Exception {
         testErrorsWithUserInput(
-                ImmutableMap.of("name", "Ruth", "age", "21"),
+                ImmutableMap.of("name", "Ruth", "age", "21", "another_age", "20"),
                 ImmutableMap.of(), null
         );
     }

--- a/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
@@ -95,7 +95,9 @@ public class CaseClaimModelTests {
         session.setCommand("patient-search");
 
         ExternalDataInstance districtInstance = buildDistrictInstance();
+        ExternalDataInstance stateInstance = buildStateInstance();
         EvaluationContext context = session.getEvaluationContext().spawnWithCleanLifecycle(ImmutableMap.of(
+                stateInstance.getInstanceId(), stateInstance,
                 districtInstance.getInstanceId(), districtInstance
         ));
 
@@ -226,6 +228,23 @@ public class CaseClaimModelTests {
         Multimap<String, String> params = remoteQuerySessionManager.getRawQueryParams(false);
 
         Assert.assertFalse(params.containsKey("exclude_patient_id"));
+    }
+
+    private ExternalDataInstance buildStateInstance() {
+        Map<String, String> noAttrs = Collections.emptyMap();
+        List<SimpleNode> nodes = ImmutableList.of(
+                SimpleNode.parentNode("state", noAttrs, ImmutableList.of(
+                        SimpleNode.textNode("id", noAttrs, "ka"),
+                        SimpleNode.textNode("name", noAttrs, "Karnataka")
+                )),
+                SimpleNode.parentNode("state", noAttrs, ImmutableList.of(
+                        SimpleNode.textNode("id", noAttrs, "rj"),
+                        SimpleNode.textNode("name", noAttrs, "Rajasthan")
+                ))
+        );
+
+        TreeElement root = TreeBuilder.buildTree("state", "state_list", nodes);
+        return new ExternalDataInstance(ExternalDataInstance.JR_SEARCH_INPUT_REFERENCE, "state", root);
     }
 
     private ExternalDataInstance buildDistrictInstance() {

--- a/src/test/resources/case_claim_example/app_strings.txt
+++ b/src/test/resources/case_claim_example/app_strings.txt
@@ -1,2 +1,6 @@
 query.name=name
 query.age=age
+query.name.validation.message=name can't be empty
+query.age.validation.message=age should be greater than 18
+query.another_age.validation.message=another age should be greater than 18
+

--- a/src/test/resources/case_claim_example/app_strings.txt
+++ b/src/test/resources/case_claim_example/app_strings.txt
@@ -2,5 +2,3 @@ query.name=name
 query.age=age
 query.name.validation.message=name can't be empty
 query.age.validation.message=age should be greater than 18
-query.another_age.validation.message=another age should be greater than 18
-

--- a/src/test/resources/case_claim_example/suite.xml
+++ b/src/test/resources/case_claim_example/suite.xml
@@ -82,6 +82,14 @@
             </text>
           </display>
         </prompt>
+        <prompt key="another_age">
+          <validation xpath="int(.)>18" message="another age should be greater than 18"/>
+          <display>
+            <text>
+              <locale id="query.name"/>
+            </text>
+          </display>
+        </prompt>
         <prompt key="patient_id" hidden="false" allow_blank_value="true" exclude="false()">
           <display>
             <text>

--- a/src/test/resources/case_claim_example/suite.xml
+++ b/src/test/resources/case_claim_example/suite.xml
@@ -67,6 +67,7 @@
         <data key="patient_id_legacy" ref="if(count(instance('search-input')/input/field[@name='patient_id']) > 0, concat('external_id = ', instance('search-input')/input/field[@name='patient_id']), '')"/>
         <data key="patient_id_custom_id" ref="if(count(instance('my-search-input')/input/field[@name='patient_id']) > 0, concat('external_id = ', instance('my-search-input')/input/field[@name='patient_id']), '')"/>
         <prompt key="name" default="instance('session')/session/context/deviceid">
+          <validation xpath="instance('my-search-input')/input/field[@name='name']!=''" message="name can't be empty"/>
           <display>
             <text>
               <locale id="query.name"/>

--- a/src/test/resources/case_claim_example/suite.xml
+++ b/src/test/resources/case_claim_example/suite.xml
@@ -74,6 +74,14 @@
             </text>
           </display>
         </prompt>
+        <prompt key="age">
+          <validation xpath="int(instance('my-search-input')/input/field[@name='age'])>18" message="age should be greater than 18"/>
+          <display>
+            <text>
+              <locale id="query.name"/>
+            </text>
+          </display>
+        </prompt>
         <prompt key="patient_id" hidden="false" allow_blank_value="true" exclude="false()">
           <display>
             <text>

--- a/src/test/resources/case_claim_example/suite.xml
+++ b/src/test/resources/case_claim_example/suite.xml
@@ -67,11 +67,6 @@
         <data key="patient_id_legacy" ref="if(count(instance('search-input')/input/field[@name='patient_id']) > 0, concat('external_id = ', instance('search-input')/input/field[@name='patient_id']), '')"/>
         <data key="patient_id_custom_id" ref="if(count(instance('my-search-input')/input/field[@name='patient_id']) > 0, concat('external_id = ', instance('my-search-input')/input/field[@name='patient_id']), '')"/>
         <prompt key="name" default="instance('session')/session/context/deviceid">
-          <validation test="instance('my-search-input')/input/field[@name='name']!=''">
-            <text>
-              <locale id="query.name.validation.message"/>
-            </text>
-          </validation>
           <display>
             <text>
               <locale id="query.name"/>

--- a/src/test/resources/case_claim_example/suite.xml
+++ b/src/test/resources/case_claim_example/suite.xml
@@ -67,7 +67,11 @@
         <data key="patient_id_legacy" ref="if(count(instance('search-input')/input/field[@name='patient_id']) > 0, concat('external_id = ', instance('search-input')/input/field[@name='patient_id']), '')"/>
         <data key="patient_id_custom_id" ref="if(count(instance('my-search-input')/input/field[@name='patient_id']) > 0, concat('external_id = ', instance('my-search-input')/input/field[@name='patient_id']), '')"/>
         <prompt key="name" default="instance('session')/session/context/deviceid">
-          <validation xpath="instance('my-search-input')/input/field[@name='name']!=''" message="name can't be empty"/>
+          <validation test="instance('my-search-input')/input/field[@name='name']!=''">
+            <text>
+              <locale id="query.name.validation.message"/>
+            </text>
+          </validation>
           <display>
             <text>
               <locale id="query.name"/>
@@ -75,18 +79,26 @@
           </display>
         </prompt>
         <prompt key="age">
-          <validation xpath="int(instance('my-search-input')/input/field[@name='age'])>18" message="age should be greater than 18"/>
+          <validation test="int(instance('my-search-input')/input/field[@name='age'])>18">
+            <text>
+              <locale id="query.age.validation.message"/>
+            </text>
+          </validation>
           <display>
             <text>
-              <locale id="query.name"/>
+              <locale id="query.age"/>
             </text>
           </display>
         </prompt>
         <prompt key="another_age">
-          <validation xpath="int(.)>18" message="another age should be greater than 18"/>
+          <validation test="int(.)>18">
+            <text>
+              <locale id="query.another_age.validation.message"/>
+            </text>
+          </validation>
           <display>
             <text>
-              <locale id="query.name"/>
+              <locale id="query.age"/>
             </text>
           </display>
         </prompt>

--- a/src/test/resources/case_claim_example/suite.xml
+++ b/src/test/resources/case_claim_example/suite.xml
@@ -92,9 +92,6 @@
         </prompt>
         <prompt key="another_age">
           <validation test="int(.)>18">
-            <text>
-              <locale id="query.another_age.validation.message"/>
-            </text>
           </validation>
           <display>
             <text>


### PR DESCRIPTION
Adds support for validation condition on case search prompts. 

Xml Spec:

````
<prompt key="name">
    <validation test=”xpath_condition"”>       
                <text>
                    <locale id="locale.id"/>
                </text>
    </validation>

    <display>
        <text>
            <locale id="search_property.m0.name"/>
        </text>
    </display>
</prompt>
````

[Design Doc](https://docs.google.com/document/d/1wF9SFfX7-R86cPRgabrqbTU9BaGdp3IlAYlTjInWXTU/edit#)

https://github.com/dimagi/formplayer/pull/1177