### PR TITLE
Revert "Bump javax.ws.rs:javax.ws.rs-api from 2.0.1 to 2.1.1"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ sourceSets {
 
 dependencies {
     api 'com.github.stefanhaustein:kxml2:2.4.1'
-    implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
+    implementation 'javax.ws.rs:javax.ws.rs-api:2.0.1'
     // Added so Android Studio recognizes libs in util jar projects
     implementation 'org.json:json:20220924'
     implementation 'commons-cli:commons-cli:1.3.1'


### PR DESCRIPTION
Reverts dimagi/commcare-core#1237

This is causing Android builds to fail. I am not exactly sure where this is getting used on Android side but reverting it for the time being. 

Error on Android builds - 

````
No variants of javax.ws.rs:javax.ws.rs-api:2.1.1 match the consumer attributes:
14:04:18              - javax.ws.rs:javax.ws.rs-api:2.1.1 configuration runtime declares a runtime of a component:
14:04:18                  - Incompatible because this component declares a component, as well as attribute 'artifactType' with value '${packaging.type}' and the consumer needed a component, as well as attribute 'artifactType' with value 'android-classes-jar'
````
