### PR TITLE
Adds support for auto selecting multiple cases at once 

### DIFF
--- a/src/cli/java/org/commcare/util/exception/InvalidEntitiesSelectionException.java
+++ b/src/cli/java/org/commcare/util/exception/InvalidEntitiesSelectionException.java
@@ -1,0 +1,11 @@
+package org.commcare.util.exception;
+
+/**
+ * Exception raised on making any invalid selections on the entity screens
+ */
+public class InvalidEntitiesSelectionException extends RuntimeException {
+
+    public InvalidEntitiesSelectionException(String message) {
+        super(message);
+    }
+}

--- a/src/cli/java/org/commcare/util/screen/EntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreen.java
@@ -142,9 +142,7 @@ public class EntityScreen extends CompoundScreenHost {
             evalContext.addFunctionHandler(new ScreenUtils.HereDummyFunc(-23.56, -46.66));
 
             if (shouldAutoSelect()) {
-                autoSelectEntities();
                 if (!this.setCurrentScreenToDetail()) {
-                    this.updateSession(session);
                     readyToSkip = true;
                 }
             } else {
@@ -159,8 +157,16 @@ public class EntityScreen extends CompoundScreenHost {
         return mNeededDatum.isAutoSelectEnabled() && references.size() == 1;
     }
 
-    protected void autoSelectEntities() {
+    /**
+     * Auto selects entities for the screen and advances the session
+     * @param session Current CommCare Session
+     * @throws CommCareSessionException
+     */
+    public void autoSelectEntities(SessionWrapper session) throws CommCareSessionException {
         this.setSelectedEntity(references.firstElement());
+        if (!setCurrentScreenToDetail()) {
+            updateSession(session);
+        }
     }
 
     protected void setSession(SessionWrapper session) throws CommCareSessionException {

--- a/src/cli/java/org/commcare/util/screen/EntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreen.java
@@ -162,8 +162,9 @@ public class EntityScreen extends CompoundScreenHost {
 
     /**
      * Auto selects entities for the screen and advances the session
+     *
      * @param session Current CommCare Session
-     * @throws CommCareSessionException
+     * @throws CommCareSessionException errors while auto selecting entities
      */
     public void autoSelectEntities(SessionWrapper session) throws CommCareSessionException {
         this.setSelectedEntity(references.firstElement());

--- a/src/cli/java/org/commcare/util/screen/EntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreen.java
@@ -309,6 +309,10 @@ public class EntityScreen extends CompoundScreenHost {
     }
 
     private boolean setCurrentScreenToDetail() throws CommCareSessionException {
+        if (mCurrentSelection == null) {
+            return false;
+        }
+
         Detail[] longDetailList = getLongDetailList(mCurrentSelection);
         if (longDetailList == null) {
             return false;

--- a/src/cli/java/org/commcare/util/screen/EntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreen.java
@@ -164,13 +164,16 @@ public class EntityScreen extends CompoundScreenHost {
      * Auto selects entities for the screen and advances the session
      *
      * @param session Current CommCare Session
+     * @return whether the session was advanced by this call
      * @throws CommCareSessionException errors while auto selecting entities
      */
-    public void autoSelectEntities(SessionWrapper session) throws CommCareSessionException {
+    public boolean autoSelectEntities(SessionWrapper session) throws CommCareSessionException {
         this.setSelectedEntity(references.firstElement());
         if (!setCurrentScreenToDetail()) {
             updateSession(session);
+            return true;
         }
+        return false;
     }
 
     protected void setSession(SessionWrapper session) throws CommCareSessionException {

--- a/src/cli/java/org/commcare/util/screen/EntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreen.java
@@ -58,7 +58,7 @@ public class EntityScreen extends CompoundScreenHost {
     private boolean needsFullInit = true;
     private boolean isDetailScreen = false;
 
-    private Vector<TreeReference> references;
+    protected Vector<TreeReference> references;
 
     private boolean initialized = false;
     private Action autoLaunchAction;
@@ -130,7 +130,7 @@ public class EntityScreen extends CompoundScreenHost {
 
         evalContext.setQueryContext(newContext);
 
-        if (needsFullInit || references.size() == 1) {
+        if (needsFullInit || references.size() == 1 || shouldAutoSelect()) {
             referenceMap = new Hashtable<>();
             EntityDatum needed = (EntityDatum)session.getNeededDatum();
             for (TreeReference reference : references) {
@@ -141,8 +141,8 @@ public class EntityScreen extends CompoundScreenHost {
             // setting
             evalContext.addFunctionHandler(new ScreenUtils.HereDummyFunc(-23.56, -46.66));
 
-            if (mNeededDatum.isAutoSelectEnabled() && references.size() == 1) {
-                this.setSelectedEntity(references.firstElement());
+            if (shouldAutoSelect()) {
+                autoSelectEntities();
                 if (!this.setCurrentScreenToDetail()) {
                     this.updateSession(session);
                     readyToSkip = true;
@@ -153,6 +153,14 @@ public class EntityScreen extends CompoundScreenHost {
             }
         }
         initialized = true;
+    }
+
+    protected boolean shouldAutoSelect() {
+        return mNeededDatum.isAutoSelectEnabled() && references.size() == 1;
+    }
+
+    protected void autoSelectEntities() {
+        this.setSelectedEntity(references.firstElement());
     }
 
     protected void setSession(SessionWrapper session) throws CommCareSessionException {

--- a/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
@@ -101,7 +101,7 @@ public class MultiSelectEntityScreen extends EntityScreen {
             return Localization.get("case.list.max.selection.error",
                     new String[]{String.valueOf(selectionSize), String.valueOf(maxSelectValue)});
         } catch (NoLocalizedTextException | NullPointerException e) {
-            return String.format("Number of selected cases %d is greater than the maximum limit of %d",
+            return String.format("Too many cases(%d) to proceed. Only %d are allowed",
                     selectionSize, maxSelectValue);
         }
     }

--- a/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
@@ -133,16 +133,18 @@ public class MultiSelectEntityScreen extends EntityScreen {
     }
 
     private void processSelectedReferences(TreeReference[] selectedRefs) {
-        String[] evaluatedValues = new String[selectedRefs.length];
-        for (int i = 0; i < selectedRefs.length; i++) {
-            evaluatedValues[i] = getReturnValueFromSelection(selectedRefs[i]);
+        if (validateSelectionSize(selectedRefs.length)) {
+            String[] evaluatedValues = new String[selectedRefs.length];
+            for (int i = 0; i < selectedRefs.length; i++) {
+                evaluatedValues[i] = getReturnValueFromSelection(selectedRefs[i]);
+            }
+            processSelectionIntoInstance(evaluatedValues);
         }
-        processSelectionIntoInstance(evaluatedValues);
     }
 
     private void processSelectedValues(String[] selectedValues)
             throws CommCareSessionException {
-        if (selectedValues != null) {
+        if (selectedValues != null && validateSelectionSize(selectedValues.length)) {
             String[] evaluatedValues = new String[selectedValues.length];
             for (int i = 0; i < selectedValues.length; i++) {
                 TreeReference currentReference = getEntityReference(selectedValues[i]);

--- a/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
@@ -90,7 +90,7 @@ public class MultiSelectEntityScreen extends EntityScreen {
 
     private String getMaxSelectError(int selectionSize) {
         try {
-            return Localization.get("max.entity.selection.error",
+            return Localization.get("case.list.max.selection.error",
                     new String[]{String.valueOf(selectionSize), String.valueOf(maxSelectValue)});
         } catch (NoLocalizedTextException | NullPointerException e) {
             return String.format("Number of selected cases %d is greater than the maximum limit of %d",
@@ -100,7 +100,7 @@ public class MultiSelectEntityScreen extends EntityScreen {
 
     private String getNoEntitiesError() {
         try {
-            return Localization.get("no.entity.selection.error");
+            return Localization.get("case.list.no.selection.error");
         } catch (NoLocalizedTextException | NullPointerException e) {
             return String.format("No cases found");
         }

--- a/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
@@ -71,7 +71,7 @@ public class MultiSelectEntityScreen extends EntityScreen {
     }
 
     @Override
-    protected void autoSelectEntities() {
+    public void autoSelectEntities(SessionWrapper session) throws CommCareSessionException {
         int selectionSize = references.size();
         if (selectionSize == 0) {
             throw new RuntimeException(getNoEntitiesError());
@@ -84,6 +84,8 @@ public class MultiSelectEntityScreen extends EntityScreen {
             }
             processSelectionIntoInstance(evaluatedValues);
         }
+
+        updateSession(session);
     }
 
     private String getMaxSelectError(int selectionSize) {

--- a/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
@@ -29,7 +29,8 @@ import javax.annotation.Nullable;
 public class MultiSelectEntityScreen extends EntityScreen {
 
     public static final String USE_SELECTED_VALUES = "use_selected_values";
-    private int maxSelectValue = -1;
+    private static final int DEFAULT_MAX_SELECT_VAL = 100;
+    private int maxSelectValue = DEFAULT_MAX_SELECT_VAL;
 
     private final VirtualDataInstanceStorage virtualDataInstanceStorage;
     private String storageReferenceId;

--- a/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
@@ -73,7 +73,7 @@ public class MultiSelectEntityScreen extends EntityScreen {
     }
 
     @Override
-    public void autoSelectEntities(SessionWrapper session) {
+    public boolean autoSelectEntities(SessionWrapper session) {
         int selectionSize = references.size();
         if (validateSelectionSize(selectionSize)) {
             String[] evaluatedValues = new String[selectionSize];
@@ -82,7 +82,9 @@ public class MultiSelectEntityScreen extends EntityScreen {
             }
             processSelectionIntoInstance(evaluatedValues);
             updateSession(session);
+            return true;
         }
+        return false;
     }
 
     private boolean validateSelectionSize(int selectionSize) {

--- a/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
@@ -11,6 +11,7 @@ import org.commcare.modern.session.SessionWrapper;
 import org.commcare.session.CommCareSession;
 import org.commcare.suite.model.MultiSelectEntityDatum;
 import org.commcare.util.FormDataUtil;
+import org.commcare.util.exception.InvalidEntitiesSelectionException;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.AbstractTreeElement;
 import org.javarosa.core.model.instance.ExternalDataInstance;
@@ -74,9 +75,9 @@ public class MultiSelectEntityScreen extends EntityScreen {
     public void autoSelectEntities(SessionWrapper session) throws CommCareSessionException {
         int selectionSize = references.size();
         if (selectionSize == 0) {
-            throw new RuntimeException(getNoEntitiesError());
+            throw new InvalidEntitiesSelectionException(getNoEntitiesError());
         } else if (selectionSize > maxSelectValue) {
-            throw new RuntimeException(getMaxSelectError(selectionSize));
+            throw new InvalidEntitiesSelectionException(getMaxSelectError(selectionSize));
         } else {
             String[] evaluatedValues = new String[selectionSize];
             for (int i = 0; i < selectionSize; i++) {

--- a/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
@@ -16,6 +16,8 @@ import org.javarosa.core.model.instance.AbstractTreeElement;
 import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.ExternalDataInstanceSource;
 import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.core.services.locale.Localization;
+import org.javarosa.core.util.NoLocalizedTextException;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -60,6 +62,45 @@ public class MultiSelectEntityScreen extends EntityScreen {
             processSelectedReferences(selectedRefs);
         } else {
             prcessSelectionAsGuid(input);
+        }
+    }
+
+    @Override
+    protected boolean shouldAutoSelect() {
+        return mNeededDatum.isAutoSelectEnabled();
+    }
+
+    @Override
+    protected void autoSelectEntities() {
+        int selectionSize = references.size();
+        if (selectionSize == 0) {
+            throw new RuntimeException(getNoEntitiesError());
+        } else if (selectionSize > maxSelectValue) {
+            throw new RuntimeException(getMaxSelectError(selectionSize));
+        } else {
+            String[] evaluatedValues = new String[selectionSize];
+            for (int i = 0; i < selectionSize; i++) {
+                evaluatedValues[i] = getReturnValueFromSelection(references.elementAt(i));
+            }
+            processSelectionIntoInstance(evaluatedValues);
+        }
+    }
+
+    private String getMaxSelectError(int selectionSize) {
+        try {
+            return Localization.get("max.entity.selection.error",
+                    new String[]{String.valueOf(selectionSize), String.valueOf(maxSelectValue)});
+        } catch (NoLocalizedTextException | NullPointerException e) {
+            return String.format("Number of selected cases %d is greater than the maximum limit of %d",
+                    selectionSize, maxSelectValue);
+        }
+    }
+
+    private String getNoEntitiesError() {
+        try {
+            return Localization.get("no.entity.selection.error");
+        } catch (NoLocalizedTextException | NullPointerException e) {
+            return String.format("No cases found");
         }
     }
 

--- a/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
@@ -73,21 +73,25 @@ public class MultiSelectEntityScreen extends EntityScreen {
     }
 
     @Override
-    public void autoSelectEntities(SessionWrapper session) throws CommCareSessionException {
+    public void autoSelectEntities(SessionWrapper session) {
         int selectionSize = references.size();
-        if (selectionSize == 0) {
-            throw new InvalidEntitiesSelectionException(getNoEntitiesError());
-        } else if (selectionSize > maxSelectValue) {
-            throw new InvalidEntitiesSelectionException(getMaxSelectError(selectionSize));
-        } else {
+        if (validateSelectionSize(selectionSize)) {
             String[] evaluatedValues = new String[selectionSize];
             for (int i = 0; i < selectionSize; i++) {
                 evaluatedValues[i] = getReturnValueFromSelection(references.elementAt(i));
             }
             processSelectionIntoInstance(evaluatedValues);
         }
-
         updateSession(session);
+    }
+
+    private boolean validateSelectionSize(int selectionSize) {
+        if (selectionSize == 0) {
+            throw new InvalidEntitiesSelectionException(getNoEntitiesError());
+        } else if (selectionSize > maxSelectValue) {
+            throw new InvalidEntitiesSelectionException(getMaxSelectError(selectionSize));
+        }
+        return true;
     }
 
     private String getMaxSelectError(int selectionSize) {

--- a/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
@@ -81,8 +81,8 @@ public class MultiSelectEntityScreen extends EntityScreen {
                 evaluatedValues[i] = getReturnValueFromSelection(references.elementAt(i));
             }
             processSelectionIntoInstance(evaluatedValues);
+            updateSession(session);
         }
-        updateSession(session);
     }
 
     private boolean validateSelectionSize(int selectionSize) {

--- a/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
@@ -97,13 +97,24 @@ public class MultiSelectEntityScreen extends EntityScreen {
     }
 
     private String getMaxSelectError(int selectionSize) {
+        String error;
         try {
-            return Localization.get("case.list.max.selection.error",
-                    new String[]{String.valueOf(selectionSize), String.valueOf(maxSelectValue)});
+            if (maxSelectValue == 1) {
+                error = Localization.get("case.list.max.selection.error.singular",
+                        new String[]{String.valueOf(selectionSize)});
+            } else {
+                error = Localization.get("case.list.max.selection.error",
+                        new String[]{String.valueOf(selectionSize), String.valueOf(maxSelectValue)});
+            }
         } catch (NoLocalizedTextException | NullPointerException e) {
-            return String.format("Too many cases(%d) to proceed. Only %d are allowed",
-                    selectionSize, maxSelectValue);
+            if (maxSelectValue == 1) {
+                error = String.format("Too many cases(%d) to proceed. Only 1 is allowed", selectionSize);
+            } else {
+                error = String.format("Too many cases(%d) to proceed. Only %d are allowed",
+                        selectionSize, maxSelectValue);
+            }
         }
+        return error;
     }
 
     private String getNoEntitiesError() {

--- a/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
@@ -1,6 +1,7 @@
 package org.commcare.util.screen;
 
 import static org.commcare.session.SessionFrame.STATE_MULTIPLE_DATUM_VAL;
+import static org.commcare.xml.SessionDatumParser.DEFAULT_MAX_SELECT_VAL;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -29,7 +30,6 @@ import javax.annotation.Nullable;
 public class MultiSelectEntityScreen extends EntityScreen {
 
     public static final String USE_SELECTED_VALUES = "use_selected_values";
-    private static final int DEFAULT_MAX_SELECT_VAL = 100;
     private int maxSelectValue = DEFAULT_MAX_SELECT_VAL;
 
     private final VirtualDataInstanceStorage virtualDataInstanceStorage;

--- a/src/main/java/org/commcare/suite/model/MultiSelectEntityDatum.java
+++ b/src/main/java/org/commcare/suite/model/MultiSelectEntityDatum.java
@@ -1,5 +1,7 @@
 package org.commcare.suite.model;
 
+import static org.commcare.xml.SessionDatumParser.DEFAULT_MAX_SELECT_VAL;
+
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
@@ -13,7 +15,7 @@ import java.io.IOException;
  */
 public class MultiSelectEntityDatum extends EntityDatum {
 
-    private int maxSelectValue = -1;
+    private int maxSelectValue = DEFAULT_MAX_SELECT_VAL;
 
     @SuppressWarnings("unused")
     public MultiSelectEntityDatum() {

--- a/src/main/java/org/commcare/xml/SessionDatumParser.java
+++ b/src/main/java/org/commcare/xml/SessionDatumParser.java
@@ -26,6 +26,8 @@ import java.util.ArrayList;
  */
 public class SessionDatumParser extends CommCareElementParser<SessionDatum> {
 
+    public static final int DEFAULT_MAX_SELECT_VAL = 100;
+
     public SessionDatumParser(KXmlParser parser) {
         super(parser);
     }
@@ -60,7 +62,7 @@ public class SessionDatumParser extends CommCareElementParser<SessionDatum> {
             String value = parser.getAttributeValue(null, "value");
             String autoselect = parser.getAttributeValue(null, "autoselect");
             String maxSelectValueStr = parser.getAttributeValue(null, "max-select-value");
-            int maxSelectValue = -1;
+            int maxSelectValue = DEFAULT_MAX_SELECT_VAL;
             if (!StringUtils.isEmpty(maxSelectValueStr)) {
                 try {
                     maxSelectValue = Integer.parseInt(maxSelectValueStr);


### PR DESCRIPTION
## Technical Summary

https://dimagi-dev.atlassian.net/browse/USH-2435

[Spec](https://docs.google.com/document/d/1C7siuOd6tZbgENuSU3pd2oFQmNEUprnuCAy7EeikeDM/edit)

Utilises the existing `autoselect` datum attribute to select all cases on a multi select entity screen and forwards user to next screen on a valid entities selection.

### Safety story

- The change should only affect Formplayer multi-select workflow where we have good navigation tests to catch issues in this area
- Will go through Formplayer regression QA

**Have not been able to test end to end yet, but would do so before merge.**

### Automated test coverage

Added tests in cross-requested formplayer PR

### QA Plan

https://dimagi-dev.atlassian.net/browse/QA-4555

### Special deploy instructions

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

cross-request: https://github.com/dimagi/formplayer/pull/1226
