### PR TITLE
Parses Android dependencies

### DIFF
--- a/src/main/java/org/commcare/suite/model/AndroidPackageDependency.java
+++ b/src/main/java/org/commcare/suite/model/AndroidPackageDependency.java
@@ -13,9 +13,6 @@ public class AndroidPackageDependency implements Externalizable {
     private String id;
     private String name;
 
-    // Set later during dependency check
-    private boolean installed = false;
-
     /**
      * Serialization Only!!!
      */
@@ -55,13 +52,5 @@ public class AndroidPackageDependency implements Externalizable {
                 "id='" + id + '\'' +
                 ", name='" + name + '\'' +
                 '}';
-    }
-
-    public boolean isInstalled() {
-        return installed;
-    }
-
-    public void setInstalled(boolean installed) {
-        this.installed = installed;
     }
 }

--- a/src/main/java/org/commcare/suite/model/AndroidPackageDependency.java
+++ b/src/main/java/org/commcare/suite/model/AndroidPackageDependency.java
@@ -9,7 +9,7 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 
-public class AppDependency implements Externalizable {
+public class AndroidPackageDependency implements Externalizable {
     private String id;
     private String name;
 
@@ -19,10 +19,10 @@ public class AppDependency implements Externalizable {
     /**
      * Serialization Only!!!
      */
-    public AppDependency() {
+    public AndroidPackageDependency() {
     }
 
-    public AppDependency(String id, String name) {
+    public AndroidPackageDependency(String id, String name) {
         this.id = id;
         this.name = name;
     }
@@ -51,8 +51,9 @@ public class AppDependency implements Externalizable {
 
     @Override
     public String toString() {
-        return "AppDependency{" +
+        return "AndroidPackageDependency{" +
                 "id='" + id + '\'' +
+                ", name='" + name + '\'' +
                 '}';
     }
 

--- a/src/main/java/org/commcare/suite/model/AndroidPackageDependency.java
+++ b/src/main/java/org/commcare/suite/model/AndroidPackageDependency.java
@@ -14,7 +14,6 @@ import java.io.IOException;
  */
 public class AndroidPackageDependency implements Externalizable {
     private String id;
-    private String name;
 
     /**
      * Serialization Only!!!
@@ -22,38 +21,29 @@ public class AndroidPackageDependency implements Externalizable {
     public AndroidPackageDependency() {
     }
 
-    public AndroidPackageDependency(String id, String name) {
+    public AndroidPackageDependency(String id) {
         this.id = id;
-        this.name = name;
     }
 
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf)
             throws IOException, DeserializationException {
         id = ExtUtil.readString(in);
-        name = ExtUtil.readString(in);
     }
 
     @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.writeString(out, id);
-        ExtUtil.writeString(out, name);
     }
 
     public String getId() {
         return id;
     }
 
-
-    public String getName() {
-        return name;
-    }
-
     @Override
     public String toString() {
         return "AndroidPackageDependency{" +
                 "id='" + id + '\'' +
-                ", name='" + name + '\'' +
                 '}';
     }
 }

--- a/src/main/java/org/commcare/suite/model/AndroidPackageDependency.java
+++ b/src/main/java/org/commcare/suite/model/AndroidPackageDependency.java
@@ -9,6 +9,9 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 
+/**
+ * Model for defining a CommCare app dependencies on other Android apps
+ */
 public class AndroidPackageDependency implements Externalizable {
     private String id;
     private String name;

--- a/src/main/java/org/commcare/suite/model/AppDependency.java
+++ b/src/main/java/org/commcare/suite/model/AppDependency.java
@@ -12,7 +12,6 @@ import java.io.IOException;
 public class AppDependency implements Externalizable {
     private String id;
     private String name;
-    private boolean force;
 
     // Set later during dependency check
     private boolean installed = false;
@@ -23,10 +22,9 @@ public class AppDependency implements Externalizable {
     public AppDependency() {
     }
 
-    public AppDependency(String id, String name, boolean force) {
+    public AppDependency(String id, String name) {
         this.id = id;
         this.name = name;
-        this.force = force;
     }
 
     @Override
@@ -34,23 +32,18 @@ public class AppDependency implements Externalizable {
             throws IOException, DeserializationException {
         id = ExtUtil.readString(in);
         name = ExtUtil.readString(in);
-        force = ExtUtil.readBool(in);
     }
 
     @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.writeString(out, id);
         ExtUtil.writeString(out, name);
-        ExtUtil.writeBool(out, force);
     }
 
     public String getId() {
         return id;
     }
 
-    public boolean isForce() {
-        return force;
-    }
 
     public String getName() {
         return name;
@@ -60,7 +53,6 @@ public class AppDependency implements Externalizable {
     public String toString() {
         return "AppDependency{" +
                 "id='" + id + '\'' +
-                ", force=" + force +
                 '}';
     }
 

--- a/src/main/java/org/commcare/suite/model/AppDependency.java
+++ b/src/main/java/org/commcare/suite/model/AppDependency.java
@@ -1,0 +1,55 @@
+package org.commcare.suite.model;
+
+import org.javarosa.core.util.externalizable.DeserializationException;
+import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.Externalizable;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+public class AppDependency implements Externalizable {
+    String id;
+    boolean force;
+
+    /**
+     * Serialization Only!!!
+     */
+    public AppDependency() {
+    }
+
+    public AppDependency(String id, boolean force) {
+        this.id = id;
+        this.force = force;
+    }
+
+    @Override
+    public void readExternal(DataInputStream in, PrototypeFactory pf)
+            throws IOException, DeserializationException {
+        id = ExtUtil.readString(in);
+        force = ExtUtil.readBool(in);
+    }
+
+    @Override
+    public void writeExternal(DataOutputStream out) throws IOException {
+        ExtUtil.writeString(out, id);
+        ExtUtil.writeBool(out, force);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public boolean isForce() {
+        return force;
+    }
+
+    @Override
+    public String toString() {
+        return "AppDependency{" +
+                "id='" + id + '\'' +
+                ", force=" + force +
+                '}';
+    }
+}

--- a/src/main/java/org/commcare/suite/model/AppDependency.java
+++ b/src/main/java/org/commcare/suite/model/AppDependency.java
@@ -10,8 +10,12 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 
 public class AppDependency implements Externalizable {
-    String id;
-    boolean force;
+    private String id;
+    private String name;
+    private boolean force;
+
+    // Set later during dependency check
+    private boolean installed = false;
 
     /**
      * Serialization Only!!!
@@ -19,8 +23,9 @@ public class AppDependency implements Externalizable {
     public AppDependency() {
     }
 
-    public AppDependency(String id, boolean force) {
+    public AppDependency(String id, String name, boolean force) {
         this.id = id;
+        this.name = name;
         this.force = force;
     }
 
@@ -28,12 +33,14 @@ public class AppDependency implements Externalizable {
     public void readExternal(DataInputStream in, PrototypeFactory pf)
             throws IOException, DeserializationException {
         id = ExtUtil.readString(in);
+        name = ExtUtil.readString(in);
         force = ExtUtil.readBool(in);
     }
 
     @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.writeString(out, id);
+        ExtUtil.writeString(out, name);
         ExtUtil.writeBool(out, force);
     }
 
@@ -45,11 +52,23 @@ public class AppDependency implements Externalizable {
         return force;
     }
 
+    public String getName() {
+        return name;
+    }
+
     @Override
     public String toString() {
         return "AppDependency{" +
                 "id='" + id + '\'' +
                 ", force=" + force +
                 '}';
+    }
+
+    public boolean isInstalled() {
+        return installed;
+    }
+
+    public void setInstalled(boolean installed) {
+        this.installed = installed;
     }
 }

--- a/src/main/java/org/commcare/suite/model/Profile.java
+++ b/src/main/java/org/commcare/suite/model/Profile.java
@@ -36,6 +36,7 @@ public class Profile implements Persistable {
     private String authRef;
     private Vector<PropertySetter> properties;
     private Vector<RootTranslator> roots;
+    private Vector<AppDependency> dependencies;
     private Hashtable<String, Boolean> featureStatus;
 
     private String uniqueId;
@@ -75,6 +76,7 @@ public class Profile implements Persistable {
         this.fromOld = fromOld;
         properties = new Vector<>();
         roots = new Vector<>();
+        dependencies = new Vector<>();
         featureStatus = new Hashtable<>();
         //turn on default features
         featureStatus.put("users", true);
@@ -181,6 +183,14 @@ public class Profile implements Persistable {
         this.featureStatus.put(feature, active);
     }
 
+    public Vector<AppDependency> getDependencies() {
+        return dependencies;
+    }
+
+    public void setDependencies(Vector<AppDependency> dependencies) {
+        this.dependencies = dependencies;
+    }
+
     /**
      * A helper method which initializes the properties specified
      * by this profile definition.
@@ -216,6 +226,7 @@ public class Profile implements Persistable {
         roots = (Vector<RootTranslator>)ExtUtil.read(in, new ExtWrapList(RootTranslator.class), pf);
         featureStatus = (Hashtable<String, Boolean>)ExtUtil.read(in, new ExtWrapMap(String.class, Boolean.class), pf);
         buildProfileId = ExtUtil.readString(in);
+        dependencies = (Vector<AppDependency>)ExtUtil.read(in, new ExtWrapList(AppDependency.class), pf);
     }
 
     @Override
@@ -231,5 +242,6 @@ public class Profile implements Persistable {
         ExtUtil.write(out, new ExtWrapList(roots));
         ExtUtil.write(out, new ExtWrapMap(featureStatus));
         ExtUtil.writeString(out, buildProfileId);
+        ExtUtil.write(out, new ExtWrapList(dependencies));
     }
 }

--- a/src/main/java/org/commcare/suite/model/Profile.java
+++ b/src/main/java/org/commcare/suite/model/Profile.java
@@ -226,7 +226,8 @@ public class Profile implements Persistable {
         roots = (Vector<RootTranslator>)ExtUtil.read(in, new ExtWrapList(RootTranslator.class), pf);
         featureStatus = (Hashtable<String, Boolean>)ExtUtil.read(in, new ExtWrapMap(String.class, Boolean.class), pf);
         buildProfileId = ExtUtil.readString(in);
-        dependencies = (Vector<AndroidPackageDependency>)ExtUtil.read(in, new ExtWrapList(AndroidPackageDependency.class), pf);
+        dependencies = (Vector<AndroidPackageDependency>)ExtUtil.read(in,
+                new ExtWrapList(AndroidPackageDependency.class), pf);
     }
 
     @Override

--- a/src/main/java/org/commcare/suite/model/Profile.java
+++ b/src/main/java/org/commcare/suite/model/Profile.java
@@ -36,7 +36,7 @@ public class Profile implements Persistable {
     private String authRef;
     private Vector<PropertySetter> properties;
     private Vector<RootTranslator> roots;
-    private Vector<AppDependency> dependencies;
+    private Vector<AndroidPackageDependency> dependencies;
     private Hashtable<String, Boolean> featureStatus;
 
     private String uniqueId;
@@ -183,11 +183,11 @@ public class Profile implements Persistable {
         this.featureStatus.put(feature, active);
     }
 
-    public Vector<AppDependency> getDependencies() {
+    public Vector<AndroidPackageDependency> getDependencies() {
         return dependencies;
     }
 
-    public void setDependencies(Vector<AppDependency> dependencies) {
+    public void setDependencies(Vector<AndroidPackageDependency> dependencies) {
         this.dependencies = dependencies;
     }
 
@@ -226,7 +226,7 @@ public class Profile implements Persistable {
         roots = (Vector<RootTranslator>)ExtUtil.read(in, new ExtWrapList(RootTranslator.class), pf);
         featureStatus = (Hashtable<String, Boolean>)ExtUtil.read(in, new ExtWrapMap(String.class, Boolean.class), pf);
         buildProfileId = ExtUtil.readString(in);
-        dependencies = (Vector<AppDependency>)ExtUtil.read(in, new ExtWrapList(AppDependency.class), pf);
+        dependencies = (Vector<AndroidPackageDependency>)ExtUtil.read(in, new ExtWrapList(AndroidPackageDependency.class), pf);
     }
 
     @Override

--- a/src/main/java/org/commcare/xml/ProfileParser.java
+++ b/src/main/java/org/commcare/xml/ProfileParser.java
@@ -29,7 +29,6 @@ public class ProfileParser extends ElementParser<Profile> {
     private static final String NAME_APP = "app";
     private static final String ATTR_ID = "id";
     private static final String ATTR_NAME = "name";
-    private static final String ATTR_FORCE = "force";
 
 
     ResourceTable table;
@@ -268,8 +267,7 @@ public class ProfileParser extends ElementParser<Profile> {
                 if (appName == null) {
                     throw new InvalidStructureException("No name defined for app dependency");
                 }
-                boolean force = Boolean.parseBoolean(parser.getAttributeValue(null, ATTR_FORCE));
-                appDependencies.add(new AppDependency(appId, appName, force));
+                appDependencies.add(new AppDependency(appId, appName));
             }
         }
         return appDependencies;

--- a/src/main/java/org/commcare/xml/ProfileParser.java
+++ b/src/main/java/org/commcare/xml/ProfileParser.java
@@ -5,7 +5,7 @@ package org.commcare.xml;
 
 import org.commcare.resources.model.Resource;
 import org.commcare.resources.model.ResourceTable;
-import org.commcare.suite.model.AppDependency;
+import org.commcare.suite.model.AndroidPackageDependency;
 import org.commcare.suite.model.Profile;
 import org.commcare.util.CommCarePlatform;
 import org.javarosa.core.reference.RootTranslator;
@@ -26,7 +26,7 @@ import java.util.Vector;
 public class ProfileParser extends ElementParser<Profile> {
 
     private static final String NAME_DEPENDENCIES = "dependencies";
-    private static final String NAME_APP = "app";
+    private static final String NAME_ANDROID_PACKAGE = "android_package";
     private static final String ATTR_ID = "id";
     private static final String ATTR_NAME = "name";
 
@@ -253,12 +253,12 @@ public class ProfileParser extends ElementParser<Profile> {
         }
     }
 
-    private Vector<AppDependency> parseDependencies()
+    private Vector<AndroidPackageDependency> parseDependencies()
             throws InvalidStructureException, XmlPullParserException, IOException {
-        Vector<AppDependency> appDependencies = new Vector<>();
+        Vector<AndroidPackageDependency> appDependencies = new Vector<>();
         while (nextTagInBlock(NAME_DEPENDENCIES)) {
             String tag = parser.getName().toLowerCase();
-            if (tag.equals(NAME_APP)) {
+            if (tag.equals(NAME_ANDROID_PACKAGE)) {
                 String appId = parser.getAttributeValue(null, ATTR_ID);
                 if (appId == null) {
                     throw new InvalidStructureException("No id defined for app dependency");
@@ -267,7 +267,7 @@ public class ProfileParser extends ElementParser<Profile> {
                 if (appName == null) {
                     throw new InvalidStructureException("No name defined for app dependency");
                 }
-                appDependencies.add(new AppDependency(appId, appName));
+                appDependencies.add(new AndroidPackageDependency(appId, appName));
             }
         }
         return appDependencies;

--- a/src/main/java/org/commcare/xml/ProfileParser.java
+++ b/src/main/java/org/commcare/xml/ProfileParser.java
@@ -28,6 +28,7 @@ public class ProfileParser extends ElementParser<Profile> {
     private static final String NAME_DEPENDENCIES = "dependencies";
     private static final String NAME_APP = "app";
     private static final String ATTR_ID = "id";
+    private static final String ATTR_NAME = "name";
     private static final String ATTR_FORCE = "force";
 
 
@@ -263,8 +264,12 @@ public class ProfileParser extends ElementParser<Profile> {
                 if (appId == null) {
                     throw new InvalidStructureException("No id defined for app dependency");
                 }
+                String appName = parser.getAttributeValue(null, ATTR_NAME);
+                if (appName == null) {
+                    throw new InvalidStructureException("No name defined for app dependency");
+                }
                 boolean force = Boolean.parseBoolean(parser.getAttributeValue(null, ATTR_FORCE));
-                appDependencies.add(new AppDependency(appId, force));
+                appDependencies.add(new AppDependency(appId, appName, force));
             }
         }
         return appDependencies;

--- a/src/main/java/org/commcare/xml/ProfileParser.java
+++ b/src/main/java/org/commcare/xml/ProfileParser.java
@@ -28,8 +28,6 @@ public class ProfileParser extends ElementParser<Profile> {
     private static final String NAME_DEPENDENCIES = "dependencies";
     private static final String NAME_ANDROID_PACKAGE = "android_package";
     private static final String ATTR_ID = "id";
-    private static final String ATTR_NAME = "name";
-
 
     ResourceTable table;
     String resourceId;
@@ -263,11 +261,7 @@ public class ProfileParser extends ElementParser<Profile> {
                 if (appId == null) {
                     throw new InvalidStructureException("No id defined for app dependency");
                 }
-                String appName = parser.getAttributeValue(null, ATTR_NAME);
-                if (appName == null) {
-                    throw new InvalidStructureException("No name defined for app dependency");
-                }
-                appDependencies.add(new AndroidPackageDependency(appId, appName));
+                appDependencies.add(new AndroidPackageDependency(appId));
             }
         }
         return appDependencies;

--- a/src/test/java/org/commcare/backend/suite/model/test/ProfileTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/ProfileTests.java
@@ -86,10 +86,9 @@ public class ProfileTests {
     public void testDependenciesParse() {
         Profile p = getProfile(BASIC_PROFILE_PATH);
         assertTrue(p.isFeatureActive("dependencies"));
-        AppDependency[] expectedDependencies = new AppDependency[3];
-        expectedDependencies[0] = new AppDependency("com.spotify.music", "Spotify", true);
-        expectedDependencies[1] = new AppDependency("org.commcare.reminders", "Reminders", false);
-        expectedDependencies[2] = new AppDependency("org.commcare.test", "Test", false);
+        AppDependency[] expectedDependencies = new AppDependency[2];
+        expectedDependencies[1] = new AppDependency("org.commcare.reminders", "Reminders");
+        expectedDependencies[2] = new AppDependency("org.commcare.test", "Test");
         assertEquals(Arrays.toString(expectedDependencies),Arrays.toString(p.getDependencies().toArray()));
     }
 

--- a/src/test/java/org/commcare/backend/suite/model/test/ProfileTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/ProfileTests.java
@@ -8,7 +8,7 @@ import static org.junit.Assert.fail;
 
 import org.commcare.resources.model.Resource;
 import org.commcare.resources.model.ResourceTable;
-import org.commcare.suite.model.AppDependency;
+import org.commcare.suite.model.AndroidPackageDependency;
 import org.commcare.suite.model.Profile;
 import org.commcare.test.utilities.PersistableSandbox;
 import org.commcare.util.engine.CommCareConfigEngine;
@@ -86,9 +86,9 @@ public class ProfileTests {
     public void testDependenciesParse() {
         Profile p = getProfile(BASIC_PROFILE_PATH);
         assertTrue(p.isFeatureActive("dependencies"));
-        AppDependency[] expectedDependencies = new AppDependency[2];
-        expectedDependencies[1] = new AppDependency("org.commcare.reminders", "Reminders");
-        expectedDependencies[2] = new AppDependency("org.commcare.test", "Test");
+        AndroidPackageDependency[] expectedDependencies = new AndroidPackageDependency[2];
+        expectedDependencies[0] = new AndroidPackageDependency("org.commcare.reminders", "Reminders");
+        expectedDependencies[1] = new AndroidPackageDependency("org.commcare.test", "Test");
         assertEquals(Arrays.toString(expectedDependencies),Arrays.toString(p.getDependencies().toArray()));
     }
 

--- a/src/test/java/org/commcare/backend/suite/model/test/ProfileTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/ProfileTests.java
@@ -87,8 +87,8 @@ public class ProfileTests {
         Profile p = getProfile(BASIC_PROFILE_PATH);
         assertTrue(p.isFeatureActive("dependencies"));
         AndroidPackageDependency[] expectedDependencies = new AndroidPackageDependency[2];
-        expectedDependencies[0] = new AndroidPackageDependency("org.commcare.reminders", "Reminders");
-        expectedDependencies[1] = new AndroidPackageDependency("org.commcare.test", "Test");
+        expectedDependencies[0] = new AndroidPackageDependency("org.commcare.reminders");
+        expectedDependencies[1] = new AndroidPackageDependency("org.commcare.test");
         assertEquals(Arrays.toString(expectedDependencies),Arrays.toString(p.getDependencies().toArray()));
     }
 

--- a/src/test/java/org/commcare/backend/suite/model/test/ProfileTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/ProfileTests.java
@@ -1,7 +1,14 @@
 package org.commcare.backend.suite.model.test;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.commcare.resources.model.Resource;
 import org.commcare.resources.model.ResourceTable;
+import org.commcare.suite.model.AppDependency;
 import org.commcare.suite.model.Profile;
 import org.commcare.test.utilities.PersistableSandbox;
 import org.commcare.util.engine.CommCareConfigEngine;
@@ -13,10 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.InputStream;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import java.util.Arrays;
 
 /**
  * Regressions and unit tests for the profile model.
@@ -76,6 +80,17 @@ public class ProfileTests {
         Profile p = getProfile(BASIC_PROFILE_PATH);
         assertNotNull("Profile uniqueId was null", p.getUniqueId());
         assertNotNull("Profile display name was null", p.getDisplayName());
+    }
+
+    @Test
+    public void testDependenciesParse() {
+        Profile p = getProfile(BASIC_PROFILE_PATH);
+        assertTrue(p.isFeatureActive("dependencies"));
+        AppDependency[] expectedDependencies = new AppDependency[3];
+        expectedDependencies[0] = new AppDependency("com.spotify.music", true);
+        expectedDependencies[1] = new AppDependency("org.commcare.reminders", false);
+        expectedDependencies[2] = new AppDependency("org.commcare.test", false);
+        assertEquals(Arrays.toString(expectedDependencies),Arrays.toString(p.getDependencies().toArray()));
     }
 
     private void compareProfiles(Profile a, Profile b) {

--- a/src/test/java/org/commcare/backend/suite/model/test/ProfileTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/ProfileTests.java
@@ -87,9 +87,9 @@ public class ProfileTests {
         Profile p = getProfile(BASIC_PROFILE_PATH);
         assertTrue(p.isFeatureActive("dependencies"));
         AppDependency[] expectedDependencies = new AppDependency[3];
-        expectedDependencies[0] = new AppDependency("com.spotify.music", true);
-        expectedDependencies[1] = new AppDependency("org.commcare.reminders", false);
-        expectedDependencies[2] = new AppDependency("org.commcare.test", false);
+        expectedDependencies[0] = new AppDependency("com.spotify.music", "Spotify", true);
+        expectedDependencies[1] = new AppDependency("org.commcare.reminders", "Reminders", false);
+        expectedDependencies[2] = new AppDependency("org.commcare.test", "Test", false);
         assertEquals(Arrays.toString(expectedDependencies),Arrays.toString(p.getDependencies().toArray()));
     }
 

--- a/src/test/resources/app_structure/profile.ccpr
+++ b/src/test/resources/app_structure/profile.ccpr
@@ -7,7 +7,6 @@
          name="trivial_test_resources"
          descriptor="Profile">
 
-
     <suite><resource id="suite" version="1">
             <location authority="local">./suite.xml</location>
     </resource></suite>

--- a/src/test/resources/basic_profile.ccpr
+++ b/src/test/resources/basic_profile.ccpr
@@ -85,6 +85,13 @@
         <users active="true">
             
         </users>
+
+        <dependencies active="true">
+            <app id ="com.spotify.music" force="true"/>
+            <app id ="org.commcare.reminders" force="false"/>
+            <app id ="org.commcare.test"/>
+        </dependencies>
+
     </features>
 
     <suite><resource id="suite" version="102">

--- a/src/test/resources/basic_profile.ccpr
+++ b/src/test/resources/basic_profile.ccpr
@@ -87,8 +87,8 @@
         </users>
 
         <dependencies active="true">
-            <android_package id="org.commcare.reminders" name="Reminders"/>
-            <android_package id="org.commcare.test" name="Test"/>
+            <android_package id="org.commcare.reminders"/>
+            <android_package id="org.commcare.test"/>
         </dependencies>
 
     </features>

--- a/src/test/resources/basic_profile.ccpr
+++ b/src/test/resources/basic_profile.ccpr
@@ -87,9 +87,9 @@
         </users>
 
         <dependencies active="true">
-            <app id ="com.spotify.music" force="true"/>
-            <app id ="org.commcare.reminders" force="false"/>
-            <app id ="org.commcare.test"/>
+            <app id="com.spotify.music" name="Spotify" force="true"/>
+            <app id="org.commcare.reminders" name="Reminders" force="false"/>
+            <app id="org.commcare.test" name="Test"/>
         </dependencies>
 
     </features>

--- a/src/test/resources/basic_profile.ccpr
+++ b/src/test/resources/basic_profile.ccpr
@@ -87,8 +87,7 @@
         </users>
 
         <dependencies active="true">
-            <app id="com.spotify.music" name="Spotify" force="true"/>
-            <app id="org.commcare.reminders" name="Reminders" force="false"/>
+            <app id="org.commcare.reminders" name="Reminders"/>
             <app id="org.commcare.test" name="Test"/>
         </dependencies>
 

--- a/src/test/resources/basic_profile.ccpr
+++ b/src/test/resources/basic_profile.ccpr
@@ -87,8 +87,8 @@
         </users>
 
         <dependencies active="true">
-            <app id="org.commcare.reminders" name="Reminders"/>
-            <app id="org.commcare.test" name="Test"/>
+            <android_package id="org.commcare.reminders" name="Reminders"/>
+            <android_package id="org.commcare.test" name="Test"/>
         </dependencies>
 
     </features>


### PR DESCRIPTION
Adds support for follwing definiton in profile file - 

````
<features>
        <dependencies active="true">
            <android_package id ="org.commcare.test" name=”Test”/>
            <android_package id ="org.commcare.reminders" name=”Reminders”/>
        </dependencies
</features>
````

Easier to review the PR as a whole. 

cross_request: https://github.com/dimagi/commcare-android/pull/2569