### PR TITLE
Add checkbox to supported query prompts

### DIFF
--- a/src/cli/java/org/commcare/util/screen/QueryScreen.java
+++ b/src/cli/java/org/commcare/util/screen/QueryScreen.java
@@ -1,6 +1,7 @@
 package org.commcare.util.screen;
 
 import static org.commcare.suite.model.QueryPrompt.INPUT_TYPE_ADDRESS;
+import static org.commcare.suite.model.QueryPrompt.INPUT_TYPE_CHECKBOX;
 import static org.commcare.suite.model.QueryPrompt.INPUT_TYPE_DATE;
 import static org.commcare.suite.model.QueryPrompt.INPUT_TYPE_DATERANGE;
 import static org.commcare.suite.model.QueryPrompt.INPUT_TYPE_SELECT;
@@ -125,6 +126,7 @@ public class QueryScreen extends Screen {
         supportedPrompts.add(INPUT_TYPE_SELECT);
         supportedPrompts.add(INPUT_TYPE_DATE);
         supportedPrompts.add(INPUT_TYPE_DATERANGE);
+        supportedPrompts.add(INPUT_TYPE_CHECKBOX);
         supportedPrompts.add(INPUT_TYPE_ADDRESS);
         return supportedPrompts;
     }

--- a/src/main/java/org/commcare/suite/model/QueryPrompt.java
+++ b/src/main/java/org/commcare/suite/model/QueryPrompt.java
@@ -25,6 +25,7 @@ public class QueryPrompt implements Externalizable {
     public static final String INPUT_TYPE_SELECT = "select";
     public static final String INPUT_TYPE_DATERANGE = "daterange";
     public static final String INPUT_TYPE_DATE = "date";
+    public static final String INPUT_TYPE_CHECKBOX = "checkbox";
     public static final String INPUT_TYPE_ADDRESS = "address";
     public static final String DEFAULT_REQUIRED_ERROR = "Sorry, this response is required!";
     public static final String DEFAULT_VALIDATION_ERROR = "Sorry, this response is invalid!";


### PR DESCRIPTION
## Technical Summary
Adds 'checkbox' to list of case search query options as part of [USH-2042](https://dimagi-dev.atlassian.net/browse/USH-2042?atlOrigin=eyJpIjoiMWRmNDg0Mzc0MWRmNDRhZDlhMjFjNzM3YzE3MTAwNDMiLCJwIjoiaiJ9).
Required for https://github.com/dimagi/commcare-hq/pull/32290

## Safety Assurance

### Safety story
Adds a new choice in query prompts only.

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [X] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
