### PR TITLE
Trigger dependabot version updates for formplayer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,12 @@ updates:
       interval: daily
     labels:
       - dependencies
+
+  # Copy of above config for formplayer
+  - package-ecosystem: gradle
+    directory: "/"
+    target-branch: "formplayer"
+    schedule:
+      interval: daily
+    labels:
+      - dependencies


### PR DESCRIPTION
[This](https://github.com/dependabot/feedback/issues/889) led me believe we can have dependabot create dependency version updates PR for both `formplayer` and `master`. So want to see if it actually works as expected. 