### PR TITLE
Simplify SSL error catching

### DIFF
--- a/src/main/java/org/commcare/modern/reference/JavaHttpReference.java
+++ b/src/main/java/org/commcare/modern/reference/JavaHttpReference.java
@@ -10,8 +10,7 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-import javax.net.ssl.SSLHandshakeException;
-import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLException;
 
 /**
  * @author ctsims
@@ -44,7 +43,7 @@ public class JavaHttpReference implements Reference {
             HttpURLConnection.setFollowRedirects(true);
 
             return conn.getInputStream();
-        } catch (SSLHandshakeException | SSLPeerUnverifiedException e) {
+        } catch (SSLException e) {
             if(NetworkStatus.isCaptivePortal()) {
                 throw new CaptivePortalRedirectException();
             }


### PR DESCRIPTION
## Technical Summary
https://dimagi-dev.atlassian.net/browse/SAAS-10301

## Safety Assurance

### Safety story
This PR simply changes how SSL exceptions are caught in two locations in the code. The base class SSLException is caught instead of catching two sub-classes, i.e. SSLHandshakeException | SSLPeerUnverifiedException.

Catching the base class exception instead of two child classes provides more appropriate messaging for all SSL exceptions, but otherwise has no effect on app behavior.

### Automated test coverage
No related tests.

### QA Plan


### Special deploy instructions

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

cross-request: https://github.com/dimagi/commcare-android/pull/2638