### PR TITLE
[No Op] Removes Migration Instance Related code 

### DIFF
--- a/src/main/java/org/commcare/core/process/CommCareInstanceInitializer.java
+++ b/src/main/java/org/commcare/core/process/CommCareInstanceInitializer.java
@@ -91,8 +91,6 @@ public class CommCareInstanceInitializer extends InstanceInitializationFactory {
             return setupSessionData(instance);
         } else if (ref.startsWith(ExternalDataInstance.JR_REMOTE_REFERENCE)) {
             return setupExternalDataInstance(instance, ref, SessionFrame.STATE_QUERY_REQUEST);
-        } else if (ref.contains("migration")) {
-            return setupMigrationData(instance);
         } else if (ref.startsWith(JR_SELECTED_ENTITIES_REFERENCE)) {
             return setupExternalDataInstance(instance, ref, SessionFrame.STATE_MULTIPLE_DATUM_VAL);
         } else if (ref.startsWith(JR_SEARCH_INPUT_REFERENCE)) {
@@ -259,10 +257,6 @@ public class CommCareInstanceInitializer extends InstanceInitializationFactory {
 
     public String getVersionString() {
         return "CommCare Version: " + mPlatform.getMajorVersion() + "." + mPlatform.getMinorVersion();
-    }
-
-    protected InstanceRoot setupMigrationData(ExternalDataInstance instance) {
-        return ConcreteInstanceRoot.NULL;
     }
 
     public static class FixtureInitializationException extends RuntimeException {

--- a/src/main/java/org/commcare/core/process/CommCareInstanceInitializer.java
+++ b/src/main/java/org/commcare/core/process/CommCareInstanceInitializer.java
@@ -104,8 +104,9 @@ public class CommCareInstanceInitializer extends InstanceInitializationFactory {
     /**
      * Initialises instances with reference to 'selected_cases'
      *
-     * @param instance  Selected Cases Instance that needs to be initialised
+     * @param instance  External data Instance that needs to be initialised
      * @param reference instance source reference
+     * @param stepType  type of CommCare session frame step with which the given instance is bundled with
      * @return Initialised instance root for the the given instance
      */
     protected InstanceRoot setupExternalDataInstance(ExternalDataInstance instance, String reference,
@@ -121,7 +122,7 @@ public class CommCareInstanceInitializer extends InstanceInitializationFactory {
                 instanceRoot = getExternalDataInstanceSource(referenceWithId, stepType);
 
                 // last attempt to find the instance
-                // this is necessary for 'sesarch-input' instances which do not follow the convention
+                // this is necessary for 'search-input' instances which do not follow the convention
                 // of instance ref = base + instance Id:
                 //    <instance id="search-input:results" ref="jr://instance/search-input/results />
                 if (instanceRoot == null) {


### PR DESCRIPTION
## Technical Summary

The migration instance doesn't seem to be in use today. So removing that code. This is actually a no op since removing this code will still result in returning `ConcreteInstanceRoot.NULL` from `generateRoot` for migration instances even if there would be any. 

https://github.com/dimagi/commcare-core/pull/1120#discussion_r1000404950 

## Safety Assurance

### Safety story

Quite minor, No Op

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
