### PR TITLE
separate cache class for local caches

### DIFF
--- a/src/main/java/org/commcare/core/process/CommCareInstanceInitializer.java
+++ b/src/main/java/org/commcare/core/process/CommCareInstanceInitializer.java
@@ -24,7 +24,7 @@ import org.javarosa.core.model.instance.InstanceRoot;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.services.storage.IStorageUtilityIndexed;
-import org.javarosa.core.util.CacheTable;
+import org.javarosa.core.util.LocalCacheTable;
 
 import javax.annotation.Nonnull;
 
@@ -40,7 +40,7 @@ public class CommCareInstanceInitializer extends InstanceInitializationFactory {
     protected final CommCareSession session;
     protected CaseInstanceTreeElement casebase;
     protected LedgerInstanceTreeElement stockbase;
-    private final CacheTable<String, TreeElement> fixtureBases = new CacheTable<>();
+    private final LocalCacheTable<String, TreeElement> fixtureBases = new LocalCacheTable<>();
     protected final UserSandbox mSandbox;
     protected final CommCarePlatform mPlatform;
 

--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -30,7 +30,7 @@ import org.javarosa.core.model.util.restorable.RestoreUtils;
 import org.javarosa.core.model.utils.ItemSetUtils;
 import org.javarosa.core.services.locale.Localizer;
 import org.javarosa.core.services.storage.IMetaData;
-import org.javarosa.core.util.CacheTable;
+import org.javarosa.core.util.LocalCacheTable;
 import org.javarosa.core.util.DataUtil;
 import org.javarosa.core.util.ShortestCycleAlgorithm;
 import org.javarosa.core.util.externalizable.DeserializationException;
@@ -150,8 +150,8 @@ public class FormDef implements IFormElement, IMetaData,
      * calculations that determine what needs to be triggered when a value
      * changes.
      */
-    private final CacheTable<TreeReference, ArrayList<TreeReference>> cachedCascadingChildren =
-            new CacheTable<>();
+    private final LocalCacheTable<TreeReference, ArrayList<TreeReference>> cachedCascadingChildren =
+            new LocalCacheTable<>();
 
     public FormDef() {
         this(false);

--- a/src/main/java/org/javarosa/core/model/instance/DataInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/DataInstance.java
@@ -6,7 +6,7 @@ import org.commcare.cases.util.QueryUtils;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.utils.CacheHost;
 import org.javarosa.core.services.storage.Persistable;
-import org.javarosa.core.util.CacheTable;
+import org.javarosa.core.util.LocalCacheTable;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.ExtWrapNullable;
@@ -46,15 +46,13 @@ public abstract class DataInstance<T extends AbstractTreeElement<T>> implements 
 
     protected CacheHost mCacheHost;
 
-    private final CacheTable<TreeReference, T> referenceCache;
+    private final LocalCacheTable<TreeReference, T> referenceCache = new LocalCacheTable<>();
 
     public DataInstance() {
-        referenceCache = new CacheTable<>();
     }
 
     public DataInstance(String instanceid) {
         this.instanceid = instanceid;
-        referenceCache = new CacheTable<>();
     }
 
     public static TreeReference unpackReference(XPathReference ref) {

--- a/src/main/java/org/javarosa/core/util/LocalCacheTable.java
+++ b/src/main/java/org/javarosa/core/util/LocalCacheTable.java
@@ -1,0 +1,44 @@
+package org.javarosa.core.util;
+
+import java.lang.ref.WeakReference;
+import java.util.Enumeration;
+import java.util.Hashtable;
+import java.util.Vector;
+
+/**
+ * A Local Cache Table is a weak reference store that can be used
+ * to maintain a cache of objects keyed by a dynamic type.
+ *
+ * Local Cache Tables should be used for non-global caches. For global caches
+ * use {@link CacheTable}.
+ */
+public class LocalCacheTable<T, K> {
+    private Hashtable<T, WeakReference> currentTable = new Hashtable<>();
+
+    public LocalCacheTable() {
+    }
+
+
+    public K retrieve(T key) {
+        synchronized (this) {
+            if (!currentTable.containsKey(key)) {
+                return null;
+            }
+            K retVal = (K)currentTable.get(key).get();
+            if (retVal == null) {
+                currentTable.remove(key);
+            }
+            return retVal;
+        }
+    }
+
+    public void register(T key, K item) {
+        synchronized (this) {
+            currentTable.put(key, new WeakReference(item));
+        }
+    }
+
+    public void clear(){
+        currentTable.clear();
+    }
+}


### PR DESCRIPTION
This change is an effort to reduce the likelihood of having threads block on global objects (in this case the `CacheTable.caches` object.

In places that do not use global caches it seems unnecessary to have the registered in a global registry and have cache cleanup thread attempt to clear it out. This adds a `LocalCacheTable` class which is identical to `CacheTable` but without the global registry and cleanup thread.

I also see that there is an `Intern` class which extends `CacheTable` and could like benefit from the same approach.

It also occurs to me that we could use a cache from a library like Guava: https://github.com/google/guava/wiki/CachesExplained#reference-based-eviction (we cannot use Caffeine since it does not support Android).