### PR TITLE
Fix no cases in auto select Mode

### DIFF
--- a/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
@@ -69,7 +69,7 @@ public class MultiSelectEntityScreen extends EntityScreen {
 
     @Override
     protected boolean shouldAutoSelect() {
-        return mNeededDatum.isAutoSelectEnabled();
+        return mNeededDatum.isAutoSelectEnabled() && references.size() != 0;
     }
 
     @Override


### PR DESCRIPTION
## Technical Summary

Since we want to show the empty case list in auto-select mode, this change disables the auto select mode when there are no cases to select. 

## Safety Assurance

### Safety story

- Should only affect multi-select auto selection mode

### Automated test coverage

Added tests in [Formplayer PR](https://github.com/dimagi/formplayer/pull/1296)
### QA Plan

No QA

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x ] The set of people pinged as reviewers is appropriate for the level of risk of the change.


cross-request: https://github.com/dimagi/formplayer/pull/1296