### PR TITLE
Added refresh of state before answering prompts

### DIFF
--- a/src/cli/java/org/commcare/util/screen/QueryScreen.java
+++ b/src/cli/java/org/commcare/util/screen/QueryScreen.java
@@ -191,6 +191,7 @@ public class QueryScreen extends Screen {
     }
 
     public void answerPrompts(Hashtable<String, String> answers) {
+        remoteQuerySessionManager.refreshInputDependentState();
         for (Enumeration en = userInputDisplays.keys(); en.hasMoreElements(); ) {
             String key = (String)en.nextElement();
             QueryPrompt queryPrompt = userInputDisplays.get(key);


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/QA-4390

~~PR into https://github.com/dimagi/commcare-core/pull/1139~~ not anymore, this was merged, so this is now a PR into formplayer

Marked `product/all-users` to please the label bot, but this is a feature flagged, bug fix that only affects case search