### PR TITLE
[No Op] Refactoring for instance loading methods

### DIFF
--- a/src/main/java/org/commcare/cases/instance/CaseDataInstance.java
+++ b/src/main/java/org/commcare/cases/instance/CaseDataInstance.java
@@ -3,7 +3,7 @@ package org.commcare.cases.instance;
 import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.instance.TreeReference;
-import org.javarosa.core.model.instance.utils.FormLoadingUtils;
+import org.javarosa.core.model.instance.utils.InstanceUtils;
 import org.javarosa.xml.util.InvalidStructureException;
 
 import java.io.IOException;
@@ -43,7 +43,7 @@ public class CaseDataInstance extends ExternalDataInstance {
         if (caseDbSpecTemplate == null) {
             try {
                 caseDbSpecTemplate =
-                        FormLoadingUtils.xmlToTreeElement("/casedb_instance_structure.xml");
+                        InstanceUtils.xmlToTreeElement("/casedb_instance_structure.xml");
             } catch (InvalidStructureException | IOException e) {
                 throw new RuntimeException(errorMsg);
             }

--- a/src/main/java/org/commcare/cases/instance/CaseDataInstance.java
+++ b/src/main/java/org/commcare/cases/instance/CaseDataInstance.java
@@ -3,7 +3,7 @@ package org.commcare.cases.instance;
 import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.instance.TreeReference;
-import org.javarosa.core.model.instance.utils.InstanceUtils;
+import org.javarosa.core.model.instance.utils.TreeUtilities;
 import org.javarosa.xml.util.InvalidStructureException;
 
 import java.io.IOException;
@@ -43,7 +43,7 @@ public class CaseDataInstance extends ExternalDataInstance {
         if (caseDbSpecTemplate == null) {
             try {
                 caseDbSpecTemplate =
-                        InstanceUtils.xmlToTreeElement("/casedb_instance_structure.xml");
+                        TreeUtilities.xmlToTreeElement("/casedb_instance_structure.xml");
             } catch (InvalidStructureException | IOException e) {
                 throw new RuntimeException(errorMsg);
             }

--- a/src/main/java/org/commcare/core/interfaces/RemoteInstanceFetcher.java
+++ b/src/main/java/org/commcare/core/interfaces/RemoteInstanceFetcher.java
@@ -1,5 +1,6 @@
 package org.commcare.core.interfaces;
 
+import org.javarosa.core.model.instance.AbstractTreeElement;
 import org.javarosa.core.model.instance.ExternalDataInstanceSource;
 import org.javarosa.core.model.instance.TreeElement;
 
@@ -8,7 +9,7 @@ import org.javarosa.core.model.instance.TreeElement;
  */
 public interface RemoteInstanceFetcher {
 
-    TreeElement getExternalRoot(String instanceId, ExternalDataInstanceSource source)
+    AbstractTreeElement getExternalRoot(String instanceId, ExternalDataInstanceSource source)
             throws RemoteInstanceException;
 
     class RemoteInstanceException extends Exception {

--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -17,6 +17,7 @@ import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.ExternalDataInstanceSource;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.core.model.instance.utils.TreeUtilities;
 import org.javarosa.core.model.utils.ItemSetUtils;
 import org.javarosa.core.util.OrderedHashtable;
 import org.javarosa.model.xform.XPathReference;
@@ -324,7 +325,7 @@ public class RemoteQuerySessionManager {
             Multimap<String, String> requestData) {
         try {
             String instanceID = getQueryDatum().getDataId();
-            TreeElement root = ExternalDataInstance.parseExternalTree(responseData, instanceID);
+            TreeElement root = TreeUtilities.xmlStreamToTreeElement(responseData, instanceID);
             ExternalDataInstanceSource instanceSource = ExternalDataInstanceSource.buildRemote(
                     instanceID, root, getQueryDatum().useCaseTemplate(), url, requestData);
             ExternalDataInstance instance = instanceSource.toInstance();

--- a/src/main/java/org/javarosa/core/model/instance/ExternalDataInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/ExternalDataInstance.java
@@ -65,13 +65,16 @@ public class ExternalDataInstance extends DataInstance {
     }
 
     public ExternalDataInstance(String reference, String instanceId,
-            TreeElement topLevel, ExternalDataInstanceSource source) {
+            AbstractTreeElement topLevel, ExternalDataInstanceSource source) {
         this(reference, instanceId);
         base = new InstanceBase(instanceId);
         this.source = source;
-        topLevel.setInstanceName(instanceId);
-        topLevel.setParent(base);
         this.root = topLevel;
+        if (root instanceof TreeElement) {
+            TreeElement rootAsTreeElement = ((TreeElement)root);
+            rootAsTreeElement.setInstanceName(instanceId);
+            rootAsTreeElement.setParent(base);
+        }
         base.setChild(root);
     }
 

--- a/src/main/java/org/javarosa/core/model/instance/ExternalDataInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/ExternalDataInstance.java
@@ -78,14 +78,6 @@ public class ExternalDataInstance extends DataInstance {
         base.setChild(root);
     }
 
-    public static TreeElement parseExternalTree(InputStream stream, String instanceId)
-            throws IOException, UnfullfilledRequirementsException, XmlPullParserException,
-            InvalidStructureException {
-        KXmlParser baseParser = ElementParser.instantiateParser(stream);
-        TreeElement root = new TreeElementParser(baseParser, 0, instanceId).parse();
-        return root;
-    }
-
     public boolean useCaseTemplate() {
         return source == null ? CaseInstanceTreeElement.MODEL_NAME.equals(instanceid) : source.useCaseTemplate();
     }

--- a/src/main/java/org/javarosa/core/model/instance/ExternalDataInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/ExternalDataInstance.java
@@ -1,5 +1,7 @@
 package org.javarosa.core.model.instance;
 
+import static org.javarosa.core.model.instance.utils.InstanceUtils.setUpInstanceRoot;
+
 import org.commcare.cases.instance.CaseInstanceTreeElement;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
@@ -70,11 +72,7 @@ public class ExternalDataInstance extends DataInstance {
         base = new InstanceBase(instanceId);
         this.source = source;
         this.root = topLevel;
-        if (root instanceof TreeElement) {
-            TreeElement rootAsTreeElement = ((TreeElement)root);
-            rootAsTreeElement.setInstanceName(instanceId);
-            rootAsTreeElement.setParent(base);
-        }
+        setUpInstanceRoot(root, instanceId, base);
         base.setChild(root);
     }
 

--- a/src/main/java/org/javarosa/core/model/instance/ExternalDataInstanceSource.java
+++ b/src/main/java/org/javarosa/core/model/instance/ExternalDataInstanceSource.java
@@ -1,6 +1,7 @@
 package org.javarosa.core.model.instance;
 
 import static org.javarosa.core.model.instance.ExternalDataInstance.JR_REMOTE_REFERENCE;
+import static org.javarosa.core.model.instance.utils.InstanceUtils.setUpInstanceRoot;
 
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
@@ -127,11 +128,7 @@ public class ExternalDataInstanceSource implements InstanceRoot, Externalizable 
             throws RemoteInstanceFetcher.RemoteInstanceException {
         String instanceId = getInstanceId();
         init(remoteInstanceFetcher.getExternalRoot(instanceId, this));
-        if (root instanceof TreeElement) {
-            TreeElement rootAsTreeElement = ((TreeElement)root);
-            rootAsTreeElement.setInstanceName(instanceId);
-            rootAsTreeElement.setParent(new InstanceBase(instanceId));
-        }
+        setUpInstanceRoot(root, instanceId, new InstanceBase(instanceId));
     }
 
     public void setupNewCopy(ExternalDataInstance instance) {

--- a/src/main/java/org/javarosa/core/model/instance/ExternalDataInstanceSource.java
+++ b/src/main/java/org/javarosa/core/model/instance/ExternalDataInstanceSource.java
@@ -16,7 +16,6 @@ import org.javarosa.core.util.externalizable.PrototypeFactory;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.UUID;
 
 import javax.annotation.Nullable;
 
@@ -27,7 +26,7 @@ import javax.annotation.Nullable;
 public class ExternalDataInstanceSource implements InstanceRoot, Externalizable {
 
     @Nullable
-    private TreeElement root;
+    private AbstractTreeElement root;
     private String instanceId;
     private boolean useCaseTemplate;
     private String reference;
@@ -109,14 +108,14 @@ public class ExternalDataInstanceSource implements InstanceRoot, Externalizable 
         return false;
     }
 
-    public TreeElement getRoot() {
+    public AbstractTreeElement getRoot() {
         if (needsInit()) {
             throw new RuntimeException("Uninstantiated external instance source");
         }
         return root;
     }
 
-    public void init(TreeElement root) {
+    public void init(AbstractTreeElement root) {
         if (this.root != null) {
             throw new RuntimeException(
                     "Initializing an already instantiated external instance source is not permitted");
@@ -128,8 +127,11 @@ public class ExternalDataInstanceSource implements InstanceRoot, Externalizable 
             throws RemoteInstanceFetcher.RemoteInstanceException {
         String instanceId = getInstanceId();
         init(remoteInstanceFetcher.getExternalRoot(instanceId, this));
-        root.setInstanceName(instanceId);
-        root.setParent(new InstanceBase(instanceId));
+        if (root instanceof TreeElement) {
+            TreeElement rootAsTreeElement = ((TreeElement)root);
+            rootAsTreeElement.setInstanceName(instanceId);
+            rootAsTreeElement.setParent(new InstanceBase(instanceId));
+        }
     }
 
     public void setupNewCopy(ExternalDataInstance instance) {

--- a/src/main/java/org/javarosa/core/model/instance/UnrecognisedInstanceRootException.java
+++ b/src/main/java/org/javarosa/core/model/instance/UnrecognisedInstanceRootException.java
@@ -3,7 +3,7 @@ package org.javarosa.core.model.instance;
 /**
  * Thrown when an instance has an unsupported instance root attached
  */
-public class UnrecognisedInstanceRootException extends RuntimeException{
+public class UnrecognisedInstanceRootException extends RuntimeException {
     public UnrecognisedInstanceRootException(String message) {
         super(message);
     }

--- a/src/main/java/org/javarosa/core/model/instance/UnrecognisedInstanceRootException.java
+++ b/src/main/java/org/javarosa/core/model/instance/UnrecognisedInstanceRootException.java
@@ -1,0 +1,10 @@
+package org.javarosa.core.model.instance;
+
+/**
+ * Thrown when an instance has an unsupported instance root attached
+ */
+public class UnrecognisedInstanceRootException extends RuntimeException{
+    public UnrecognisedInstanceRootException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/javarosa/core/model/instance/utils/InstanceUtils.java
+++ b/src/main/java/org/javarosa/core/model/instance/utils/InstanceUtils.java
@@ -13,16 +13,15 @@ import java.io.IOException;
 import java.io.InputStream;
 
 /**
- * Collection of static form loading methods
+ * Collection of static instance loading methods
  *
  * @author Phillip Mates
  */
-public class FormLoadingUtils {
+public class InstanceUtils {
 
     public static FormInstance loadFormInstance(String formFilepath)
             throws InvalidStructureException, IOException {
         TreeElement root = xmlToTreeElement(formFilepath);
-
         return new FormInstance(root, null);
     }
 
@@ -30,7 +29,7 @@ public class FormLoadingUtils {
             throws InvalidStructureException, IOException {
         InputStream is = null;
         try {
-            is = FormLoadingUtils.class.getResourceAsStream(xmlFilepath);
+            is = InstanceUtils.class.getResourceAsStream(xmlFilepath);
             TreeElementParser parser = new TreeElementParser(ElementParser.instantiateParser(is), 0, "instance");
 
             try {

--- a/src/main/java/org/javarosa/core/model/instance/utils/InstanceUtils.java
+++ b/src/main/java/org/javarosa/core/model/instance/utils/InstanceUtils.java
@@ -1,16 +1,12 @@
 package org.javarosa.core.model.instance.utils;
 
-import org.javarosa.core.io.StreamsUtil;
+import static org.javarosa.core.model.instance.utils.TreeUtilities.xmlToTreeElement;
+
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.TreeElement;
-import org.javarosa.xml.ElementParser;
-import org.javarosa.xml.TreeElementParser;
 import org.javarosa.xml.util.InvalidStructureException;
-import org.javarosa.xml.util.UnfullfilledRequirementsException;
-import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
-import java.io.InputStream;
 
 /**
  * Collection of static instance loading methods
@@ -23,22 +19,5 @@ public class InstanceUtils {
             throws InvalidStructureException, IOException {
         TreeElement root = xmlToTreeElement(formFilepath);
         return new FormInstance(root, null);
-    }
-
-    public static TreeElement xmlToTreeElement(String xmlFilepath)
-            throws InvalidStructureException, IOException {
-        InputStream is = null;
-        try {
-            is = InstanceUtils.class.getResourceAsStream(xmlFilepath);
-            TreeElementParser parser = new TreeElementParser(ElementParser.instantiateParser(is), 0, "instance");
-
-            try {
-                return parser.parse();
-            } catch (UnfullfilledRequirementsException | XmlPullParserException e) {
-                throw new IOException(e.getMessage());
-            }
-        } finally {
-            StreamsUtil.closeStream(is);
-        }
     }
 }

--- a/src/main/java/org/javarosa/core/model/instance/utils/InstanceUtils.java
+++ b/src/main/java/org/javarosa/core/model/instance/utils/InstanceUtils.java
@@ -2,7 +2,9 @@ package org.javarosa.core.model.instance.utils;
 
 import static org.javarosa.core.model.instance.utils.TreeUtilities.xmlToTreeElement;
 
+import org.javarosa.core.model.instance.AbstractTreeElement;
 import org.javarosa.core.model.instance.FormInstance;
+import org.javarosa.core.model.instance.InstanceBase;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.xml.util.InvalidStructureException;
 
@@ -19,5 +21,21 @@ public class InstanceUtils {
             throws InvalidStructureException, IOException {
         TreeElement root = xmlToTreeElement(formFilepath);
         return new FormInstance(root, null);
+    }
+
+    /**
+     * Sets instance properties to the given instance root
+     *
+     * @param instanceRoot instance root
+     * @param instanceId   instance id to set
+     * @param instanceBase instance base to set
+     */
+    public static void setUpInstanceRoot(AbstractTreeElement instanceRoot, String instanceId,
+            InstanceBase instanceBase) {
+        if (instanceRoot instanceof TreeElement) {
+            TreeElement rootAsTreeElement = ((TreeElement)instanceRoot);
+            rootAsTreeElement.setInstanceName(instanceId);
+            rootAsTreeElement.setParent(instanceBase);
+        }
     }
 }

--- a/src/main/java/org/javarosa/core/model/instance/utils/InstanceUtils.java
+++ b/src/main/java/org/javarosa/core/model/instance/utils/InstanceUtils.java
@@ -6,6 +6,7 @@ import org.javarosa.core.model.instance.AbstractTreeElement;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.InstanceBase;
 import org.javarosa.core.model.instance.TreeElement;
+import org.javarosa.core.model.instance.UnrecognisedInstanceRootException;
 import org.javarosa.xml.util.InvalidStructureException;
 
 import java.io.IOException;
@@ -36,6 +37,10 @@ public class InstanceUtils {
             TreeElement rootAsTreeElement = ((TreeElement)instanceRoot);
             rootAsTreeElement.setInstanceName(instanceId);
             rootAsTreeElement.setParent(instanceBase);
+        } else {
+            String error = "Unrecognised Instance root of type " + instanceRoot.getClass().getName() +
+                    " for instance " + instanceId;
+            throw new UnrecognisedInstanceRootException(error);
         }
     }
 }

--- a/src/main/java/org/javarosa/core/model/instance/utils/TreeUtilities.java
+++ b/src/main/java/org/javarosa/core/model/instance/utils/TreeUtilities.java
@@ -56,11 +56,11 @@ public class TreeUtilities {
      * is provided
      */
     public static Collection<TreeReference> tryBatchChildFetch(AbstractTreeElement parent,
-                                                               Hashtable<XPathPathExpr, Hashtable<String, TreeElement[]>> childAttributeHintMap,
-                                                               String name,
-                                                               int mult,
-                                                               Vector<XPathExpression> predicates,
-                                                               EvaluationContext evalContext) {
+            Hashtable<XPathPathExpr, Hashtable<String, TreeElement[]>> childAttributeHintMap,
+            String name,
+            int mult,
+            Vector<XPathExpression> predicates,
+            EvaluationContext evalContext) {
         // This method builds a predictive model for quick queries that
         // prevents the need to fully flesh out full walks of the tree.
 
@@ -101,7 +101,8 @@ public class TreeUtilities {
 
                 //For now, only cheat when this is a string literal (this basically just means that we're
                 //handling attribute based referencing with very reasonable timing, but it's complex otherwise)
-                if (left instanceof XPathPathExpr && (right instanceof XPathStringLiteral || right instanceof XPathPathExpr)) {
+                if (left instanceof XPathPathExpr && (right instanceof XPathStringLiteral
+                        || right instanceof XPathPathExpr)) {
                     String literalMatch = null;
                     if (right instanceof XPathStringLiteral) {
                         literalMatch = ((XPathStringLiteral)right).s;
@@ -109,7 +110,8 @@ public class TreeUtilities {
                         //We'll also try to match direct path queries as long as they are not
                         //complex.
 
-                        //First: Evaluate whether there are predicates (which may have nesting that ruins our ability to do this)
+                        //First: Evaluate whether there are predicates (which may have nesting that ruins our
+                        // ability to do this)
                         for (XPathStep step : ((XPathPathExpr)right).steps) {
                             if (step.predicates.length > 0) {
                                 //We can't evaluate this, just bail
@@ -122,7 +124,8 @@ public class TreeUtilities {
                             Object o = FunctionUtils.unpack(right.eval(evalContext));
                             literalMatch = FunctionUtils.toString(o);
                         } catch (XPathException e) {
-                            //We may have some weird lack of context that makes this not work, so don't choke on the bonus evaluation
+                            //We may have some weird lack of context that makes this not work, so don't choke on
+                            // the bonus evaluation
                             //and just evaluate that traditional way
                             e.printStackTrace();
                             break;
@@ -141,7 +144,8 @@ public class TreeUtilities {
                                     predicateMatches.add(element.getRef());
                                 }
                             }
-                            //Merge and note that this predicate is evaluated and doesn't need to be evaluated in the future.
+                            //Merge and note that this predicate is evaluated and doesn't need to be evaluated
+                            // in the future.
                             allSelectedChildren = merge(allSelectedChildren, predicateMatches, i, toRemove);
                             continue predicate;
                         }
@@ -181,7 +185,7 @@ public class TreeUtilities {
                             for (int kidI = 0; kidI < kids.size(); ++kidI) {
                                 String attrValue = kids.elementAt(kidI).getAttributeValue(null, attributeName);
 
-                                if(attrValue == null ) {
+                                if (attrValue == null) {
                                     attrValue = "";
                                 }
 
@@ -226,8 +230,8 @@ public class TreeUtilities {
 
 
     private static Collection<TreeReference> merge(Collection<TreeReference> allSelectedChildren,
-                                               Collection<TreeReference> predicateMatches,
-                                               int i, Vector<Integer> toRemove) {
+            Collection<TreeReference> predicateMatches,
+            int i, Vector<Integer> toRemove) {
         toRemove.addElement(DataUtil.integer(i));
         if (allSelectedChildren == null) {
             return predicateMatches;
@@ -261,7 +265,7 @@ public class TreeUtilities {
 
             @Override
             public void visit(AbstractTreeElement element) {
-                ((TreeElement) element).setInstanceName(instanceId);
+                ((TreeElement)element).setInstanceName(instanceId);
             }
         });
         return copy;

--- a/src/main/java/org/javarosa/core/model/instance/utils/TreeUtilities.java
+++ b/src/main/java/org/javarosa/core/model/instance/utils/TreeUtilities.java
@@ -280,9 +280,8 @@ public class TreeUtilities {
         InputStream is = null;
         try {
             is = InstanceUtils.class.getResourceAsStream(xmlFilepath);
-            TreeElementParser parser = new TreeElementParser(ElementParser.instantiateParser(is), 0, "instance");
             try {
-                return parser.parse();
+                return xmlStreamToTreeElement(is, "instance");
             } catch (UnfullfilledRequirementsException | XmlPullParserException e) {
                 throw new IOException(e.getMessage());
             }

--- a/src/main/java/org/javarosa/core/model/instance/utils/TreeUtilities.java
+++ b/src/main/java/org/javarosa/core/model/instance/utils/TreeUtilities.java
@@ -306,7 +306,6 @@ public class TreeUtilities {
             throws IOException, UnfullfilledRequirementsException, XmlPullParserException,
             InvalidStructureException {
         KXmlParser baseParser = ElementParser.instantiateParser(stream);
-        TreeElement root = new TreeElementParser(baseParser, 0, instanceId).parse();
-        return root;
+        return new TreeElementParser(baseParser, 0, instanceId).parse();
     }
 }

--- a/src/main/java/org/javarosa/core/model/instance/utils/TreeUtilities.java
+++ b/src/main/java/org/javarosa/core/model/instance/utils/TreeUtilities.java
@@ -1,5 +1,6 @@
 package org.javarosa.core.model.instance.utils;
 
+import org.javarosa.core.io.StreamsUtil;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.AbstractTreeElement;
 import org.javarosa.core.model.instance.FormInstance;
@@ -8,6 +9,10 @@ import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.util.CacheTable;
 import org.javarosa.core.util.DataUtil;
 import org.javarosa.model.xform.XPathReference;
+import org.javarosa.xml.ElementParser;
+import org.javarosa.xml.TreeElementParser;
+import org.javarosa.xml.util.InvalidStructureException;
+import org.javarosa.xml.util.UnfullfilledRequirementsException;
 import org.javarosa.xpath.XPathException;
 import org.javarosa.xpath.expr.FunctionUtils;
 import org.javarosa.xpath.expr.XPathEqExpr;
@@ -15,7 +20,10 @@ import org.javarosa.xpath.expr.XPathExpression;
 import org.javarosa.xpath.expr.XPathPathExpr;
 import org.javarosa.xpath.expr.XPathStep;
 import org.javarosa.xpath.expr.XPathStringLiteral;
+import org.xmlpull.v1.XmlPullParserException;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Collection;
 import java.util.Hashtable;
 import java.util.LinkedHashSet;
@@ -256,5 +264,28 @@ public class TreeUtilities {
             }
         });
         return copy;
+    }
+
+    /**
+     * Converts xml in a given file to TreeElement
+     * @param xmlFilepath file path for the xml file
+     * @return TreeElement for the given xml
+     * @throws InvalidStructureException
+     * @throws IOException
+     */
+    public static TreeElement xmlToTreeElement(String xmlFilepath)
+            throws InvalidStructureException, IOException {
+        InputStream is = null;
+        try {
+            is = InstanceUtils.class.getResourceAsStream(xmlFilepath);
+            TreeElementParser parser = new TreeElementParser(ElementParser.instantiateParser(is), 0, "instance");
+            try {
+                return parser.parse();
+            } catch (UnfullfilledRequirementsException | XmlPullParserException e) {
+                throw new IOException(e.getMessage());
+            }
+        } finally {
+            StreamsUtil.closeStream(is);
+        }
     }
 }

--- a/src/main/java/org/javarosa/core/model/instance/utils/TreeUtilities.java
+++ b/src/main/java/org/javarosa/core/model/instance/utils/TreeUtilities.java
@@ -20,6 +20,7 @@ import org.javarosa.xpath.expr.XPathExpression;
 import org.javarosa.xpath.expr.XPathPathExpr;
 import org.javarosa.xpath.expr.XPathStep;
 import org.javarosa.xpath.expr.XPathStringLiteral;
+import org.kxml2.io.KXmlParser;
 import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
@@ -268,6 +269,7 @@ public class TreeUtilities {
 
     /**
      * Converts xml in a given file to TreeElement
+     *
      * @param xmlFilepath file path for the xml file
      * @return TreeElement for the given xml
      * @throws InvalidStructureException
@@ -287,5 +289,24 @@ public class TreeUtilities {
         } finally {
             StreamsUtil.closeStream(is);
         }
+    }
+
+    /**
+     * Converts a xml stream to TreeElement
+     *
+     * @param stream     Xml Stream
+     * @param instanceId Instance Id for the TreeElement
+     * @return TreeElement for the given xml stream
+     * @throws IOException
+     * @throws UnfullfilledRequirementsException
+     * @throws XmlPullParserException
+     * @throws InvalidStructureException
+     */
+    public static TreeElement xmlStreamToTreeElement(InputStream stream, String instanceId)
+            throws IOException, UnfullfilledRequirementsException, XmlPullParserException,
+            InvalidStructureException {
+        KXmlParser baseParser = ElementParser.instantiateParser(stream);
+        TreeElement root = new TreeElementParser(baseParser, 0, instanceId).parse();
+        return root;
     }
 }

--- a/src/test/java/org/commcare/data/xml/TreeBuilderTest.java
+++ b/src/test/java/org/commcare/data/xml/TreeBuilderTest.java
@@ -3,8 +3,8 @@ package org.commcare.data.xml;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
-import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.TreeElement;
+import org.javarosa.core.model.instance.utils.TreeUtilities;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
 import org.junit.Test;
@@ -48,7 +48,7 @@ public class TreeBuilderTest {
                 "</node>",
                 "</test>"
         );
-        TreeElement expected = ExternalDataInstance.parseExternalTree(
+        TreeElement expected = TreeUtilities.xmlStreamToTreeElement(
                 new ByteArrayInputStream(expectedXml.getBytes(StandardCharsets.UTF_8)),
                 "test-instance"
         );

--- a/src/test/java/org/commcare/data/xml/VirtualInstancesTest.java
+++ b/src/test/java/org/commcare/data/xml/VirtualInstancesTest.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableMap;
 
 import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.TreeElement;
+import org.javarosa.core.model.instance.utils.TreeUtilities;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
 import org.junit.Test;
@@ -35,7 +36,7 @@ public class VirtualInstancesTest {
                 "<field name=\"key2\">val2</field>",
                 "</input>"
         );
-        TreeElement expected = ExternalDataInstance.parseExternalTree(
+        TreeElement expected = TreeUtilities.xmlStreamToTreeElement(
                 new ByteArrayInputStream(expectedXml.getBytes(StandardCharsets.UTF_8)),
                 instanceId
         );
@@ -56,7 +57,7 @@ public class VirtualInstancesTest {
                 "<value>case2</value>",
                 "</results>"
         );
-        TreeElement expected = ExternalDataInstance.parseExternalTree(
+        TreeElement expected = TreeUtilities.xmlStreamToTreeElement(
                 new ByteArrayInputStream(expectedXml.getBytes(StandardCharsets.UTF_8)),
                 instanceId
         );

--- a/src/test/java/org/javarosa/core/model/instance/test/DataInstanceTest.java
+++ b/src/test/java/org/javarosa/core/model/instance/test/DataInstanceTest.java
@@ -3,7 +3,7 @@ package org.javarosa.core.model.instance.test;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.TreeReference;
-import org.javarosa.core.model.instance.utils.FormLoadingUtils;
+import org.javarosa.core.model.instance.utils.InstanceUtils;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xpath.XPathException;
 import org.javarosa.xpath.XPathParseTool;
@@ -30,7 +30,7 @@ public class DataInstanceTest {
         // load the xml doc into a form instance
         FormInstance model = null;
         try {
-            model = FormLoadingUtils.loadFormInstance(formPath);
+            model = InstanceUtils.loadFormInstance(formPath);
         } catch (IOException e) {
             fail("Unable to load form at " + formPath);
         } catch (InvalidStructureException e) {

--- a/src/test/java/org/javarosa/test_utils/ExprEvalUtils.java
+++ b/src/test/java/org/javarosa/test_utils/ExprEvalUtils.java
@@ -2,7 +2,7 @@ package org.javarosa.test_utils;
 
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.FormInstance;
-import org.javarosa.core.model.instance.utils.FormLoadingUtils;
+import org.javarosa.core.model.instance.utils.InstanceUtils;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xpath.XPathException;
 import org.javarosa.xpath.XPathParseTool;
@@ -179,7 +179,7 @@ public class ExprEvalUtils {
     public static FormInstance loadInstance(String formPath) {
         FormInstance instance = null;
         try {
-            instance = FormLoadingUtils.loadFormInstance(formPath);
+            instance = InstanceUtils.loadFormInstance(formPath);
         } catch (IOException e) {
             fail("Unable to load form at " + formPath);
         } catch (InvalidStructureException e) {

--- a/src/test/java/org/javarosa/xform/util/test/XmlSerializerTests.java
+++ b/src/test/java/org/javarosa/xform/util/test/XmlSerializerTests.java
@@ -1,7 +1,7 @@
 package org.javarosa.xform.util.test;
 
 import org.javarosa.core.model.instance.FormInstance;
-import org.javarosa.core.model.instance.utils.FormLoadingUtils;
+import org.javarosa.core.model.instance.utils.InstanceUtils;
 import org.javarosa.core.services.transport.payload.ByteArrayPayload;
 import org.javarosa.core.services.transport.payload.IDataPayload;
 import org.javarosa.model.xform.XFormSerializingVisitor;
@@ -26,7 +26,7 @@ public class XmlSerializerTests {
     public void testParseXmlWithNonBMPCharacters() {
         FormInstance model = null;
         try {
-            model = FormLoadingUtils.loadFormInstance(formPath);
+            model = InstanceUtils.loadFormInstance(formPath);
             // Serialize the xml containing special characters.
             IDataPayload payload = new XFormSerializingVisitor().createSerializedPayload(model);
             assertTrue(payload instanceof ByteArrayPayload);


### PR DESCRIPTION
## Technical Summary

- [Major change](https://github.com/dimagi/commcare-core/commit/2e645e85123505092a2a7ed248bd6fd701616b8f) in PR is to generalise instance root as `AbstractTreeElement` so that we can support other storage backed roots in instance
- Some function renaming and moving around

## Safety Assurance

Abundant test coverage around changed methods, errors should surface at build time. 

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
Not required

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

FP: https://github.com/dimagi/formplayer/pull/1324
