### PR TITLE
getLongDetail

### DIFF
--- a/src/cli/java/org/commcare/util/screen/EntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreen.java
@@ -349,24 +349,25 @@ public class EntityScreen extends CompoundScreenHost {
     }
 
     public Detail[] getLongDetailList(TreeReference ref) {
-        Detail[] longDetailList;
-        String longDetailId = this.mNeededDatum.getLongDetail();
-        if (longDetailId == null) {
-            return null;
-        }
-        Detail d = mPlatform.getDetail(longDetailId);
-        if (d == null) {
-            return null;
-        }
+        Detail d = getLongDetail();
+        if (d == null) return null;
 
         EvaluationContext contextForChildDetailDisplayConditions =
                 EntityUtil.prepareCompoundEvaluationContext(ref, d, evalContext);
 
-        longDetailList = d.getDisplayableChildDetails(contextForChildDetailDisplayConditions);
+        Detail[] longDetailList = d.getDisplayableChildDetails(contextForChildDetailDisplayConditions);
         if (longDetailList == null || longDetailList.length == 0) {
             longDetailList = new Detail[]{d};
         }
         return longDetailList;
+    }
+
+    public Detail getLongDetail() {
+        String longDetailId = this.mNeededDatum.getLongDetail();
+        if (longDetailId == null) {
+            return null;
+        }
+        return mPlatform.getDetail(longDetailId);
     }
 
     public String[] getDetailListTitles(EvaluationContext subContext, TreeReference reference) {


### PR DESCRIPTION
## Technical Summary
Add method on `EntityScreen` to make it easy to get the 'longDetail' for an entity screen.

This will be used by Formplayer to tell Web Apps if there is a 'longDetail' when sending the entity list response. (https://github.com/dimagi/formplayer/pull/1374)

See 

## Safety Assurance

### Safety story
Simple refactor

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
