### PR TITLE
Updated Nepali Date Conversion

### DIFF
--- a/src/main/java/org/javarosa/core/model/utils/DateUtils.java
+++ b/src/main/java/org/javarosa/core/model/utils/DateUtils.java
@@ -120,7 +120,7 @@ public class DateUtils {
         return tzProvider.getTimezoneOffsetMillis();
     }
 
-    private static TimeZone timezone() {
+    public static TimeZone timezone() {
         return tzProvider.getTimezone();
     }
 

--- a/src/main/java/org/javarosa/xform/util/CalendarUtils.java
+++ b/src/main/java/org/javarosa/xform/util/CalendarUtils.java
@@ -356,7 +356,9 @@ public class CalendarUtils {
         } else if (timezone() != null) {
             cd.setTimeZone(timezone());
         }
-        return fromMillis(cd.getTime().getTime(), DateTimeZone.forID(cd.getTimeZone().getID()));
+        long dateInMillis = cd.getTime().getTime();
+        DateTimeZone timezoneObject = DateTimeZone.forOffsetMillis(cd.getTimeZone().getRawOffset());
+        return fromMillis(dateInMillis, timezoneObject);
     }
 
     public static UniversalDate fromMillis(Date date) {

--- a/src/main/java/org/javarosa/xform/util/CalendarUtils.java
+++ b/src/main/java/org/javarosa/xform/util/CalendarUtils.java
@@ -13,6 +13,9 @@ import org.joda.time.chrono.GregorianChronology;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.TimeZone;
+
+import static org.javarosa.core.model.utils.DateUtils.timezone;
 
 public class CalendarUtils {
 
@@ -245,7 +248,7 @@ public class CalendarUtils {
             format = "%e %B %Y";
         }
 
-        UniversalDate dateUniv = CalendarUtils.fromMillis(date.getTime());
+        UniversalDate dateUniv = CalendarUtils.fromMillis(date);
         DateUtils.DateFields df = DateUtils.getFieldsForNonGregorianCalendar(dateUniv.year,
                 dateUniv.month, dateUniv.day);
 
@@ -345,8 +348,19 @@ public class CalendarUtils {
         throw new RuntimeException("Date out of bounds");
     }
 
-    public static UniversalDate fromMillis(long millisFromJavaEpoch) {
-        return fromMillis(millisFromJavaEpoch, DateTimeZone.getDefault());
+    public static UniversalDate fromMillis(Date date, String timezone){
+        Calendar cd = Calendar.getInstance();
+        cd.setTime(date);
+        if (timezone != null) {
+            cd.setTimeZone(TimeZone.getTimeZone(timezone));
+        } else if (timezone() != null) {
+            cd.setTimeZone(timezone());
+        }
+        return fromMillis(cd.getTime().getTime(), DateTimeZone.forID(cd.getTimeZone().getID()));
+    }
+
+    public static UniversalDate fromMillis(Date date) {
+        return fromMillis(date, null);
     }
 
     public static UniversalDate incrementMonth(UniversalDate date) {


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->
format-date-for-calendar() function is returning a date that is behind when the selected date format is nepali or ethiopian. This fixes the nepali side of that.

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
[Ticket](https://dimagi-dev.atlassian.net/browse/SAAS-13168) describes format-date-for-calendar function not working. Since this only happens depending on which time zone you are currently in I was able to conclude that the problem is that the date sent to formplayer has a timezone attached which triggers formplayer to do a date conversion by subtracting the time offset of the date sent. The `fromMillis` function here functions like the `getDate` function does for the ethiopian date conversion. I believe it makes sense to seperate these functions as there are clear differences in how they are executed.

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
local testing.
Specifically tested that the following time offsets:
06:00 - 18:00
23:59 - 00:59
23:01 - 00:01
The reason for testing these time offsets was to ensure that the returned date was correct regardless of client side and server side date differentials.

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->
The tests already written are supposed to cover this already since they work with time zones but we know the function works as intended since the date being passed into the function is wrong, not the function itself. I'm not sure it is too plausible to write a test that catches this specific problem.

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
