### PR TITLE
Move common code for Case parsers to a Util Class

### DIFF
--- a/src/main/java/org/commcare/xml/CaseIndexChangeListener.java
+++ b/src/main/java/org/commcare/xml/CaseIndexChangeListener.java
@@ -1,0 +1,21 @@
+package org.commcare.xml;
+
+/**
+ * listener for any changes to case indexes due to processing a case transaction
+ */
+public interface CaseIndexChangeListener {
+
+
+    /**
+     * A signal that notes that processing a transaction has resulted in a
+     * potential change in what cases should be on the phone. This can be
+     * due to a case's owner changing, a case closing, an index moving, etc.
+     *
+     * Does not have to be consumed, but can be used to identify proactively
+     * when to reconcile what cases should be available.
+     *
+     * @param caseId The ID of a case which has changed in a potentially
+     *               disruptive way
+     */
+    abstract void onIndexDisrupted(String caseId);
+}

--- a/src/main/java/org/commcare/xml/CaseXmlParser.java
+++ b/src/main/java/org/commcare/xml/CaseXmlParser.java
@@ -31,12 +31,6 @@ import java.util.NoSuchElementException;
  */
 public class CaseXmlParser extends TransactionParser<Case> {
 
-    public static final String ATTACHMENT_FROM_LOCAL = "local";
-    public static final String ATTACHMENT_FROM_REMOTE = "remote";
-    public static final String ATTACHMENT_FROM_INLINE = "inline";
-
-    public static final String CASE_XML_NAMESPACE = "http://commcarehq.org/case/transaction/v2";
-
     private final IStorageUtilityIndexed storage;
     private final boolean acceptCreateOverwrites;
 

--- a/src/main/java/org/commcare/xml/CaseXmlParser.java
+++ b/src/main/java/org/commcare/xml/CaseXmlParser.java
@@ -1,5 +1,19 @@
 package org.commcare.xml;
 
+import static org.commcare.xml.CaseXmlParserUtil.CASE_NODE;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_NODE_NAME;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_CASE_ID;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_CASE_NAME;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_CASE_TYPE;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_CATEGORY;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_DATE_MODIFIED;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_DATE_OPENED;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_EXTERNAL_ID;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_OWNER_ID;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_STATE;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_USER_ID;
+import static org.commcare.xml.CaseXmlParserUtil.validateMandatoryProperty;
+
 import org.commcare.cases.model.Case;
 import org.commcare.cases.model.CaseIndex;
 import org.commcare.data.xml.TransactionParser;
@@ -55,25 +69,22 @@ public class CaseXmlParser extends TransactionParser<Case> {
 
     @Override
     public Case parse() throws InvalidStructureException, IOException, XmlPullParserException {
-        checkNode("case");
+        checkNode(CASE_NODE_NAME);
 
-        String caseId = parser.getAttributeValue(null, "case_id");
-        if (caseId == null || caseId.equals("")) {
-            throw InvalidStructureException.readableInvalidStructureException("The case_id attribute of a <case> wasn't set", parser);
-        }
+        String caseId = parser.getAttributeValue(null, CASE_PROPERTY_CASE_ID);
+        validateMandatoryProperty(CASE_PROPERTY_CASE_ID, caseId, "", parser);
 
-        String dateModified = parser.getAttributeValue(null, "date_modified");
-        if (dateModified == null) {
-            throw InvalidStructureException.readableInvalidStructureException("The date_modified attribute of a <case> wasn't set", parser);
-        }
+        String dateModified = parser.getAttributeValue(null, CASE_PROPERTY_DATE_MODIFIED);
+        validateMandatoryProperty(CASE_PROPERTY_DATE_MODIFIED, dateModified, caseId, parser);
+
         Date modified = DateUtils.parseDateTime(dateModified);
 
-        String userId = parser.getAttributeValue(null, "user_id");
+        String userId = parser.getAttributeValue(null, CASE_PROPERTY_USER_ID);
 
         Case caseForBlock = null;
         boolean isCreateOrUpdate = false;
 
-        while (nextTagInBlock("case")) {
+        while (nextTagInBlock(CASE_NODE_NAME)) {
             String action = parser.getName().toLowerCase();
             switch (action) {
                 case "create":
@@ -126,13 +137,13 @@ public class CaseXmlParser extends TransactionParser<Case> {
         while (nextTagInBlock("create")) {
             String tag = parser.getName();
             switch (tag) {
-                case "case_type":
+                case CASE_PROPERTY_CASE_TYPE:
                     data[0] = parser.nextText().trim();
                     break;
-                case "owner_id":
+                case CASE_PROPERTY_OWNER_ID:
                     data[1] = parser.nextText().trim();
                     break;
-                case "case_name":
+                case CASE_PROPERTY_CASE_NAME:
                     data[2] = parser.nextText().trim();
                     break;
                 default:
@@ -181,16 +192,16 @@ public class CaseXmlParser extends TransactionParser<Case> {
             String value = parser.nextText().trim();
 
             switch (key) {
-                case "case_type":
+                case CASE_PROPERTY_CASE_TYPE:
                     caseForBlock.setTypeId(value);
                     break;
-                case "case_name":
+                case CASE_PROPERTY_CASE_NAME:
                     caseForBlock.setName(value);
                     break;
-                case "date_opened":
+                case CASE_PROPERTY_DATE_OPENED:
                     caseForBlock.setDateOpened(DateUtils.parseDate(value));
                     break;
-                case "owner_id":
+                case CASE_PROPERTY_OWNER_ID:
                     String oldUserId = caseForBlock.getUserId();
 
                     if (!oldUserId.equals(value)) {
@@ -198,13 +209,13 @@ public class CaseXmlParser extends TransactionParser<Case> {
                     }
                     caseForBlock.setUserId(value);
                     break;
-                case "external_id":
+                case CASE_PROPERTY_EXTERNAL_ID:
                     caseForBlock.setExternalId(value);
                     break;
-                case "category":
+                case CASE_PROPERTY_CATEGORY:
                     caseForBlock.setCategory(value);
                     break;
-                case "state":
+                case CASE_PROPERTY_STATE:
                     caseForBlock.setState(value);
                     break;
                 default:

--- a/src/main/java/org/commcare/xml/CaseXmlParser.java
+++ b/src/main/java/org/commcare/xml/CaseXmlParser.java
@@ -52,7 +52,7 @@ import java.util.NoSuchElementException;
  *
  * @author ctsims
  */
-public class CaseXmlParser extends TransactionParser<Case> {
+public class CaseXmlParser extends TransactionParser<Case> implements CaseIndexChangeListener {
 
     private final IStorageUtilityIndexed storage;
     private final boolean acceptCreateOverwrites;
@@ -335,17 +335,7 @@ public class CaseXmlParser extends TransactionParser<Case> {
         return storage;
     }
 
-    /**
-     * A signal that notes that processing a transaction has resulted in a
-     * potential change in what cases should be on the phone. This can be
-     * due to a case's owner changing, a case closing, an index moving, etc.
-     *
-     * Does not have to be consumed, but can be used to identify proactively
-     * when to reconcile what cases should be available.
-     *
-     * @param caseId The ID of a case which has changed in a potentially
-     *               disruptive way
-     */
+    @Override
     public void onIndexDisrupted(String caseId) {
 
     }

--- a/src/main/java/org/commcare/xml/CaseXmlParser.java
+++ b/src/main/java/org/commcare/xml/CaseXmlParser.java
@@ -12,6 +12,7 @@ import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_EXTERNAL_ID;
 import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_OWNER_ID;
 import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_STATE;
 import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_USER_ID;
+import static org.commcare.xml.CaseXmlParserUtil.checkForMaxLength;
 import static org.commcare.xml.CaseXmlParserUtil.validateMandatoryProperty;
 
 import org.commcare.cases.model.Case;
@@ -224,25 +225,6 @@ public class CaseXmlParser extends TransactionParser<Case> {
             }
         }
         checkForMaxLength(caseForBlock);
-    }
-
-    private void checkForMaxLength(Case caseForBlock) throws InvalidStructureException {
-        if (getStringLength(caseForBlock.getTypeId()) > 255) {
-            throw new InvalidCasePropertyLengthException("case_type");
-        } else if (getStringLength(caseForBlock.getUserId()) > 255) {
-            throw new InvalidCasePropertyLengthException("owner_id");
-        } else if (getStringLength(caseForBlock.getName()) > 255) {
-            throw new InvalidCasePropertyLengthException("case_name");
-        } else if (getStringLength(caseForBlock.getExternalId()) > 255) {
-            throw new InvalidCasePropertyLengthException("external_id");
-        }
-    }
-
-    /**
-     * Returns the length of string if it's not null, otherwise 0.
-     */
-    private int getStringLength(String input) {
-        return input != null ? input.length() : 0;
     }
 
     private Case loadCase(Case caseForBlock, String caseId, boolean errorIfMissing) throws InvalidStructureException {

--- a/src/main/java/org/commcare/xml/CaseXmlParserUtil.java
+++ b/src/main/java/org/commcare/xml/CaseXmlParserUtil.java
@@ -6,7 +6,12 @@ import org.javarosa.xml.util.InvalidStructureException;
 import org.kxml2.io.KXmlParser;
 
 public class CaseXmlParserUtil {
-    public static final String CASE_NODE_NAME = "case";
+    public static final String CASE_NODE = "case";
+    public static final String CASE_CREATE_NODE = "create";
+    public static final String CASE_UPDATE_NODE = "update";
+    public static final String CASE_CLOSE_NODE = "close";
+    public static final String CASE_INDEX_NODE = "index";
+    public static final String CASE_ATTACHMENT_NODE = "attachment";
     public static final String CASE_PROPERTY_CASE_ID = "case_id";
     public static final String CASE_PROPERTY_CASE_TYPE = "case_type";
     public static final String CASE_PROPERTY_OWNER_ID = "owner_id";
@@ -20,10 +25,11 @@ public class CaseXmlParserUtil {
     public static final String CASE_PROPERTY_CATEGORY = "category";
     public static final String CASE_PROPERTY_STATE = "state";
     public static final String CASE_PROPERTY_INDEX = "index";
-    public static final String ATTACHMENT_FROM_LOCAL = "local";
-    public static final String ATTACHMENT_FROM_REMOTE = "remote";
-    public static final String ATTACHMENT_FROM_INLINE = "inline";
-    public static final String CASE_XML_NAMESPACE = "http://commcarehq.org/case/transaction/v2";
+    public static final String CASE_PROPERTY_INDEX_CASE_TYPE = "case_type";
+    public static final String CASE_PROPERTY_INDEX_RELATIONSHIP = "relationship";
+    public static final String CASE_PROPERTY_ATTACHMENT_SRC = "src";
+    public static final String CASE_PROPERTY_ATTACHMENT_FROM = "from";
+    public static final String CASE_PROPERTY_ATTACHMENT_NAME = "name";
 
 
     public static void validateMandatoryProperty(String key, Object value, String caseId, KXmlParser parser) throws

--- a/src/main/java/org/commcare/xml/CaseXmlParserUtil.java
+++ b/src/main/java/org/commcare/xml/CaseXmlParserUtil.java
@@ -1,6 +1,7 @@
 package org.commcare.xml;
 
 import org.commcare.cases.model.Case;
+import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.xml.util.InvalidCasePropertyLengthException;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.kxml2.io.KXmlParser;
@@ -57,6 +58,19 @@ public class CaseXmlParserUtil {
      */
     private static int getStringLength(String input) {
         return input != null ? input.length() : 0;
+    }
+
+    /**
+     * Trims and returns elements value or empty string
+     * @param element TreeElement we want the value for
+     * @return empty string if element value is null, otherwise the trimmed value for element
+     */
+    public static String getTrimmedElementTextOrBlank(TreeElement element) {
+        if (element.getValue() == null) {
+            return "";
+        }
+
+        return element.getValue().uncast().getString().trim();
     }
 
 }

--- a/src/main/java/org/commcare/xml/CaseXmlParserUtil.java
+++ b/src/main/java/org/commcare/xml/CaseXmlParserUtil.java
@@ -1,5 +1,7 @@
 package org.commcare.xml;
 
+import org.commcare.cases.model.Case;
+import org.javarosa.xml.util.InvalidCasePropertyLengthException;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.kxml2.io.KXmlParser;
 
@@ -30,6 +32,25 @@ public class CaseXmlParserUtil {
             String error = String.format("The %s attribute of a <case> %s wasn't set", key, caseId);
             throw  InvalidStructureException.readableInvalidStructureException(error, parser);
         }
+    }
+
+    protected static void checkForMaxLength(Case caseForBlock) throws InvalidStructureException {
+        if (getStringLength(caseForBlock.getTypeId()) > 255) {
+            throw new InvalidCasePropertyLengthException(CASE_PROPERTY_CASE_TYPE);
+        } else if (getStringLength(caseForBlock.getUserId()) > 255) {
+            throw new InvalidCasePropertyLengthException(CASE_PROPERTY_OWNER_ID);
+        } else if (getStringLength(caseForBlock.getName()) > 255) {
+            throw new InvalidCasePropertyLengthException(CASE_PROPERTY_CASE_NAME);
+        } else if (getStringLength(caseForBlock.getExternalId()) > 255) {
+            throw new InvalidCasePropertyLengthException(CASE_PROPERTY_EXTERNAL_ID);
+        }
+    }
+
+    /**
+     * Returns the length of string if it's not null, otherwise 0.
+     */
+    private static int getStringLength(String input) {
+        return input != null ? input.length() : 0;
     }
 
 }

--- a/src/main/java/org/commcare/xml/CaseXmlParserUtil.java
+++ b/src/main/java/org/commcare/xml/CaseXmlParserUtil.java
@@ -1,13 +1,18 @@
 package org.commcare.xml;
 
-public class CaseXmlParserUtil {
+import org.javarosa.xml.util.InvalidStructureException;
+import org.kxml2.io.KXmlParser;
 
+public class CaseXmlParserUtil {
+    public static final String CASE_NODE_NAME = "case";
     public static final String CASE_PROPERTY_CASE_ID = "case_id";
     public static final String CASE_PROPERTY_CASE_TYPE = "case_type";
     public static final String CASE_PROPERTY_OWNER_ID = "owner_id";
+    public static final String CASE_PROPERTY_USER_ID = "user_id";
     public static final String CASE_PROPERTY_STATUS = "status";
     public static final String CASE_PROPERTY_CASE_NAME = "case_name";
     public static final String CASE_PROPERTY_LAST_MODIFIED = "last_modified";
+    public static final String CASE_PROPERTY_DATE_MODIFIED = "date_modified";
     public static final String CASE_PROPERTY_DATE_OPENED = "date_opened";
     public static final String CASE_PROPERTY_EXTERNAL_ID = "external_id";
     public static final String CASE_PROPERTY_CATEGORY = "category";
@@ -17,5 +22,14 @@ public class CaseXmlParserUtil {
     public static final String ATTACHMENT_FROM_REMOTE = "remote";
     public static final String ATTACHMENT_FROM_INLINE = "inline";
     public static final String CASE_XML_NAMESPACE = "http://commcarehq.org/case/transaction/v2";
+
+
+    public static void validateMandatoryProperty(String key, Object value, String caseId, KXmlParser parser) throws
+            InvalidStructureException {
+        if (value == null || value.equals("")) {
+            String error = String.format("The %s attribute of a <case> %s wasn't set", key, caseId);
+            throw  InvalidStructureException.readableInvalidStructureException(error, parser);
+        }
+    }
 
 }

--- a/src/main/java/org/commcare/xml/CaseXmlParserUtil.java
+++ b/src/main/java/org/commcare/xml/CaseXmlParserUtil.java
@@ -1,0 +1,21 @@
+package org.commcare.xml;
+
+public class CaseXmlParserUtil {
+
+    public static final String CASE_PROPERTY_CASE_ID = "case_id";
+    public static final String CASE_PROPERTY_CASE_TYPE = "case_type";
+    public static final String CASE_PROPERTY_OWNER_ID = "owner_id";
+    public static final String CASE_PROPERTY_STATUS = "status";
+    public static final String CASE_PROPERTY_CASE_NAME = "case_name";
+    public static final String CASE_PROPERTY_LAST_MODIFIED = "last_modified";
+    public static final String CASE_PROPERTY_DATE_OPENED = "date_opened";
+    public static final String CASE_PROPERTY_EXTERNAL_ID = "external_id";
+    public static final String CASE_PROPERTY_CATEGORY = "category";
+    public static final String CASE_PROPERTY_STATE = "state";
+    public static final String CASE_PROPERTY_INDEX = "index";
+    public static final String ATTACHMENT_FROM_LOCAL = "local";
+    public static final String ATTACHMENT_FROM_REMOTE = "remote";
+    public static final String ATTACHMENT_FROM_INLINE = "inline";
+    public static final String CASE_XML_NAMESPACE = "http://commcarehq.org/case/transaction/v2";
+
+}

--- a/src/main/java/org/commcare/xml/bulk/BulkCaseInstanceXmlParser.java
+++ b/src/main/java/org/commcare/xml/bulk/BulkCaseInstanceXmlParser.java
@@ -14,6 +14,7 @@ import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_LAST_MODIFIED;
 import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_OWNER_ID;
 import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_STATE;
 import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_STATUS;
+import static org.commcare.xml.CaseXmlParserUtil.getTrimmedElementTextOrBlank;
 import static org.commcare.xml.CaseXmlParserUtil.validateMandatoryProperty;
 
 import org.commcare.cases.model.Case;
@@ -106,13 +107,6 @@ public class BulkCaseInstanceXmlParser extends BulkElementParser<Case> implement
                 parser);
         validateMandatoryProperty(CASE_PROPERTY_CASE_NAME, caseForBlock.getName(), caseForBlock.getCaseId(),
                 parser);
-    }
-
-    private static String getTrimmedElementTextOrBlank(TreeElement element) {
-        if (element.getValue() == null) {
-            return "";
-        }
-        return element.getValue().uncast().getString().trim();
     }
 
     protected Case buildCase(String name, String typeId) {

--- a/src/main/java/org/commcare/xml/bulk/BulkCaseInstanceXmlParser.java
+++ b/src/main/java/org/commcare/xml/bulk/BulkCaseInstanceXmlParser.java
@@ -1,5 +1,6 @@
 package org.commcare.xml.bulk;
 
+import static org.commcare.xml.CaseXmlParserUtil.CASE_NODE;
 import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_CASE_ID;
 import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_CASE_NAME;
 import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_CASE_TYPE;
@@ -7,6 +8,8 @@ import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_CATEGORY;
 import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_DATE_OPENED;
 import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_EXTERNAL_ID;
 import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_INDEX;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_INDEX_CASE_TYPE;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_INDEX_RELATIONSHIP;
 import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_LAST_MODIFIED;
 import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_OWNER_ID;
 import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_STATE;
@@ -50,13 +53,13 @@ public class BulkCaseInstanceXmlParser extends BulkElementParser<Case> {
 
     @Override
     protected void requestModelReadsForElement(TreeElement bufferedTreeElement, Set<String> currentBulkReadSet) {
-        String caseId = bufferedTreeElement.getAttributeValue(null, "case_id");
+        String caseId = bufferedTreeElement.getAttributeValue(null, CASE_PROPERTY_CASE_ID);
         currentBulkReadSet.add(caseId);
     }
 
     @Override
     protected void preParseValidate() throws InvalidStructureException {
-        checkNode("case");
+        checkNode(CASE_NODE);
     }
 
     @Override
@@ -184,10 +187,10 @@ public class BulkCaseInstanceXmlParser extends BulkElementParser<Case> {
             TreeElement subElement = indexElement.getChildAt(i);
 
             String indexName = subElement.getName();
-            String caseType = subElement.getAttributeValue(null, "case_type");
+            String caseType = subElement.getAttributeValue(null, CASE_PROPERTY_INDEX_CASE_TYPE);
 
             String value = getTrimmedElementTextOrBlank(subElement);
-            String relationship = subElement.getAttributeValue(null, "relationship");
+            String relationship = subElement.getAttributeValue(null, CASE_PROPERTY_INDEX_RELATIONSHIP);
             if (relationship == null) {
                 relationship = CaseIndex.RELATIONSHIP_CHILD;
             } else if ("".equals(relationship)) {

--- a/src/main/java/org/commcare/xml/bulk/BulkCaseInstanceXmlParser.java
+++ b/src/main/java/org/commcare/xml/bulk/BulkCaseInstanceXmlParser.java
@@ -1,5 +1,17 @@
 package org.commcare.xml.bulk;
 
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_CASE_ID;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_CASE_NAME;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_CASE_TYPE;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_CATEGORY;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_DATE_OPENED;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_EXTERNAL_ID;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_INDEX;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_LAST_MODIFIED;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_OWNER_ID;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_STATE;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_STATUS;
+
 import org.commcare.cases.model.Case;
 import org.commcare.cases.model.CaseIndex;
 import org.commcare.modern.engine.cases.CaseIndexTable;
@@ -24,18 +36,6 @@ import java.util.Set;
 
 // todo this and other case parsers duplicates a bunch of logic today that can be unified
 public class BulkCaseInstanceXmlParser extends BulkElementParser<Case> {
-
-    private static final String CASE_PROPERTY_CASE_ID = "case_id";
-    private static final String CASE_PROPERTY_CASE_TYPE = "case_type";
-    private static final String CASE_PROPERTY_OWNER_ID = "owner_id";
-    private static final String CASE_PROPERTY_STATUS = "status";
-    private static final String CASE_PROPERTY_CASE_NAME = "case_name";
-    private static final String CASE_PROPERTY_LAST_MODIFIED = "last_modified";
-    private static final String CASE_PROPERTY_DATE_OPENED = "date_opened";
-    private static final String CASE_PROPERTY_EXTERNAL_ID = "external_id";
-    private static final String CASE_PROPERTY_CATEGORY = "category";
-    private static final String CASE_PROPERTY_STATE = "state";
-    private static final String CASE_PROPERTY_INDEX = "index";
 
     private final CaseIndexTable mCaseIndexTable;
     private final IStorageUtilityIndexed<Case> storage;

--- a/src/main/java/org/commcare/xml/bulk/BulkCaseInstanceXmlParser.java
+++ b/src/main/java/org/commcare/xml/bulk/BulkCaseInstanceXmlParser.java
@@ -11,6 +11,7 @@ import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_LAST_MODIFIED;
 import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_OWNER_ID;
 import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_STATE;
 import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_STATUS;
+import static org.commcare.xml.CaseXmlParserUtil.validateMandatoryProperty;
 
 import org.commcare.cases.model.Case;
 import org.commcare.cases.model.CaseIndex;
@@ -62,16 +63,16 @@ public class BulkCaseInstanceXmlParser extends BulkElementParser<Case> {
     protected void processBufferedElement(TreeElement bufferedTreeElement, Map<String, Case> currentOperatingSet,
             LinkedHashMap<String, Case> writeLog) throws InvalidStructureException {
         String caseId = bufferedTreeElement.getAttributeValue(null, CASE_PROPERTY_CASE_ID);
-        validateMandatoryProperty(CASE_PROPERTY_CASE_ID, caseId, "");
+        validateMandatoryProperty(CASE_PROPERTY_CASE_ID, caseId, "", parser);
 
         String caseType = bufferedTreeElement.getAttributeValue(null, CASE_PROPERTY_CASE_TYPE);
-        validateMandatoryProperty(CASE_PROPERTY_CASE_TYPE, caseType, caseId);
+        validateMandatoryProperty(CASE_PROPERTY_CASE_TYPE, caseType, caseId, parser);
 
         String ownerId = bufferedTreeElement.getAttributeValue(null, CASE_PROPERTY_OWNER_ID);
-        validateMandatoryProperty(CASE_PROPERTY_OWNER_ID, ownerId, caseId);
+        validateMandatoryProperty(CASE_PROPERTY_OWNER_ID, ownerId, caseId, parser);
 
         String status = bufferedTreeElement.getAttributeValue(null, CASE_PROPERTY_STATUS);
-        validateMandatoryProperty(CASE_PROPERTY_STATUS, status, caseId);
+        validateMandatoryProperty(CASE_PROPERTY_STATUS, status, caseId, parser);
 
         Case caseForBlock = currentOperatingSet.get(caseId);
         if (caseForBlock == null) {
@@ -97,9 +98,10 @@ public class BulkCaseInstanceXmlParser extends BulkElementParser<Case> {
     }
 
     private void validateCase(Case caseForBlock) throws InvalidStructureException {
-        validateMandatoryProperty(CASE_PROPERTY_LAST_MODIFIED, caseForBlock.getLastModified(),
-                caseForBlock.getCaseId());
-        validateMandatoryProperty(CASE_PROPERTY_CASE_NAME, caseForBlock.getName(), caseForBlock.getCaseId());
+        validateMandatoryProperty(CASE_PROPERTY_LAST_MODIFIED, caseForBlock.getLastModified(), caseForBlock.getCaseId(),
+                parser);
+        validateMandatoryProperty(CASE_PROPERTY_CASE_NAME, caseForBlock.getName(), caseForBlock.getCaseId(),
+                parser);
     }
 
     private static String getTrimmedElementTextOrBlank(TreeElement element) {
@@ -107,14 +109,6 @@ public class BulkCaseInstanceXmlParser extends BulkElementParser<Case> {
             return "";
         }
         return element.getValue().uncast().getString().trim();
-    }
-
-    private static void validateMandatoryProperty(String key, Object value, String caseId)
-            throws InvalidStructureException {
-        if (value == null || value.equals("")) {
-            String error = String.format("The %s attribute of a <case> %s wasn't set", key, caseId);
-            throw new InvalidStructureException(error);
-        }
     }
 
     protected Case buildCase(String name, String typeId) {

--- a/src/main/java/org/commcare/xml/bulk/BulkCaseInstanceXmlParser.java
+++ b/src/main/java/org/commcare/xml/bulk/BulkCaseInstanceXmlParser.java
@@ -19,6 +19,7 @@ import static org.commcare.xml.CaseXmlParserUtil.validateMandatoryProperty;
 import org.commcare.cases.model.Case;
 import org.commcare.cases.model.CaseIndex;
 import org.commcare.modern.engine.cases.CaseIndexTable;
+import org.commcare.xml.CaseIndexChangeListener;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.utils.DateUtils;
 import org.javarosa.core.services.storage.IStorageUtilityIndexed;
@@ -39,7 +40,7 @@ import java.util.Set;
  */
 
 // todo this and other case parsers duplicates a bunch of logic today that can be unified
-public class BulkCaseInstanceXmlParser extends BulkElementParser<Case> {
+public class BulkCaseInstanceXmlParser extends BulkElementParser<Case> implements CaseIndexChangeListener {
 
     private final CaseIndexTable mCaseIndexTable;
     private final IStorageUtilityIndexed<Case> storage;
@@ -218,5 +219,10 @@ public class BulkCaseInstanceXmlParser extends BulkElementParser<Case> {
                         relationship));
             }
         }
+    }
+
+    @Override
+    public void onIndexDisrupted(String caseId) {
+
     }
 }

--- a/src/main/java/org/commcare/xml/bulk/BulkProcessingCaseXmlParser.java
+++ b/src/main/java/org/commcare/xml/bulk/BulkProcessingCaseXmlParser.java
@@ -256,24 +256,23 @@ public abstract class BulkProcessingCaseXmlParser extends BulkElementParser<Case
             String indexName = subElement.getName();
             String caseType = subElement.getAttributeValue(null, CASE_PROPERTY_INDEX_CASE_TYPE);
 
-            String relationship = subElement.getAttributeValue(null, CASE_PROPERTY_INDEX_RELATIONSHIP);
-            if (relationship == null) {
-                relationship = CaseIndex.RELATIONSHIP_CHILD;
-            }
-
             String value = getTrimmedElementTextOrBlank(subElement);
-
             if (value.equals(caseId)) {
-                throw new ActionableInvalidStructureException("case.error.self.index", new String[]{caseId}, "Case " + caseId + " cannot index itself");
-            }
-
-            //Remove any ambiguity associated with empty values
-            if (value.equals("")) {
+                throw new ActionableInvalidStructureException("case.error.self.index", new String[]{caseId},
+                        "Case " + caseId + " cannot index itself");
+            } else if (value.equals("")) {
+                //Remove any ambiguity associated with empty values
                 value = null;
             }
 
-            if ("".equals(relationship)) {
-                throw new InvalidStructureException(String.format("Invalid Case Transaction for Case[%s]: Attempt to add a '' relationship type to entity[%s]", caseId, value));
+            String relationship = subElement.getAttributeValue(null, CASE_PROPERTY_INDEX_RELATIONSHIP);
+            if (relationship == null) {
+                relationship = CaseIndex.RELATIONSHIP_CHILD;
+            } else if ("".equals(relationship)) {
+                throw new InvalidStructureException(String.format(
+                        "Invalid Case Transaction for Case[%s]: Attempt to add a '' relationship type to "
+                                + "entity[%s]",
+                        caseId, value));
             }
 
 

--- a/src/main/java/org/commcare/xml/bulk/BulkProcessingCaseXmlParser.java
+++ b/src/main/java/org/commcare/xml/bulk/BulkProcessingCaseXmlParser.java
@@ -1,5 +1,17 @@
 package org.commcare.xml.bulk;
 
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_CASE_ID;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_CASE_NAME;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_CASE_TYPE;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_CATEGORY;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_DATE_MODIFIED;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_DATE_OPENED;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_EXTERNAL_ID;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_OWNER_ID;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_STATE;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_USER_ID;
+import static org.commcare.xml.CaseXmlParserUtil.validateMandatoryProperty;
+
 import org.commcare.cases.model.Case;
 import org.commcare.cases.model.CaseIndex;
 import org.javarosa.core.model.instance.TreeElement;
@@ -43,18 +55,14 @@ public abstract class BulkProcessingCaseXmlParser extends BulkElementParser<Case
 
     @Override
     protected void processBufferedElement(TreeElement bufferedTreeElement, Map<String, Case> currentOperatingSet, LinkedHashMap<String, Case> writeLog) throws InvalidStructureException {
-        String caseId = bufferedTreeElement.getAttributeValue(null, "case_id");
-        if (caseId == null || caseId.equals("")) {
-            throw new InvalidStructureException("The case_id attribute of a <case> wasn't set");
-        }
+        String caseId = bufferedTreeElement.getAttributeValue(null, CASE_PROPERTY_CASE_ID);
+        validateMandatoryProperty(CASE_PROPERTY_CASE_ID, caseId, "", parser);
 
-        String dateModified = bufferedTreeElement.getAttributeValue(null, "date_modified");
-        if (dateModified == null) {
-            throw new InvalidStructureException("The date_modified attribute of a <case> wasn't set");
-        }
+        String dateModified = bufferedTreeElement.getAttributeValue(null, CASE_PROPERTY_DATE_MODIFIED);
+        validateMandatoryProperty(CASE_PROPERTY_DATE_MODIFIED, dateModified, caseId, parser);
         Date modified = DateUtils.parseDateTime(dateModified);
 
-        String userId = parser.getAttributeValue(null, "user_id");
+        String userId = parser.getAttributeValue(null, CASE_PROPERTY_USER_ID);
 
         Case caseForBlock = null;
         boolean isCreateOrUpdate = false;
@@ -119,19 +127,19 @@ public abstract class BulkProcessingCaseXmlParser extends BulkElementParser<Case
                             String caseId, Date modified, String userId) throws InvalidStructureException {
 
         String[] data = new String[3];
-        Case caseForBlock = null;
+        Case caseForBlock;
 
         for (int i = 0; i < createElement.getNumChildren(); i++) {
             TreeElement subElement = createElement.getChildAt(i);
             String tag = subElement.getName();
             switch (tag) {
-                case "case_type":
+                case CASE_PROPERTY_CASE_TYPE:
                     data[0] = getTrimmedElementTextOrBlank(subElement);
                     break;
-                case "owner_id":
+                case CASE_PROPERTY_OWNER_ID:
                     data[1] = getTrimmedElementTextOrBlank(subElement);
                     break;
-                case "case_name":
+                case CASE_PROPERTY_CASE_NAME:
                     data[2] = getTrimmedElementTextOrBlank(subElement);
                     break;
                 default:
@@ -193,16 +201,16 @@ public abstract class BulkProcessingCaseXmlParser extends BulkElementParser<Case
             String value = getTrimmedElementTextOrBlank(subElement);
 
             switch (key) {
-                case "case_type":
+                case CASE_PROPERTY_CASE_TYPE:
                     caseForBlock.setTypeId(value);
                     break;
-                case "case_name":
+                case CASE_PROPERTY_CASE_NAME:
                     caseForBlock.setName(value);
                     break;
-                case "date_opened":
+                case CASE_PROPERTY_DATE_OPENED:
                     caseForBlock.setDateOpened(DateUtils.parseDate(value));
                     break;
-                case "owner_id":
+                case CASE_PROPERTY_OWNER_ID:
                     String oldUserId = caseForBlock.getUserId();
 
                     if (!oldUserId.equals(value)) {
@@ -210,13 +218,13 @@ public abstract class BulkProcessingCaseXmlParser extends BulkElementParser<Case
                     }
                     caseForBlock.setUserId(value);
                     break;
-                case "external_id":
+                case CASE_PROPERTY_EXTERNAL_ID:
                     caseForBlock.setExternalId(value);
                     break;
-                case "category":
+                case CASE_PROPERTY_CATEGORY:
                     caseForBlock.setCategory(value);
                     break;
-                case "state":
+                case CASE_PROPERTY_STATE:
                     caseForBlock.setState(value);
                     break;
                 default:

--- a/src/main/java/org/commcare/xml/bulk/BulkProcessingCaseXmlParser.java
+++ b/src/main/java/org/commcare/xml/bulk/BulkProcessingCaseXmlParser.java
@@ -21,6 +21,7 @@ import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_OWNER_ID;
 import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_STATE;
 import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_USER_ID;
 import static org.commcare.xml.CaseXmlParserUtil.CASE_UPDATE_NODE;
+import static org.commcare.xml.CaseXmlParserUtil.getTrimmedElementTextOrBlank;
 import static org.commcare.xml.CaseXmlParserUtil.validateMandatoryProperty;
 
 import org.commcare.cases.model.Case;
@@ -125,14 +126,6 @@ public abstract class BulkProcessingCaseXmlParser extends BulkElementParser<Case
                 onCaseCreateUpdate(caseId);
             }
         }
-    }
-
-    private String getTrimmedElementTextOrBlank(TreeElement element) {
-        if (element.getValue() == null) {
-            return "";
-        }
-
-        return element.getValue().uncast().getString().trim();
     }
 
 
@@ -268,7 +261,7 @@ public abstract class BulkProcessingCaseXmlParser extends BulkElementParser<Case
                 relationship = CaseIndex.RELATIONSHIP_CHILD;
             }
 
-            String value = this.getTrimmedElementTextOrBlank(subElement);
+            String value = getTrimmedElementTextOrBlank(subElement);
 
             if (value.equals(caseId)) {
                 throw new ActionableInvalidStructureException("case.error.self.index", new String[]{caseId}, "Case " + caseId + " cannot index itself");

--- a/src/main/java/org/commcare/xml/bulk/BulkProcessingCaseXmlParser.java
+++ b/src/main/java/org/commcare/xml/bulk/BulkProcessingCaseXmlParser.java
@@ -1,5 +1,13 @@
 package org.commcare.xml.bulk;
 
+import static org.commcare.xml.CaseXmlParserUtil.CASE_ATTACHMENT_NODE;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_CLOSE_NODE;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_CREATE_NODE;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_INDEX_NODE;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_NODE;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_ATTACHMENT_FROM;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_ATTACHMENT_NAME;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_ATTACHMENT_SRC;
 import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_CASE_ID;
 import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_CASE_NAME;
 import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_CASE_TYPE;
@@ -7,9 +15,12 @@ import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_CATEGORY;
 import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_DATE_MODIFIED;
 import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_DATE_OPENED;
 import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_EXTERNAL_ID;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_INDEX_CASE_TYPE;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_INDEX_RELATIONSHIP;
 import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_OWNER_ID;
 import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_STATE;
 import static org.commcare.xml.CaseXmlParserUtil.CASE_PROPERTY_USER_ID;
+import static org.commcare.xml.CaseXmlParserUtil.CASE_UPDATE_NODE;
 import static org.commcare.xml.CaseXmlParserUtil.validateMandatoryProperty;
 
 import org.commcare.cases.model.Case;
@@ -50,7 +61,7 @@ public abstract class BulkProcessingCaseXmlParser extends BulkElementParser<Case
 
     @Override
     protected void preParseValidate() throws InvalidStructureException {
-        checkNode("case");
+        checkNode(CASE_NODE);
     }
 
     @Override
@@ -71,24 +82,24 @@ public abstract class BulkProcessingCaseXmlParser extends BulkElementParser<Case
             TreeElement subElement = bufferedTreeElement.getChildAt(i);
             String action = subElement.getName().toLowerCase();
             switch (action) {
-                case "create":
+                case CASE_CREATE_NODE:
                     caseForBlock = createCase(subElement, currentOperatingSet, caseId, modified, userId);
                     isCreateOrUpdate = true;
                     break;
-                case "update":
+                case CASE_UPDATE_NODE:
                     caseForBlock = loadCase(caseForBlock, caseId, currentOperatingSet, true);
                     updateCase(subElement, caseForBlock, caseId);
                     isCreateOrUpdate = true;
                     break;
-                case "close":
+                case CASE_CLOSE_NODE:
                     caseForBlock = loadCase(caseForBlock, caseId, currentOperatingSet, true);
                     closeCase(caseForBlock, caseId);
                     break;
-                case "index":
+                case CASE_INDEX_NODE:
                     caseForBlock = loadCase(caseForBlock, caseId, currentOperatingSet, false);
                     indexCase(subElement, caseForBlock, caseId);
                     break;
-                case "attachment":
+                case CASE_ATTACHMENT_NODE:
                     caseForBlock = loadCase(caseForBlock, caseId, currentOperatingSet, false);
                     processCaseAttachment(subElement, caseForBlock);
                     break;
@@ -247,9 +258,9 @@ public abstract class BulkProcessingCaseXmlParser extends BulkElementParser<Case
             TreeElement subElement = indexElement.getChildAt(i);
 
             String indexName = subElement.getName();
-            String caseType = subElement.getAttributeValue(null, "case_type");
+            String caseType = subElement.getAttributeValue(null, CASE_PROPERTY_INDEX_CASE_TYPE);
 
-            String relationship = subElement.getAttributeValue(null, "relationship");
+            String relationship = subElement.getAttributeValue(null, CASE_PROPERTY_INDEX_RELATIONSHIP);
             if (relationship == null) {
                 relationship = CaseIndex.RELATIONSHIP_CHILD;
             }
@@ -310,9 +321,9 @@ public abstract class BulkProcessingCaseXmlParser extends BulkElementParser<Case
             TreeElement subElement = attachmentElement.getChildAt(i);
 
             String attachmentName = subElement.getName();
-            String src = subElement.getAttributeValue(null, "src");
-            String from = subElement.getAttributeValue(null, "from");
-            String fileName = subElement.getAttributeValue(null, "name");
+            String src = subElement.getAttributeValue(null, CASE_PROPERTY_ATTACHMENT_SRC);
+            String from = subElement.getAttributeValue(null, CASE_PROPERTY_ATTACHMENT_FROM);
+            String fileName = subElement.getAttributeValue(null, CASE_PROPERTY_ATTACHMENT_NAME);
 
             if ((src == null || "".equals(src)) && (from == null || "".equals(from))) {
                 //this is actually an attachment removal


### PR DESCRIPTION
## Technical Summary

Moves common code between parsers to a util class. I was earlier thinking we should be able to remove code repetetition for other methods like [createCase](https://github.com/dimagi/commcare-core/blob/master/src/main/java/org/commcare/xml/CaseXmlParser.java#L128) but it's a little more complicated since `CaseXmlParser` and `BulkProcessingCaseXmlParser` iterates on different elements (raw parser vs a TreeElement) to process these transactions. I have let them be as it is in order to avoid more fine grained changes to existing parsers. 

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
Pure refactoring with no effective code changes. 

### Automated test coverage

We have test coverage on different parsers - [BulkCaseInstanceXmlParserTests](https://github.com/dimagi/commcare-core/blob/formplayer/src/test/java/org/commcare/cases/util/test/BulkCaseInstanceXmlParserTests.java), [CaseParseAndReadTest](https://github.com/dimagi/commcare-core/blob/formplayer/src/test/java/org/commcare/cases/test/CaseParseAndReadTest.java), [CaseParseReindexTests](https://github.com/dimagi/commcare-core/blob/formplayer/src/test/java/org/commcare/cases/util/test/CaseParseReindexTests.java) and [BulkCaseInstanceXmlParserTests](https://github.com/dimagi/commcare-core/blob/formplayer/src/test/java/org/commcare/cases/util/test/BulkCaseInstanceXmlParserTests.java). 

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
No QA
### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
