### PR TITLE
QueryScreen.init title translation change for Master

### DIFF
--- a/src/cli/java/org/commcare/util/screen/QueryScreen.java
+++ b/src/cli/java/org/commcare/util/screen/QueryScreen.java
@@ -4,6 +4,7 @@ import org.commcare.modern.session.SessionWrapper;
 import org.commcare.modern.util.Pair;
 import org.commcare.session.CommCareSession;
 import org.commcare.session.RemoteQuerySessionManager;
+import org.commcare.suite.model.RemoteQueryDatum;
 import org.commcare.suite.model.QueryPrompt;
 import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.instance.ExternalDataInstance;
@@ -165,6 +166,10 @@ public class QueryScreen extends Screen {
         if (dataInstance != null) {
             sessionWrapper.setQueryDatum(dataInstance);
         }
+    }
+
+    public RemoteQueryDatum getQueryDatum() {
+        return remoteQuerySessionManager.getQueryDatum();
     }
 
     public ExternalDataInstance buildExternalDataInstance(TreeElement root) {

--- a/src/cli/java/org/commcare/util/screen/QueryScreen.java
+++ b/src/cli/java/org/commcare/util/screen/QueryScreen.java
@@ -77,12 +77,26 @@ public class QueryScreen extends Screen {
         for (Map.Entry<String, QueryPrompt> queryPromptEntry : userInputDisplays.entrySet()) {
             fields[count] = queryPromptEntry.getValue().getDisplay().getText().evaluate(sessionWrapper.getEvaluationContext());
         }
+        
+        mTitle = getTitleLocaleString();
+    }
 
+    private String getTitleLocaleString() {
+        try {
+            mTitle = getQueryDatum().getTitleText().evaluate();
+        } catch (NoLocalizedTextException | NullPointerException e) {
+            mTitle = getTitleLocaleStringLegacy();
+        }
+        return mTitle;
+    }
+
+    private String getTitleLocaleStringLegacy() {
         try {
             mTitle = Localization.get("case.search.title");
-        } catch (NoLocalizedTextException nlte) {
+        } catch (NoLocalizedTextException | NullPointerException e) {
             mTitle = "Case Claim";
         }
+        return mTitle;  
     }
 
     // Formplayer List of Supported prompts

--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -87,6 +87,10 @@ public class RemoteQuerySessionManager {
         }
     }
 
+    public RemoteQueryDatum getQueryDatum() {
+        return queryDatum;
+    }
+
     public OrderedHashtable<String, QueryPrompt> getNeededUserInputDisplays() {
         return queryDatum.getUserQueryPrompts();
     }

--- a/src/main/java/org/commcare/suite/model/RemoteQueryDatum.java
+++ b/src/main/java/org/commcare/suite/model/RemoteQueryDatum.java
@@ -6,6 +6,7 @@ import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.ExtWrapMap;
 import org.javarosa.core.util.externalizable.ExtWrapMapPoly;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.javarosa.core.util.externalizable.ExtWrapNullable;
 import org.javarosa.xpath.expr.XPathExpression;
 
 import java.io.DataInputStream;
@@ -26,6 +27,7 @@ public class RemoteQueryDatum extends SessionDatum {
     private OrderedHashtable<String, QueryPrompt> userQueryPrompts;
     private boolean useCaseTemplate;
     private boolean defaultSearch;
+    private Text title;
 
     @SuppressWarnings("unused")
     public RemoteQueryDatum() {
@@ -39,12 +41,13 @@ public class RemoteQueryDatum extends SessionDatum {
     public RemoteQueryDatum(URL url, String storageInstance,
                             Hashtable<String, XPathExpression> hiddenQueryValues,
                             OrderedHashtable<String, QueryPrompt> userQueryPrompts,
-                            boolean useCaseTemplate, boolean defaultSearch) {
+                            boolean useCaseTemplate, boolean defaultSearch, Text title) {
         super(storageInstance, url.toString());
         this.hiddenQueryValues = hiddenQueryValues;
         this.userQueryPrompts = userQueryPrompts;
         this.useCaseTemplate = useCaseTemplate;
         this.defaultSearch = defaultSearch;
+        this.title = title;
     }
 
     public OrderedHashtable<String, QueryPrompt> getUserQueryPrompts() {
@@ -53,6 +56,10 @@ public class RemoteQueryDatum extends SessionDatum {
 
     public Hashtable<String, XPathExpression> getHiddenQueryValues() {
         return hiddenQueryValues;
+    }
+
+    public Text getTitleText() {
+        return title;
     }
 
     public URL getUrl() {
@@ -83,6 +90,7 @@ public class RemoteQueryDatum extends SessionDatum {
         userQueryPrompts =
                 (OrderedHashtable<String, QueryPrompt>)ExtUtil.read(in,
                         new ExtWrapMap(String.class, QueryPrompt.class, ExtWrapMap.TYPE_ORDERED), pf);
+        title = (Text) ExtUtil.read(in, new ExtWrapNullable(Text.class), pf);
         useCaseTemplate = ExtUtil.readBool(in);
         defaultSearch = ExtUtil.readBool(in);
     }
@@ -93,6 +101,7 @@ public class RemoteQueryDatum extends SessionDatum {
 
         ExtUtil.write(out, new ExtWrapMapPoly(hiddenQueryValues));
         ExtUtil.write(out, new ExtWrapMap(userQueryPrompts));
+        ExtUtil.write(out, new ExtWrapNullable(title));
         ExtUtil.writeBool(out, useCaseTemplate);
         ExtUtil.writeBool(out, defaultSearch);
     }

--- a/src/main/java/org/commcare/suite/model/RemoteQueryDatum.java
+++ b/src/main/java/org/commcare/suite/model/RemoteQueryDatum.java
@@ -5,8 +5,8 @@ import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.ExtWrapMap;
 import org.javarosa.core.util.externalizable.ExtWrapMapPoly;
-import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.core.util.externalizable.ExtWrapNullable;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.xpath.expr.XPathExpression;
 
 import java.io.DataInputStream;

--- a/src/main/java/org/commcare/xml/SessionDatumParser.java
+++ b/src/main/java/org/commcare/xml/SessionDatumParser.java
@@ -7,6 +7,7 @@ import org.commcare.suite.model.FormIdDatum;
 import org.commcare.suite.model.QueryPrompt;
 import org.commcare.suite.model.RemoteQueryDatum;
 import org.commcare.suite.model.SessionDatum;
+import org.commcare.suite.model.Text;
 import org.javarosa.core.util.OrderedHashtable;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
@@ -102,6 +103,7 @@ public class SessionDatumParser extends CommCareElementParser<SessionDatum> {
         }
 
         boolean defaultSearch = "true".equals(parser.getAttributeValue(null, "default_search"));
+        Text title = null;
 
         while (nextTagInBlock("query")) {
             String tagName = parser.getName();
@@ -117,10 +119,13 @@ public class SessionDatumParser extends CommCareElementParser<SessionDatum> {
             } else if ("prompt".equals(tagName)) {
                 String key = parser.getAttributeValue(null, "key");
                 userQueryPrompts.put(key, new QueryPromptParser(parser).parse());
+            } else if ("title".equals(tagName)) {
+                nextTagInBlock("title");
+                title = new TextParser(parser).parse();
             }
         }
 
         return new RemoteQueryDatum(queryUrl, queryResultStorageInstance,
-                hiddenQueryValues, userQueryPrompts, useCaseTemplate, defaultSearch);
+                hiddenQueryValues, userQueryPrompts, useCaseTemplate, defaultSearch, title);
     }
 }

--- a/src/test/java/org/commcare/xml/ParserTestUtils.java
+++ b/src/test/java/org/commcare/xml/ParserTestUtils.java
@@ -1,0 +1,35 @@
+package org.commcare.xml;
+
+import org.javarosa.xml.ElementParser;
+import org.kxml2.io.KXmlParser;
+
+import java.io.ByteArrayInputStream;
+import java.lang.reflect.Constructor;
+import java.util.function.Function;
+
+/**
+ * Helper functions for building parsers
+ */
+public class ParserTestUtils {
+
+    public static <T extends CommCareElementParser> T buildParser(String xml, Class<T> parserClass) {
+        return buildParser(xml, (xmlParser) -> {
+            try {
+                Constructor<T> constructor = parserClass.getConstructor(KXmlParser.class);
+                return constructor.newInstance(xmlParser);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    public static <T extends CommCareElementParser> T buildParser(String xml, Function<KXmlParser, T> builder) {
+        try {
+            ByteArrayInputStream inputStream = new ByteArrayInputStream(xml.getBytes("UTF-8"));
+            KXmlParser parser = ElementParser.instantiateParser(inputStream);
+            return builder.apply(parser);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/org/commcare/xml/SessionDatumParserTest.java
+++ b/src/test/java/org/commcare/xml/SessionDatumParserTest.java
@@ -3,17 +3,17 @@ package org.commcare.xml;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import org.commcare.suite.model.RemoteQueryDatum;
 import org.commcare.suite.model.Text;
+import org.commcare.suite.model.RemoteQueryDatum;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
+import org.javarosa.xpath.expr.XPathExpression;
 import org.junit.Test;
 import org.xmlpull.v1.XmlPullParserException;
-import org.javarosa.xpath.expr.XPathExpression;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Hashtable;
+import java.util.List;
 
 /**
  * Low level tests for session parsing

--- a/src/test/java/org/commcare/xml/SessionDatumParserTest.java
+++ b/src/test/java/org/commcare/xml/SessionDatumParserTest.java
@@ -3,8 +3,8 @@ package org.commcare.xml;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import org.commcare.suite.model.Text;
 import org.commcare.suite.model.RemoteQueryDatum;
+import org.commcare.suite.model.Text;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
 import org.javarosa.xpath.expr.XPathExpression;

--- a/src/test/java/org/commcare/xml/SessionDatumParserTest.java
+++ b/src/test/java/org/commcare/xml/SessionDatumParserTest.java
@@ -1,0 +1,59 @@
+package org.commcare.xml;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.commcare.suite.model.RemoteQueryDatum;
+import org.commcare.suite.model.Text;
+import org.javarosa.xml.util.InvalidStructureException;
+import org.javarosa.xml.util.UnfullfilledRequirementsException;
+import org.junit.Test;
+import org.xmlpull.v1.XmlPullParserException;
+import org.javarosa.xpath.expr.XPathExpression;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Hashtable;
+
+/**
+ * Low level tests for session parsing
+ */
+public class SessionDatumParserTest {
+
+    @Test
+    public void testSessionDatumParser()
+            throws UnfullfilledRequirementsException, InvalidStructureException, XmlPullParserException,
+            IOException {
+        String query = "<query url=\"https://www.fake.com/patient_search/\" storage-instance=\"patients\">"
+                + "<data key=\"device_id\" ref=\"instance('session')/session/context/deviceid\"/>"
+                + "</query>";
+        SessionDatumParser parser = ParserTestUtils.buildParser(query, SessionDatumParser.class);
+        RemoteQueryDatum datum = (RemoteQueryDatum) parser.parse();
+        Hashtable<String, XPathExpression> hiddenQueryValues = datum.getHiddenQueryValues();
+
+        assertEquals(1, hiddenQueryValues.size());
+        assertTrue(hiddenQueryValues.containsKey("device_id"));
+    }
+
+    @Test
+    public void testSessionDatumParser__withTitle()
+            throws UnfullfilledRequirementsException, InvalidStructureException, XmlPullParserException,
+            IOException {
+        String query = "<query url=\"https://www.fake.com/patient_search/\" storage-instance=\"patients\">"
+                + "<title>"
+                + "<text>"
+                + "<locale id=\"locale_id\"/>"
+                + "</text>"
+                + "</title>"
+                + "<data key=\"device_id\" ref=\"instance('session')/session/context/deviceid\"/>"
+                + "</query>";
+        SessionDatumParser parser = ParserTestUtils.buildParser(query, SessionDatumParser.class);
+        RemoteQueryDatum datum = (RemoteQueryDatum) parser.parse();
+        String title = datum.getTitleText().getArgument();
+        Hashtable<String, XPathExpression> hiddenQueryValues = datum.getHiddenQueryValues();
+
+        assertEquals(1, hiddenQueryValues.size());
+        assertTrue(hiddenQueryValues.containsKey("device_id"));
+        assertEquals("locale_id", title);
+    }
+}


### PR DESCRIPTION
## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
[Jira](https://dimagi-dev.atlassian.net/browse/USH-2271)

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
This code change is limited to the query screen code. There is logic to handle errors such that it defaults to the original behavior. 

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.
-


and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->
This is the follow up to the formplayer PR [here](https://github.com/dimagi/commcare-core/pull/1110)

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
