### PR TITLE
Fixes Dependent Itemsets Selection in Case search

### DIFF
--- a/src/cli/java/org/commcare/util/screen/QueryScreen.java
+++ b/src/cli/java/org/commcare/util/screen/QueryScreen.java
@@ -199,6 +199,7 @@ public class QueryScreen extends Screen {
             // If select question, we should have got an index as the answer which should
             // be converted to the corresponding value
             if (queryPrompt.isSelect() && !StringUtils.isEmpty(answer)) {
+                remoteQuerySessionManager.populateItemSetChoices(queryPrompt);
                 Vector<SelectChoice> selectChoices = queryPrompt.getItemsetBinding().getChoices();
                 String[] indicesOfSelectedChoices = RemoteQuerySessionManager.extractMultipleChoices(answer);
                 ArrayList<String> selectedChoices = new ArrayList<>(indicesOfSelectedChoices.length);


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/USH-2267

Issue was that we were doing the [selection index to itemset choice conversion](https://github.com/dimagi/commcare-core/blob/formplayer/src/cli/java/org/commcare/util/screen/QueryScreen.java#L202-L216) before updating the itemset choices for the select prompt. This caused the selection to not be valid for the new inputs and ultimately removed in [refreshItemSetChoices](https://github.com/dimagi/commcare-core/blob/formplayer/src/main/java/org/commcare/session/RemoteQuerySessionManager.java#L232)

This PR surfaces(not a regression) another funny behaviour which is ticketed [here](https://dimagi-dev.atlassian.net/browse/USH-2289)


https://github.com/dimagi/formplayer/pull/1195