### PR TITLE
Rc/custom assertions core

### DIFF
--- a/src/main/java/org/commcare/suite/model/AssertionSet.java
+++ b/src/main/java/org/commcare/suite/model/AssertionSet.java
@@ -69,6 +69,19 @@ public class AssertionSet implements Externalizable {
         return this.xpathExpressions;
     }
 
+    public Text evalAssertionAtIndex(Integer i, XPathExpression expression, EvaluationContext ec) {
+        try {
+            Object val = expression.eval(ec);
+            if (!FunctionUtils.toBoolean(val)) {
+                return messages.elementAt(i);
+            }
+        } catch (Exception e) {
+            return messages.elementAt(i);
+        }
+
+        return null;
+    }
+
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         this.xpathExpressions = (Vector<String>)ExtUtil.read(in, new ExtWrapList(String.class), pf);

--- a/src/main/java/org/commcare/suite/model/AssertionSet.java
+++ b/src/main/java/org/commcare/suite/model/AssertionSet.java
@@ -65,6 +65,10 @@ public class AssertionSet implements Externalizable {
         }
     }
 
+    public Vector<String> getAssertionsXPaths() {
+        return this.xpathExpressions;
+    }
+
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         this.xpathExpressions = (Vector<String>)ExtUtil.read(in, new ExtWrapList(String.class), pf);

--- a/src/main/java/org/commcare/suite/model/Menu.java
+++ b/src/main/java/org/commcare/suite/model/Menu.java
@@ -4,6 +4,7 @@ import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.ExtWrapList;
+import org.javarosa.core.util.externalizable.ExtWrapNullable;
 import org.javarosa.core.util.externalizable.Externalizable;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.xpath.XPathParseTool;
@@ -36,6 +37,7 @@ public class Menu implements Externalizable, MenuDisplayable {
     private String rawRelevance;
     private String style;
     private XPathExpression relevance;
+    AssertionSet assertions;
 
     /**
      * Serialization only!!!
@@ -46,7 +48,8 @@ public class Menu implements Externalizable, MenuDisplayable {
 
     public Menu(String id, String root, String rawRelevance,
                 XPathExpression relevance, DisplayUnit display,
-                Vector<String> commandIds, String[] commandExprs, String style) {
+                Vector<String> commandIds, String[] commandExprs,
+                String style, AssertionSet assertions) {
         this.id = id;
         this.root = root;
         this.rawRelevance = rawRelevance;
@@ -55,6 +58,7 @@ public class Menu implements Externalizable, MenuDisplayable {
         this.commandIds = commandIds;
         this.commandExprs = commandExprs;
         this.style = style;
+        this.assertions = assertions;
     }
 
     /**
@@ -115,6 +119,10 @@ public class Menu implements Externalizable, MenuDisplayable {
         return commandExprs[index] == null ? null : XPathParseTool.parseXPath(commandExprs[index]);
     }
 
+    public AssertionSet getAssertions() {
+        return assertions == null ? new AssertionSet(new Vector<String>(), new Vector<Text>()) : assertions;
+    }
+
     /**
      * @return an optional string indicating how this menu wants to display its items
      */
@@ -146,6 +154,7 @@ public class Menu implements Externalizable, MenuDisplayable {
             }
         }
         style = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
+        assertions = (AssertionSet)ExtUtil.read(in, new ExtWrapNullable(AssertionSet.class), pf);
     }
 
     @Override
@@ -166,6 +175,7 @@ public class Menu implements Externalizable, MenuDisplayable {
         }
 
         ExtUtil.writeString(out, ExtUtil.emptyIfNull(style));
+        ExtUtil.write(out, new ExtWrapNullable(assertions));
     }
 
 

--- a/src/main/java/org/commcare/suite/model/MenuLoader.java
+++ b/src/main/java/org/commcare/suite/model/MenuLoader.java
@@ -73,7 +73,7 @@ public class MenuLoader {
             for (Menu m : s.getMenus()) {
                 try {
                     if (m.getId().equals(menuID)) {
-                        if (menuIsRelevant(sessionWrapper, m)) {
+                        if (menuIsRelevant(sessionWrapper, m) && menuAssertionsPass(sessionWrapper, m)) {
                             addRelevantCommandEntries(sessionWrapper, m, items, badges, map, includeBadges);
                         }
                     } else {
@@ -143,6 +143,11 @@ public class MenuLoader {
             return result;
         }
         return true;
+    }
+
+    public boolean menuAssertionsPass(SessionWrapperInterface sessionWrapper, Menu m) {
+        Text text =  m.getAssertions().getAssertionFailure(sessionWrapper.getEvaluationContext());
+        return text == null;
     }
 
     private void addRelevantCommandEntries(SessionWrapperInterface sessionWrapper,

--- a/src/main/java/org/commcare/suite/model/MenuLoader.java
+++ b/src/main/java/org/commcare/suite/model/MenuLoader.java
@@ -147,7 +147,10 @@ public class MenuLoader {
 
     public boolean menuAssertionsPass(SessionWrapperInterface sessionWrapper, Menu m) {
         Text text =  m.getAssertions().getAssertionFailure(sessionWrapper.getEvaluationContext());
-        return text == null;
+        if (text != null) {
+            loadException = new Exception(text.evaluate());
+        }
+        return true;
     }
 
     private void addRelevantCommandEntries(SessionWrapperInterface sessionWrapper,

--- a/src/main/java/org/commcare/suite/model/MenuLoader.java
+++ b/src/main/java/org/commcare/suite/model/MenuLoader.java
@@ -149,6 +149,7 @@ public class MenuLoader {
         Text text =  m.getAssertions().getAssertionFailure(sessionWrapper.getEvaluationContext());
         if (text != null) {
             loadException = new Exception(text.evaluate());
+            return false;
         }
         return true;
     }

--- a/src/main/java/org/commcare/xml/MenuParser.java
+++ b/src/main/java/org/commcare/xml/MenuParser.java
@@ -93,6 +93,7 @@ public class MenuParser extends CommCareElementParser<Menu> {
         String[] expressions = new String[relevantExprs.size()];
         relevantExprs.copyInto(expressions);
 
-        return new Menu(id, root, relevant, relevantExpression, display, commandIds, expressions, style, assertions);
+        return new Menu(id, root, relevant, relevantExpression, display, commandIds, expressions,
+                style, assertions);
     }
 }

--- a/src/test/java/org/commcare/backend/session/test/MenuTests.java
+++ b/src/test/java/org/commcare/backend/session/test/MenuTests.java
@@ -12,7 +12,9 @@ import org.javarosa.core.model.condition.EvaluationContext;
 import org.junit.Before;
 import org.junit.Test;
 
-
+/**
+ * Tests for assertions in menus
+ */
 public class MenuTests {
 
     MockApp appWithMenuAssertions;

--- a/src/test/java/org/commcare/backend/session/test/MenuTests.java
+++ b/src/test/java/org/commcare/backend/session/test/MenuTests.java
@@ -1,0 +1,37 @@
+package org.commcare.backend.session.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.commcare.suite.model.AssertionSet;
+import org.commcare.suite.model.Menu;
+import org.commcare.suite.model.Suite;
+import org.commcare.suite.model.Text;
+import org.commcare.test.utilities.MockApp;
+import org.javarosa.core.model.condition.EvaluationContext;
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class MenuTests {
+
+    MockApp appWithMenuAssertions;
+    Suite suite;
+
+    @Before
+    public void setup() throws Exception {
+        appWithMenuAssertions = new MockApp("/app_structure/");
+        suite = appWithMenuAssertions.getSession().getPlatform().getInstalledSuites().get(0);
+    }
+
+
+    @Test
+    public void testAssertionsEvaluated() throws Exception {
+        Menu menuWithAssertionsBlock = suite.getMenusWithId("m0").get(0);
+        AssertionSet assertions = menuWithAssertionsBlock.getAssertions();
+        EvaluationContext ec = appWithMenuAssertions.getSession().getEvaluationContext();
+        Text assertionFailures = assertions.getAssertionFailure(ec);
+        assertNotNull(assertions);
+        assertEquals("custom_assertion.m0.0", assertionFailures.getArgument());
+    }
+}

--- a/src/test/java/org/commcare/backend/suite/model/test/AppStructureTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/AppStructureTests.java
@@ -1,6 +1,7 @@
 package org.commcare.backend.suite.model.test;
 
 import org.commcare.resources.model.UnresolvedResourceException;
+import org.commcare.suite.model.AssertionSet;
 import org.commcare.suite.model.Callout;
 import org.commcare.suite.model.DetailField;
 import org.commcare.suite.model.GeoOverlay;
@@ -199,4 +200,11 @@ public class AppStructureTests {
         }
     }
 
+    @Test
+    public void testMenuAssertions() {
+        Suite s = mApp.getSession().getPlatform().getInstalledSuites().get(0);
+        Menu menuWithAssertionsBlock = s.getMenusWithId("m0").get(0);
+        AssertionSet assertions = menuWithAssertionsBlock.getAssertions();
+        Assert.assertNotNull(assertions);
+    }
 }

--- a/src/test/resources/app_structure/suite.xml
+++ b/src/test/resources/app_structure/suite.xml
@@ -185,6 +185,18 @@
   <menu id="m0">
     <text>Menu</text>
     <command id="m0-f0"/>
+    <assertions>
+      <assert test="2 - 1 = 1">
+        <text>
+          <locale id="custom_assertion.m0.0"/>
+        </text>
+      </assert>
+      <assert test="0 + 1 = 0">
+        <text>
+          <locale id="custom_assertion.m0.0"/>
+        </text>
+      </assert>
+    </assertions>
   </menu>
 
   <menu id="root" style="grid">


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->
This handles custom assertions in menus. Menus will be displayed or not depending on the evaluation of the assertions.

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
https://docs.google.com/document/d/112St-i7h7jZHpqxcAU-d6VASftXKLfiFnqkS3ovsEVU/edit#heading=h.37a7vgf78nog
Jira ticket:  https://dimagi-dev.atlassian.net/browse/USH-2983
Jira epic with this and HQ tickets: https://dimagi-dev.atlassian.net/browse/USH-2905


## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
Feature Flagged (CUSTOM_ASSERTIONS: Inject custom assertions into the suite), will go through QA

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->
tests add here

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
will be tested in QA along with required HQ changes


<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
