### PR TITLE
Added address display format

### DIFF
--- a/src/main/java/org/commcare/suite/model/Style.java
+++ b/src/main/java/org/commcare/suite/model/Style.java
@@ -36,6 +36,7 @@ public class Style {
         Image,
         Audio,
         Text,
+        Address,
         Graph,
         Phone,
         Markdown,
@@ -75,6 +76,9 @@ public class Style {
                 break;
             case "text":
                 setDisplayFormat(DisplayFormat.Text);
+                break;
+            case "address":
+                setDisplayFormat(DisplayFormat.Address);
                 break;
             case "graph":
                 setDisplayFormat(DisplayFormat.Graph);


### PR DESCRIPTION
## Technical Summary
Although our [public docs](https://confluence.dimagi.com/display/commcarepublic/Case+List+and+Case+Detail+Configuration#CaseListandCaseDetailConfiguration-DisplayProperties) say the address format works in Web Apps / CloudCare, it doesn't seem to. Although `address` is a template form, it doesn't get passed along to the formplayer response. Add it as a recognized display format so that future work can display these points on a map.

On Android, this format is handled on the UI side, like here: https://github.com/dimagi/commcare-android/blob/f0f77df6f6d9c9e5a2c54cb32142d3279ad4a013/app/src/org/commcare/views/EntityDetailView.java#L183-L184

## Safety Assurance

### Safety story
Trivial.

### Automated test coverage
Unlikely.

### QA Plan
No

### Special deploy instructions
- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
