### PR TITLE
Skip evaluation of entity list fields when input is an Action

### DIFF
--- a/src/cli/java/org/commcare/util/screen/EntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreen.java
@@ -63,6 +63,9 @@ public class EntityScreen extends CompoundScreenHost {
     private boolean initialized = false;
     private Action autoLaunchAction;
 
+    // Whether the input to the entity screen is going to be an action
+    private boolean inActionMode = false;
+
     public EntityScreen(boolean handleCaseIndex) {
         this.handleCaseIndex = handleCaseIndex;
     }
@@ -148,7 +151,9 @@ public class EntityScreen extends CompoundScreenHost {
                     readyToSkip = true;
                 }
             } else {
-                mCurrentScreen = new EntityListSubscreen(mShortDetail, references, evalContext,
+                // if the input to this screen is going to be an action, we can skip evaluating the references
+                Vector<TreeReference> entityListReferences = inActionMode ? new Vector<>() : references;
+                mCurrentScreen = new EntityListSubscreen(mShortDetail, entityListReferences, evalContext,
                         handleCaseIndex);
             }
         }
@@ -424,5 +429,9 @@ public class EntityScreen extends CompoundScreenHost {
      */
     public void updateDatum(CommCareSession session, String input) {
         session.setEntityDatum(session.getNeededDatum(), input);
+    }
+
+    public void enableActionMode(boolean enable) {
+        inActionMode = enable;
     }
 }


### PR DESCRIPTION
## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->

https://dimagi-dev.atlassian.net/browse/SUPPORT-14839

We do not need to initialise entity list fields when we are going to launch an Action that will take us away from the current entity screen. 

## Safety Assurance


### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
Did some testing locally and seem to work fine. It should only affect the case search and registation from case list workflows.

### Automated test coverage

Case claim workflows have a good number of tests on Formplayer side which should be sufficient to catch any regressions

### QA Plan

https://dimagi-dev.atlassian.net/browse/QA-4595

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

We most probably won't need to roll this back, instead rolling back the cross-requested FP PR should be enough which is responsible for activating code in this PR. 

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

cross-request: https://github.com/dimagi/formplayer/pull/1244
