### PR TITLE
Auto multi select no results displays empty case list

### DIFF
--- a/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
@@ -89,7 +89,7 @@ public class MultiSelectEntityScreen extends EntityScreen {
 
     private boolean validateSelectionSize(int selectionSize) {
         if (selectionSize == 0) {
-            throw new InvalidEntitiesSelectionException(getNoEntitiesError());
+            return false;
         } else if (selectionSize > maxSelectValue) {
             throw new InvalidEntitiesSelectionException(getMaxSelectError(selectionSize));
         }
@@ -115,14 +115,6 @@ public class MultiSelectEntityScreen extends EntityScreen {
             }
         }
         return error;
-    }
-
-    private String getNoEntitiesError() {
-        try {
-            return Localization.get("case.list.no.selection.error");
-        } catch (NoLocalizedTextException | NullPointerException e) {
-            return String.format("No cases found");
-        }
     }
 
     private void setSelectedEntities(String input, @Nullable String[] selectedValues)


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->
Ticket: [USH-2684](https://dimagi-dev.atlassian.net/browse/USH-2684)
formplayer PR:

This change will navigate the user to an empty case list rather that throwing an error on a case list query screen if there are no results to select.

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
Noting this is the only exception to the idea that if auto-select is enabled, a case list screen will never be shown

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
Tested locally and (shortly) on staging
Plus implements a workflow that already existed outside of auto-select

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
I was not planning on QA and rather testing locally and on staging

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
