### PR TITLE
Revert "Bump javax.ws.rs:javax.ws.rs-api from 2.0.1 to 2.1.1"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ sourceSets {
 
 dependencies {
     api 'com.github.stefanhaustein:kxml2:2.4.1'
-    implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
+    implementation 'javax.ws.rs:javax.ws.rs-api:2.0.1'
     // Added so Android Studio recognizes libs in util jar projects
     implementation 'org.json:json:20220924'
     implementation 'commons-cli:commons-cli:1.3.1'


### PR DESCRIPTION
Copy of https://github.com/dimagi/commcare-core/pull/1242