### PR TITLE
Custom Text for Case List Empty State

### DIFF
--- a/src/main/java/org/commcare/suite/model/Detail.java
+++ b/src/main/java/org/commcare/suite/model/Detail.java
@@ -60,6 +60,8 @@ public class Detail implements Externalizable {
     private TreeReference nodeset;
 
     private DisplayUnit title;
+
+    @Nullable
     private Text noItemsText;
 
     /**
@@ -185,6 +187,7 @@ public class Detail implements Externalizable {
      * @return The text to be displayed to users if case list
      * has no items.
      */
+    @Nullable
     public Text getNoItemsText() {
         return noItemsText;
     }

--- a/src/main/java/org/commcare/suite/model/Detail.java
+++ b/src/main/java/org/commcare/suite/model/Detail.java
@@ -185,6 +185,7 @@ public class Detail implements Externalizable {
 
     /**
      * Returns the text displayed when case list results contain no items.
+     * 
      * @return The text to be displayed to users if case list
      * has no items.
      */

--- a/src/main/java/org/commcare/suite/model/Detail.java
+++ b/src/main/java/org/commcare/suite/model/Detail.java
@@ -185,7 +185,7 @@ public class Detail implements Externalizable {
 
     /**
      * Returns the text displayed when case list results contain no items.
-     * 
+     *
      * @return returns Text for empty case list.
      */
     @Nullable

--- a/src/main/java/org/commcare/suite/model/Detail.java
+++ b/src/main/java/org/commcare/suite/model/Detail.java
@@ -110,7 +110,7 @@ public class Detail implements Externalizable {
 
     }
 
-    public Detail(String id, DisplayUnit title, String nodeset, Vector<Detail> detailsVector,
+    public Detail(String id, DisplayUnit title, Text noItemsText, String nodeset, Vector<Detail> detailsVector,
                   Vector<DetailField> fieldsVector, OrderedHashtable<String, String> variables,
                   Vector<Action> actions, Callout callout, String fitAcross,
                   String uniformUnitsString, String forceLandscape, String focusFunction,

--- a/src/main/java/org/commcare/suite/model/Detail.java
+++ b/src/main/java/org/commcare/suite/model/Detail.java
@@ -184,6 +184,7 @@ public class Detail implements Externalizable {
     }
 
     /**
+     * Returns the text displayed when case list results contain no items.
      * @return The text to be displayed to users if case list
      * has no items.
      */

--- a/src/main/java/org/commcare/suite/model/Detail.java
+++ b/src/main/java/org/commcare/suite/model/Detail.java
@@ -186,8 +186,7 @@ public class Detail implements Externalizable {
     /**
      * Returns the text displayed when case list results contain no items.
      * 
-     * @return The text to be displayed to users if case list
-     * has no items.
+     * @return returns Text for empty case list.
      */
     @Nullable
     public Text getNoItemsText() {

--- a/src/main/java/org/commcare/suite/model/Detail.java
+++ b/src/main/java/org/commcare/suite/model/Detail.java
@@ -60,6 +60,7 @@ public class Detail implements Externalizable {
     private TreeReference nodeset;
 
     private DisplayUnit title;
+    private Text noItemsText;
 
     /**
      * Optional and only relevant if this detail has child details. In that
@@ -122,6 +123,7 @@ public class Detail implements Externalizable {
 
         this.id = id;
         this.title = title;
+        this.noItemsText = noItemsText;
         if (nodeset != null) {
             this.nodeset = XPathReference.getPathExpr(nodeset).getReference();
         }
@@ -177,6 +179,14 @@ public class Detail implements Externalizable {
      */
     public DisplayUnit getTitle() {
         return title;
+    }
+
+    /**
+     * @return The text to be displayed to users if case list
+     * has no items.
+     */
+    public Text getNoItemsText() {
+        return noItemsText;
     }
 
     /**
@@ -238,6 +248,7 @@ public class Detail implements Externalizable {
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         id = (String)ExtUtil.read(in, new ExtWrapNullable(String.class), pf);
         title = (DisplayUnit)ExtUtil.read(in, DisplayUnit.class, pf);
+        noItemsText = (Text) ExtUtil.read(in, new ExtWrapNullable(Text.class), pf);
         titleForm = (String)ExtUtil.read(in, new ExtWrapNullable(String.class), pf);
         nodeset = (TreeReference)ExtUtil.read(in, new ExtWrapNullable(TreeReference.class), pf);
         Vector<Detail> theDetails = (Vector<Detail>)ExtUtil.read(in, new ExtWrapList(Detail.class), pf);
@@ -261,6 +272,7 @@ public class Detail implements Externalizable {
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.write(out, new ExtWrapNullable(id));
         ExtUtil.write(out, title);
+        ExtUtil.write(out, new ExtWrapNullable(noItemsText));
         ExtUtil.write(out, new ExtWrapNullable(titleForm));
         ExtUtil.write(out, new ExtWrapNullable(nodeset));
         ExtUtil.write(out, new ExtWrapList(ArrayUtilities.toVector(details)));

--- a/src/main/java/org/commcare/xml/DetailParser.java
+++ b/src/main/java/org/commcare/xml/DetailParser.java
@@ -21,6 +21,7 @@ import java.util.Vector;
  * @author ctsims
  */
 public class DetailParser extends CommCareElementParser<Detail> {
+    private static final String NAME_NO_ITEMS_TEXT = "no_items_text";
 
     public DetailParser(KXmlParser parser) {
         super(parser);
@@ -73,7 +74,7 @@ public class DetailParser extends CommCareElementParser<Detail> {
                 callout = new CalloutParser(parser).parse();
                 parser.nextTag();
             }
-            if ("no_items_text".equals(parser.getName().toLowerCase())) {
+            if (NAME_NO_ITEMS_TEXT.equals(parser.getName().toLowerCase())) {
                 checkNode("no_items_text");
                 getNextTagInBlock("no_items_text");
                 if ("text".equals(parser.getName().toLowerCase())) {

--- a/src/main/java/org/commcare/xml/DetailParser.java
+++ b/src/main/java/org/commcare/xml/DetailParser.java
@@ -6,6 +6,7 @@ import org.commcare.suite.model.Detail;
 import org.commcare.suite.model.DetailField;
 import org.commcare.suite.model.DisplayUnit;
 import org.commcare.suite.model.Global;
+import org.commcare.suite.model.Text;
 import org.javarosa.core.util.OrderedHashtable;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xpath.XPathParseTool;
@@ -55,6 +56,7 @@ public class DetailParser extends CommCareElementParser<Detail> {
         Vector<Action> actions = new Vector<>();
 
         //Now get the headers and templates.
+        Text noItemsText = null;
         Vector<Detail> subdetails = new Vector<>();
         Vector<DetailField> fields = new Vector<>();
         OrderedHashtable<String, String> variables = new OrderedHashtable<>();
@@ -70,6 +72,14 @@ public class DetailParser extends CommCareElementParser<Detail> {
                 checkNode("lookup");
                 callout = new CalloutParser(parser).parse();
                 parser.nextTag();
+            }
+            if ("no_items_text".equals(parser.getName().toLowerCase())) {
+                checkNode("no_items_text");
+                getNextTagInBlock("no_items_text");
+                if ("text".equals(parser.getName().toLowerCase())) {
+                    noItemsText = new TextParser(parser).parse();
+                }
+                continue;
             }
             if ("variables".equals(parser.getName().toLowerCase())) {
                 while (nextTagInBlock("variables")) {
@@ -112,7 +122,7 @@ public class DetailParser extends CommCareElementParser<Detail> {
             }
         }
 
-        return new Detail(id, title, nodeset, subdetails, fields, variables, actions, callout,
+        return new Detail(id, title, noItemsText, nodeset, subdetails, fields, variables, actions, callout,
                 fitAcross, useUniformUnits, forceLandscapeView, focusFunction, printTemplatePath,
                 relevancy, global);
     }

--- a/src/test/java/org/commcare/backend/suite/model/test/AppStructureTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/AppStructureTests.java
@@ -115,6 +115,12 @@ public class AppStructureTests {
     }
 
     @Test
+    public void testDetailNoItemsText() {
+        Text noItemsText = mApp.getSession().getPlatform().getDetail("m0_case_short").getNoItemsText();
+        Assert.assertEquals("Empty List", noItemsText.evaluate());
+    }
+
+    @Test
     public void testDemoUserRestoreParsing() throws Exception {
         // Test parsing an app with a properly-formed demo user restore file
         MockApp appWithGoodUserRestore = new MockApp("/app_with_good_demo_restore/");

--- a/src/test/resources/app_structure/app_strings.txt
+++ b/src/test/resources/app_structure/app_strings.txt
@@ -1,0 +1,1 @@
+m0_no_items_text=Empty List

--- a/src/test/resources/app_structure/suite.xml
+++ b/src/test/resources/app_structure/suite.xml
@@ -5,11 +5,21 @@
       <location authority="local">./form_placeholder.xml</location>
     </resource>
   </xform>
+  <locale language="default">
+    <resource id="default" version="1399" descriptor="Default">
+      <location authority="local">./app_strings.txt</location>
+    </resource>
+  </locale>
 
   <detail id="m0_case_short">
     <title>
       <text>Case List</text>
     </title>
+    <no_items_text>
+      <text>
+        <locale id="m0_no_items_text"/>
+      </text>
+    </no_items_text>
     <global>
       <geo-overlay>
         <coordinates>


### PR DESCRIPTION
## Product Description
Related to HQ PR: https://github.com/dimagi/commcare-hq/pull/32491

## Technical Summary
[Spec](https://docs.google.com/document/d/1HXlCmBW19lsCfGIidZkge0LMI1m7c20wPgzp8uAZbL8/edit#heading=h.gkfaicygwvet)
[USH-2683](https://dimagi-dev.atlassian.net/browse/USH-2683?focusedCommentId=243779&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-243779)

## Safety Assurance

### Safety story
manual testing on local env and updated existing tests. Will also go through QA. 
Existing apps that do not have `no_items_text` node will have `noItemsText` set as null in the model

### Automated test coverage
Added test in PR that tests data parsed from suite is correctly grabbed from app_strings and saved in model.

### QA Plan
[QA Ticket
](https://dimagi-dev.atlassian.net/browse/QA-4726?focusedCommentId=245658&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-245658)
### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [X] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations.

### Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change.
