### PR TITLE
Updated ConvertToEthiopian Function to also use the getFields method

### DIFF
--- a/src/main/java/org/javarosa/xform/util/CalendarUtils.java
+++ b/src/main/java/org/javarosa/xform/util/CalendarUtils.java
@@ -14,6 +14,8 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 
+import static org.javarosa.core.model.utils.DateUtils.getFields;
+
 public class CalendarUtils {
 
     private static ArrayDataSource arrayDataSource = new LocaleArrayDataSource(
@@ -49,9 +51,8 @@ public class CalendarUtils {
             format = "%e %B %Y";
         }
 
-        Calendar c = Calendar.getInstance();
-        c.setTime(d);
-        return ConvertToEthiopian(c.get(Calendar.YEAR), c.get(Calendar.MONTH) + 1, c.get(Calendar.DAY_OF_MONTH), format);
+        DateUtils.DateFields fields = getFields(d);
+        return ConvertToEthiopian(fields.year, fields.month, fields.day, format);
     }
 
     private static final HashMap<Integer, int[]> NEPALI_YEAR_MONTHS = new HashMap<>();


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->
format-date-for-calendar() function is returning a date that is behind when the selected date format is nepali or ethiopian. This fixes the ethiopian side of that.

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
[Ticket](https://dimagi-dev.atlassian.net/browse/SAAS-13168) describes format-date-for-calendar function not working. Since this only happens depending on which time zone you are currently in I was able to conclude that the problem is that the date sent to formplayer has a timezone attached which triggers formplayer to do a date conversion by subtracting the time offset of the date sent. The getFields function already does timezoneoffset math to counteract this so I decided to use that instead of a calendar object

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
local testing. 
Specifically tested that the following time offsets:
06:00 - 18:00 
23:59 - 00:59
23:01 - 00:01
The reason for testing these time offsets was to ensure that the returned date was correct regardless of client side and server side date differentials.

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->
The tests already written are supposed to cover this already since they work with time zones but we know the function works as intended since the date being passed into the function is wrong, not the function itself. I'm not sure it is too plausible to write a test that catches this specific problem.

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
