### PR TITLE
Fixed Ethiopian and Nepali date conversion functions

### DIFF
--- a/src/main/java/org/javarosa/core/model/utils/DateUtils.java
+++ b/src/main/java/org/javarosa/core/model/utils/DateUtils.java
@@ -120,7 +120,7 @@ public class DateUtils {
         return tzProvider.getTimezoneOffsetMillis();
     }
 
-    private static TimeZone timezone() {
+    public static TimeZone timezone() {
         return tzProvider.getTimezone();
     }
 

--- a/src/main/java/org/javarosa/xform/util/CalendarUtils.java
+++ b/src/main/java/org/javarosa/xform/util/CalendarUtils.java
@@ -14,6 +14,8 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 
+import static org.javarosa.core.model.utils.DateUtils.getFields;
+
 public class CalendarUtils {
 
     private static ArrayDataSource arrayDataSource = new LocaleArrayDataSource(
@@ -49,9 +51,8 @@ public class CalendarUtils {
             format = "%e %B %Y";
         }
 
-        Calendar c = Calendar.getInstance();
-        c.setTime(d);
-        return ConvertToEthiopian(c.get(Calendar.YEAR), c.get(Calendar.MONTH) + 1, c.get(Calendar.DAY_OF_MONTH), format);
+        DateUtils.DateFields fields = getFields(d);
+        return ConvertToEthiopian(fields.year, fields.month, fields.day, format);
     }
 
     private static final HashMap<Integer, int[]> NEPALI_YEAR_MONTHS = new HashMap<>();

--- a/src/main/java/org/javarosa/xform/util/CalendarUtils.java
+++ b/src/main/java/org/javarosa/xform/util/CalendarUtils.java
@@ -13,8 +13,7 @@ import org.joda.time.chrono.GregorianChronology;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
-
-import static org.javarosa.core.model.utils.DateUtils.getFields;
+import java.util.TimeZone;
 
 public class CalendarUtils {
 
@@ -51,7 +50,7 @@ public class CalendarUtils {
             format = "%e %B %Y";
         }
 
-        DateUtils.DateFields fields = getFields(d);
+        DateUtils.DateFields fields = DateUtils.getFields(d);
         return ConvertToEthiopian(fields.year, fields.month, fields.day, format);
     }
 
@@ -246,7 +245,7 @@ public class CalendarUtils {
             format = "%e %B %Y";
         }
 
-        UniversalDate dateUniv = CalendarUtils.fromMillis(date.getTime());
+        UniversalDate dateUniv = CalendarUtils.fromMillis(date);
         DateUtils.DateFields df = DateUtils.getFieldsForNonGregorianCalendar(dateUniv.year,
                 dateUniv.month, dateUniv.day);
 
@@ -346,8 +345,21 @@ public class CalendarUtils {
         throw new RuntimeException("Date out of bounds");
     }
 
-    public static UniversalDate fromMillis(long millisFromJavaEpoch) {
-        return fromMillis(millisFromJavaEpoch, DateTimeZone.getDefault());
+    public static UniversalDate fromMillis(Date date, String timezone) {
+        Calendar cd = Calendar.getInstance();
+        cd.setTime(date);
+        if (timezone != null) {
+            cd.setTimeZone(TimeZone.getTimeZone(timezone));
+        } else if (DateUtils.timezone() != null) {
+            cd.setTimeZone(DateUtils.timezone());
+        }
+        long dateInMillis = cd.getTime().getTime();
+        DateTimeZone timezoneObject = DateTimeZone.forOffsetMillis(cd.getTimeZone().getRawOffset());
+        return fromMillis(dateInMillis, timezoneObject);
+    }
+
+    public static UniversalDate fromMillis(Date date) {
+        return fromMillis(date, null);
     }
 
     public static UniversalDate incrementMonth(UniversalDate date) {


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->
format-date-for-calendar() function is returning a date that is behind when the selected date format is nepali or ethiopian. This fixes that.

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
[Ticket](https://dimagi-dev.atlassian.net/browse/SAAS-13168) describes format-date-for-calendar function not working. Since this only happens depending on which time zone you are currently in I was able to conclude that the problem is that the date sent to formplayer has a timezone attached which triggers formplayer to do a date conversion by subtracting the time offset of the date sent. The getFields function already does timezoneoffset math to counteract this so I decided to use that instead of a calendar object for the Ethiopian function. However, the Nepali function had significant enough differences that it made sense to create its own set of functions that would handle this problem. I simply altered the fromMillis function to do some timeoffset math to fix the problem.

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
local testing.
Specifically tested that the following time offsets:
14 nov 2022 06:00 - 14 nov 2022 18:00
14 nov 2022 23:59 - 15 nov 2022 00:59
14 nov 2022 23:01 - 15 nov 2022 00:01
The reason for testing these time offsets was to ensure that the returned date was correct regardless of client side and server side date differentials.

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->
I believe it is super hard to write a test for this specific problem because the function is handling the conversion as expected. The problem is the date being passed into formplayer getting converted to a default timezone which is by design. The test would have to mock this happening and then we test to see if the time is being added to the date. Which I believe is something that we can reliably assume would work as expected. It is because of this that I don't think writing a test like that is valuable.

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
