### PR TITLE
Duplicate PR Github Action

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -8,15 +8,7 @@ We try to keep both these branches in sync with each other the best we can. To d
 
 1. If you are working on a Formplayer change, you will want to start by checking out `your_feature_branch` from `formplayer` as the base branch. Make changes on `your_feature_branch` and create your original PR against `formplayer` branch.
 
-2. Now you will need to duplicate this PR by making another PR against `master`.
-
-    To do this with GitHub Action -
-    Make sure the branch for this PR is not deleted. Then create the comment `duplicate this PR`. If the PR has already been merged, comment `duplicate this PR <starting-commit-SHA>`.
-
-    To do this manually -
-    Firstly you would want to compare `your_feature_branch` to the `master` and see if the diff only shows the commit that belongs to your branch. If yes, you can directly create another PR from `your_feature_branch` to `master`.
-    Otherwise you will need to create another branch by checking out `your_feature_branch_dupe` from `master` as the base branch. You will then need to [cherry-pick](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/managing-commits/cherry-picking-a-commit#about-git-cherry-pick) each of the commits from `your_feature_branch` to `your_feature_branch_dupe`. 
-    Subsequently you should create a PR from `your_feature_branch_dupe` against `master`. While creating this PR you can remove all the PR template field and simply mention your original `formplayer` PR as a reference.
+2. Now you will need to duplicate this PR by making another PR against `master`. Make sure the branch for this PR is not deleted. Then create the comment `duplicate this PR`. If the PR has already been merged, comment `duplicate this PR <starting-commit-id>`.
 
 3. In order for us to test that your PR against `master` doesn't break anything on CommCare Android, we need to run android side tests with your PR.
 To do this - 
@@ -37,15 +29,7 @@ To do this -
 
 1. If you are working on a CommCare Android change, you will want to start by checking out `your_feature_branch` from `master` as the base branch. Make changes on `your_feature_branch` and create your original PR against `master` branch.
 
-2. Now you will need to duplicate this PR by making another PR against `formplayer`.
-
-    To do this with GitHub Action -
-    Make sure the branch for this PR is not deleted. Then create the comment `duplicate this PR`. If the PR has already been merged, comment `duplicate this PR <starting-commit-SHA>`.
-
-    To do this manually -
-    Firstly you would want to compare `your_feature_branch` to the `formplayer` and see if the diff only shows the commit that belongs to your branch. If yes, you can directly create another PR from `your_feature_branch` to `formplayer`.
-    Otherwise you will need to create another branch by checking out `your_feature_branch_dupe` from `formplayer` as the base branch. You will then need to [cherry-pick](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/managing-commits/cherry-picking-a-commit#about-git-cherry-pick) each of the commits from `your_feature_branch` to `your_feature_branch_dupe`.
-    Subsequently you should create a PR from `your_feature_branch_dupe` against `formplayer`. While creating this PR you can remove all the PR template field and simply mention your original `master` PR as a reference.
+2. Now you will need to duplicate this PR by making another PR against `formplayer`. Make sure the branch for this PR is not deleted. Then create the comment `duplicate this PR`. If the PR has already been merged, comment `duplicate this PR <starting-commit-id>`.
 
 3. In order for us to test that your PR against `formplayer` doesn't break anything on Formplayer, we need to run formplayer side tests with your PR.
 To do this - 

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -8,9 +8,15 @@ We try to keep both these branches in sync with each other the best we can. To d
 
 1. If you are working on a Formplayer change, you will want to start by checking out `your_feature_branch` from `formplayer` as the base branch. Make changes on `your_feature_branch` and create your original PR against `formplayer` branch.
 
-2. Now you will need to duplicate this PR by making another PR against `master`. To do this, firstly you would want to compare `your_feature_branch` to the `master` and see if the diff only shows the commit that belongs to your branch. If yes, you can directly create another PR from `your_feature_branch` to `master`. 
-Otherwise you will need to create another branch by checking out `your_feature_branch_dupe` from `master` as the base branch. You will then need to [cherry-pick](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/managing-commits/cherry-picking-a-commit#about-git-cherry-pick) each of the commits from `your_feature_branch` to `your_feature_branch_dupe`. 
-Subsequently you should create a PR from `your_feature_branch_dupe` against `master`. While creating this PR you can remove all the PR template field and simply mention your original `formplayer` PR as a reference. 
+2. Now you will need to duplicate this PR by making another PR against `master`.
+
+    To do this with GitHub Action -
+    Make sure the branch for this PR is not deleted. Then create the comment `duplicate this PR`. If the PR has already been merged, comment `duplicate this PR <starting-commit-SHA>`.
+
+    To do this manually -
+    Firstly you would want to compare `your_feature_branch` to the `master` and see if the diff only shows the commit that belongs to your branch. If yes, you can directly create another PR from `your_feature_branch` to `master`.
+    Otherwise you will need to create another branch by checking out `your_feature_branch_dupe` from `master` as the base branch. You will then need to [cherry-pick](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/managing-commits/cherry-picking-a-commit#about-git-cherry-pick) each of the commits from `your_feature_branch` to `your_feature_branch_dupe`. 
+    Subsequently you should create a PR from `your_feature_branch_dupe` against `master`. While creating this PR you can remove all the PR template field and simply mention your original `formplayer` PR as a reference.
 
 3. In order for us to test that your PR against `master` doesn't break anything on CommCare Android, we need to run android side tests with your PR.
 To do this - 
@@ -31,9 +37,15 @@ To do this -
 
 1. If you are working on a CommCare Android change, you will want to start by checking out `your_feature_branch` from `master` as the base branch. Make changes on `your_feature_branch` and create your original PR against `master` branch.
 
-2. Now you will need to duplicate this PR by making another PR against `formplayer`. To do this, firstly you would want to compare `your_feature_branch` to the `formplayer` and see if the diff only shows the commit that belongs to your branch. If yes, you can directly create another PR from `your_feature_branch` to `formplayer`. 
-Otherwise you will need to create another branch by checking out `your_feature_branch_dupe` from `formplayer` as the base branch. You will then need to [cherry-pick](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/managing-commits/cherry-picking-a-commit#about-git-cherry-pick) each of the commits from `your_feature_branch` to `your_feature_branch_dupe`. 
-Subsequently you should create a PR from `your_feature_branch_dupe` against `formplayer`. While creating this PR you can remove all the PR template field and simply mention your original `master` PR as a reference. 
+2. Now you will need to duplicate this PR by making another PR against `formplayer`.
+
+    To do this with GitHub Action -
+    Make sure the branch for this PR is not deleted. Then create the comment `duplicate this PR`. If the PR has already been merged, comment `duplicate this PR <starting-commit-SHA>`.
+
+    To do this manually -
+    Firstly you would want to compare `your_feature_branch` to the `formplayer` and see if the diff only shows the commit that belongs to your branch. If yes, you can directly create another PR from `your_feature_branch` to `formplayer`.
+    Otherwise you will need to create another branch by checking out `your_feature_branch_dupe` from `formplayer` as the base branch. You will then need to [cherry-pick](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/managing-commits/cherry-picking-a-commit#about-git-cherry-pick) each of the commits from `your_feature_branch` to `your_feature_branch_dupe`.
+    Subsequently you should create a PR from `your_feature_branch_dupe` against `formplayer`. While creating this PR you can remove all the PR template field and simply mention your original `master` PR as a reference.
 
 3. In order for us to test that your PR against `formplayer` doesn't break anything on Formplayer, we need to run formplayer side tests with your PR.
 To do this - 

--- a/.github/workflows/duplicate_pr.yml
+++ b/.github/workflows/duplicate_pr.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   duplicate_pr:
     name: Duplicate PR
-    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body,'@dimagibot duplicate this PR') }}
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body,'duplicate this PR') }}
     runs-on: ubuntu-latest
     steps:
       # https://github.com/marketplace/actions/github-script

--- a/.github/workflows/duplicate_pr.yml
+++ b/.github/workflows/duplicate_pr.yml
@@ -47,24 +47,18 @@ jobs:
       - name: Run duplicate_pr.py script with PR not merged
         if: ${{ github.event.issue.pull_request.merged_at == null }}
         run: python scripts/duplicate_pr.py ${{ steps.comment-branch.outputs.head_ref }} ${{ steps.comment-branch.outputs.base_ref }}
-      - name: Create Pull Request Base Master
-        if: ${{ steps.comment-branch.outputs.base_ref == 'formplayer' }}
-        run: gh pr create --title "${title_text}" --body "${body_text}" --base master 
+      - name: Determine Base Branch
+        id: base-branch
+        run: |
+          if [[ ${{ steps.comment-branch.outputs.base_ref}} = "formplayer" ]]
+          then echo "NAME=master" >> $GITHUB_OUTPUT
+          elif [[ ${{ steps.comment-branch.outputs.base_ref}} = "master" ]]
+          then echo "NAME=formplayer" >> $GITHUB_OUTPUT
+          fi
+      - name: Create Pull Request
+        run: gh pr create --title "${title_text}" --body "${body_text}" --base "${base_branch_name}"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          title_text: Duplicate of ${{ steps.comment-branch.outputs.head_ref }}
-          body_text: |
-            Copy of PR ${{github.event.issue.pull_request.html_url}} and used GitHub CLI to open this pull request.
-
-            GitHub Actions automatically ran duplicate_pr.py
-            
-            Please **close and reopen** this pull request to have tests run.<sup>†</sup>
-
-            <sup>†</sup> Workaround for [this GitHub Actions constraint](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)
-      - name: Create Pull Request Base Formplayer
-        if: ${{ steps.comment-branch.outputs.base_ref == 'master' }}
-        run: gh pr create --title "${title_text}" --body "${body_text}" --base formplayer 
-        env:
+          base_branch_name: ${{ steps.base-branch.outputs.NAME }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           title_text: Duplicate of ${{ steps.comment-branch.outputs.head_ref }}
           body_text: |

--- a/.github/workflows/duplicate_pr.yml
+++ b/.github/workflows/duplicate_pr.yml
@@ -11,6 +11,15 @@ jobs:
     if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body,'@dimagibot duplicate this PR') }}
     runs-on: ubuntu-latest
     steps:
+      # https://github.com/marketplace/actions/github-script
+      - name: Get PR Intial Commit SHA
+        if: ${{ github.event.issue.pull_request.merged_at }}
+        id: initial-sha
+        uses: actions/github-script@0.9.0
+        with:
+          script: |
+            const sha = context.payload.comment.body.split(" ").pop()
+            core.setOutput('sha', sha)
       # https://github.com/marketplace/actions/pull-request-comment-branch
       - name: Pull Request Comment Branch
         uses: xt0rted/pull-request-comment-branch@v2.0.0
@@ -28,7 +37,15 @@ jobs:
         run: |
           git config --global user.email github-actions@github.com
           git config --global user.name github-actions
+      - name: Run duplicate_pr.py script with PR merged
+        if: ${{ github.event.issue.pull_request.merged_at }}
+        run: |
+          echo Intial SHA is "${{ steps.initial-sha.outputs.sha }}"
+          python scripts/duplicate_pr.py ${{ steps.comment-branch.outputs.head_ref }} ${{ steps.comment-branch.outputs.base_ref }} --initial_sha ${initial_sha}
+        env:
+          initial_sha: ${{ steps.initial-sha.outputs.sha }}
       - name: Run duplicate_pr.py script with PR not merged
+        if: ${{ github.event.issue.pull_request.merged_at == null }}
         run: python scripts/duplicate_pr.py ${{ steps.comment-branch.outputs.head_ref }} ${{ steps.comment-branch.outputs.base_ref }}
       - name: Create Pull Request Base Master
         if: ${{ steps.comment-branch.outputs.base_ref == 'formplayer' }}

--- a/.github/workflows/duplicate_pr.yml
+++ b/.github/workflows/duplicate_pr.yml
@@ -30,3 +30,31 @@ jobs:
           git config --global user.name github-actions
       - name: Run duplicate_pr.py script with PR not merged
         run: python scripts/duplicate_pr.py ${{ steps.comment-branch.outputs.head_ref }} ${{ steps.comment-branch.outputs.base_ref }}
+      - name: Create Pull Request Base Master
+        if: ${{ steps.comment-branch.outputs.base_ref == 'formplayer' }}
+        run: gh pr create --title "${title_text}" --body "${body_text}" --base master 
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          title_text: Duplicate of ${{ steps.comment-branch.outputs.head_ref }}
+          body_text: |
+            Copy of PR ${{github.event.issue.pull_request.html_url}} and used GitHub CLI to open this pull request.
+
+            GitHub Actions automatically ran duplicate_pr.py
+            
+            Please **close and reopen** this pull request to have tests run.<sup>†</sup>
+
+            <sup>†</sup> Workaround for [this GitHub Actions constraint](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)
+      - name: Create Pull Request Base Formplayer
+        if: ${{ steps.comment-branch.outputs.base_ref == 'master' }}
+        run: gh pr create --title "${title_text}" --body "${body_text}" --base formplayer 
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          title_text: Duplicate of ${{ steps.comment-branch.outputs.head_ref }}
+          body_text: |
+            Copy of PR ${{github.event.issue.pull_request.html_url}}
+
+            GitHub Actions automatically ran duplicate_pr.py and used GitHub CLI to open this pull request.
+            
+            Please **close and reopen** this pull request to have tests run.<sup>†</sup>
+
+            <sup>†</sup> Workaround for [this GitHub Actions constraint](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)

--- a/.github/workflows/duplicate_pr.yml
+++ b/.github/workflows/duplicate_pr.yml
@@ -1,0 +1,32 @@
+name: Duplicate PR
+
+#Duplication workflow must be run before PR branch is deleted
+on:
+  issue_comment:
+    types: [created, edited]
+
+jobs:
+  duplicate_pr:
+    name: Duplicate PR
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body,'@dimagibot duplicate this PR') }}
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/marketplace/actions/pull-request-comment-branch
+      - name: Pull Request Comment Branch
+        uses: xt0rted/pull-request-comment-branch@v2.0.0
+        id: comment-branch
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Install Requirements
+        run: pip install sh
+      - name: Config Git
+        run: |
+          git config --global user.email github-actions@github.com
+          git config --global user.name github-actions
+      - name: Run duplicate_pr.py script with PR not merged
+        run: python scripts/duplicate_pr.py ${{ steps.comment-branch.outputs.head_ref }} ${{ steps.comment-branch.outputs.base_ref }}

--- a/scripts/duplicate_pr.py
+++ b/scripts/duplicate_pr.py
@@ -52,6 +52,8 @@ def git_fetch_branch(branch_name:str):
 
 def get_new_commits(base_branch: str, curr_branch:str):
     git = get_git()
+    if base_branch != BranchName.MASTER.value:
+        git_fetch_branch(base_branch)
     base_commit = merge_base_commit(base_branch, curr_branch)
     recent_commit = latest_commit(curr_branch)
 

--- a/scripts/duplicate_pr.py
+++ b/scripts/duplicate_pr.py
@@ -79,7 +79,10 @@ def cherry_pick_new_commits(commits:list[str], branch:str):
 
 def git_push_pr(branch:str):
     git = get_git()
-    output = git.push("origin", branch, _err_to_out=True)
+    try:
+        output = git.push("origin", branch, _err_to_out=True)
+    except sh.ErrorReturnCode_1 as e:
+        print(red("Failed to push. Branch {} already exists remotely. Try deleting remote branch and run action again".format(branch)))
     print(output)
 
 

--- a/scripts/duplicate_pr.py
+++ b/scripts/duplicate_pr.py
@@ -26,7 +26,8 @@ def get_target_branch(orig_target_branch:str):
 def git_create_branch(orig_branch_name:str, new_branch_name: str):
     git = get_git()
     try:
-        git_fetch_branch(orig_branch_name)
+        if orig_branch_name != BranchName.MASTER.value:
+            git_fetch_branch(orig_branch_name)
         git.checkout(orig_branch_name)
     except sh.ErrorReturnCode_1 as e:
         print(red(e.stderr.decode()))

--- a/scripts/duplicate_pr.py
+++ b/scripts/duplicate_pr.py
@@ -69,7 +69,12 @@ def cherry_pick_new_commits(commits:list[str], branch:str):
     git = get_git()
     git.checkout(branch)
     for commits in reversed(commits):
-        git("cherry-pick", commits)
+        try:
+            empty_commit_message = "The previous cherry-pick is now empty"
+            git("cherry-pick", commits)
+        except sh.ErrorReturnCode_1 as e:
+            if empty_commit_message in e.stderr.decode():
+                git("cherry-pick", "--skip")
 
 
 def git_push_pr(branch:str):


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->
Script for internal use.

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
https://dimagi-dev.atlassian.net/browse/USH-2669
Creates a GitHub Action on the issue_comment event to trigger duplicate_pr.py. Also adds ability to duplicate a PR that has already been merged by specifying the starting SHA to cherrypick from.

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
Tested action on a different repo. Has no impact on data. There was consideration on needing to sanitize inputs and is handled by passing inputs through an environment variable. 
https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->
No automated test.
### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
No QA.
### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [X] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations.

### Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change.
