### PR TITLE
[USH-3239] reverse index query optimization

### DIFF
--- a/src/main/java/org/commcare/cases/instance/CaseInstanceTreeElement.java
+++ b/src/main/java/org/commcare/cases/instance/CaseInstanceTreeElement.java
@@ -11,6 +11,7 @@ import org.commcare.cases.query.handlers.ModelQueryLookupHandler;
 import org.commcare.cases.query.queryset.CaseModelQuerySetMatcher;
 import org.commcare.modern.engine.cases.CaseIndexQuerySetTransform;
 import org.commcare.modern.engine.cases.CaseIndexTable;
+import org.commcare.modern.engine.cases.ReverseCaseIndexQuerySetTransform;
 import org.commcare.modern.engine.cases.query.CaseIndexPrefetchHandler;
 import org.javarosa.core.model.instance.AbstractTreeElement;
 import org.javarosa.core.model.instance.TreeReference;
@@ -83,6 +84,10 @@ public class CaseInstanceTreeElement extends StorageInstanceTreeElement<Case, Ca
         queryPlanner.addQueryHandler(new CaseIndexPrefetchHandler(caseIndexTable));
         CaseModelQuerySetMatcher matcher = new CaseModelQuerySetMatcher(multiplicityIdMapping);
         matcher.addQuerySetTransform(new CaseIndexQuerySetTransform(caseIndexTable));
+        matcher.addMatchAndOutputSetTransform(
+                CaseInstanceTreeElement.CASE_INDEX_EXPR,
+                new ReverseCaseIndexQuerySetTransform(caseIndexTable)
+        );
         queryPlanner.addQueryHandler(new ModelQueryLookupHandler(matcher));
     }
 

--- a/src/main/java/org/commcare/cases/query/IndexedSetMemberLookup.java
+++ b/src/main/java/org/commcare/cases/query/IndexedSetMemberLookup.java
@@ -1,5 +1,7 @@
 package org.commcare.cases.query;
 
+import java.util.Arrays;
+
 /**
  * An indexed set member lookup is a check for whether a value which is indexed on the current
  * platform is a member of a set of elements.
@@ -22,5 +24,13 @@ public class IndexedSetMemberLookup implements PredicateProfile {
 
     public String getKey() {
         return key;
+    }
+
+    @Override
+    public String toString() {
+        return "IndexedSetMemberLookup{" +
+                "key='" + key + '\'' +
+                ", valueSet=" + Arrays.toString(valueSet) +
+                '}';
     }
 }

--- a/src/main/java/org/commcare/cases/query/IndexedValueLookup.java
+++ b/src/main/java/org/commcare/cases/query/IndexedValueLookup.java
@@ -24,4 +24,12 @@ public class IndexedValueLookup implements PredicateProfile {
     public String getKey() {
         return key;
     }
+
+    @Override
+    public String toString() {
+        return "IndexedValueLookup{" +
+                "key='" + key + '\'' +
+                ", value=" + value +
+                '}';
+    }
 }

--- a/src/main/java/org/commcare/cases/query/NegativeIndexedValueLookup.java
+++ b/src/main/java/org/commcare/cases/query/NegativeIndexedValueLookup.java
@@ -24,4 +24,12 @@ public class NegativeIndexedValueLookup implements PredicateProfile {
     public String getKey() {
         return key;
     }
+
+    @Override
+    public String toString() {
+        return "NegativeIndexedValueLookup{" +
+                "key='" + key + '\'' +
+                ", value=" + value +
+                '}';
+    }
 }

--- a/src/main/java/org/commcare/cases/query/QueryHandler.java
+++ b/src/main/java/org/commcare/cases/query/QueryHandler.java
@@ -67,7 +67,7 @@ public interface QueryHandler<T> {
      * lookup for any of them. If so, return an object representing the query to be run, it will
      * be passed back in the loadProfileMatches method.
      *
-     * @param profiles pending predicate profiles which havent' been processed/handled
+     * @param profiles pending predicate profiles which haven't been processed/handled
      * @return a querySet object to be passed back into this handler specifying the query to be run.
      * often a single (or collection of) predicate profiles.
      */
@@ -78,7 +78,7 @@ public interface QueryHandler<T> {
      * generate a list of matching model ID's.
      *
      * If for some reason the query set cannot be run against the current context, this method
-     * can return null, which will signal the the query couldn't be run and no predicates have
+     * can return null, which will signal the query couldn't be run and no predicates have
      * been evaluated.
      */
     List<Integer> loadProfileMatches(T querySet, QueryContext queryContext);

--- a/src/main/java/org/commcare/cases/query/handlers/ModelQueryLookupHandler.java
+++ b/src/main/java/org/commcare/cases/query/handlers/ModelQueryLookupHandler.java
@@ -73,6 +73,8 @@ public class ModelQueryLookupHandler implements QueryHandler<ModelQueryLookup> {
                                                                  EvaluationContext evalContext) {
 
         XPathExpression predicate = predicates.elementAt(0);
+        // e.g. [@case_id = current()/index/parent]
+        // optimize the right side of the predicate (`current()/index/parent`)
         QuerySetLookup lookup = matcher.getQueryLookupFromPredicate(predicate);
         if (lookup == null) {
             return null;
@@ -86,6 +88,9 @@ public class ModelQueryLookupHandler implements QueryHandler<ModelQueryLookup> {
 
         XPathEqExpr eq = (XPathEqExpr)predicate;
         TreeReference matchTo = ((XPathPathExpr)eq.a).getReference();
+
+        // Optimize the left side of the predicate (querySet -> `@case_id` or `index/parent`).
+        // This is either an identity transform or a reverse index lookup transform.
         lookup = matcher.getTransformedQuerySetLookupForOutput(lookup, matchTo);
         Vector<PredicateProfile> newProfile = new Vector<>();
         newProfile.add(new ModelQueryLookup(lookup.getQueryModelId(), lookup, ref));

--- a/src/main/java/org/commcare/cases/query/handlers/ModelQueryLookupHandler.java
+++ b/src/main/java/org/commcare/cases/query/handlers/ModelQueryLookupHandler.java
@@ -9,7 +9,9 @@ import org.commcare.cases.query.queryset.QuerySetLookup;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.model.trace.EvaluationTrace;
+import org.javarosa.xpath.expr.XPathEqExpr;
 import org.javarosa.xpath.expr.XPathExpression;
+import org.javarosa.xpath.expr.XPathPathExpr;
 
 import java.util.Collection;
 import java.util.List;
@@ -70,7 +72,8 @@ public class ModelQueryLookupHandler implements QueryHandler<ModelQueryLookup> {
                                                                  QueryContext context,
                                                                  EvaluationContext evalContext) {
 
-        QuerySetLookup lookup = matcher.getQueryLookupFromPredicate(predicates.elementAt(0));
+        XPathExpression predicate = predicates.elementAt(0);
+        QuerySetLookup lookup = matcher.getQueryLookupFromPredicate(predicate);
         if (lookup == null) {
             return null;
         }
@@ -81,6 +84,9 @@ public class ModelQueryLookupHandler implements QueryHandler<ModelQueryLookup> {
             return null;
         }
 
+        XPathEqExpr eq = (XPathEqExpr)predicate;
+        TreeReference matchTo = ((XPathPathExpr)eq.a).getReference();
+        lookup = matcher.getTransformedQuerySetLookupForOutput(lookup, matchTo);
         Vector<PredicateProfile> newProfile = new Vector<>();
         newProfile.add(new ModelQueryLookup(lookup.getQueryModelId(), lookup, ref));
         return newProfile;

--- a/src/main/java/org/commcare/cases/query/queryset/CaseModelQuerySetMatcher.java
+++ b/src/main/java/org/commcare/cases/query/queryset/CaseModelQuerySetMatcher.java
@@ -124,7 +124,7 @@ public class CaseModelQuerySetMatcher implements ModelQuerySetMatcher {
     }
 
     private QuerySetLookup transformQuerySetLookup(
-            QuerySetLookup lookup, TreeReference remainder, Vector<QuerySetTransform> transforms){
+            QuerySetLookup lookup, TreeReference remainder, Vector<QuerySetTransform> transforms) {
         for (QuerySetTransform transform : transforms) {
             QuerySetLookup retVal = transform.getTransformedLookup(lookup, remainder);
             if (retVal != null) {

--- a/src/main/java/org/commcare/cases/query/queryset/DualTableMultiMatchModelQuerySet.java
+++ b/src/main/java/org/commcare/cases/query/queryset/DualTableMultiMatchModelQuerySet.java
@@ -1,0 +1,36 @@
+package org.commcare.cases.query.queryset;
+
+import java.util.*;
+
+/**
+ * A model query set implementation for queries which have one-to-many results.
+ *
+ * Created by skelly on 2023/05/17
+ */
+
+public class DualTableMultiMatchModelQuerySet implements ModelQuerySet {
+    private Map<Integer, Set<Integer>> map = new HashMap<>();
+    private LinkedHashSet<Integer> body = new LinkedHashSet<>();
+
+    public void loadResult(Integer key, Integer value) {
+        if (!map.containsKey(key)) {
+            map.put(key, new HashSet<>());
+        }
+        map.get(key).add(value);
+        body.add(value);
+    }
+
+    @Override
+    public Collection<Integer> getMatchingValues(Integer i) {
+        Set<Integer> result = map.get(i);
+        if(result == null) {
+            return null;
+        }
+        return new ArrayList<>(result);
+    }
+
+    @Override
+    public LinkedHashSet<Integer> getSetBody() {
+        return body;
+    }
+}

--- a/src/main/java/org/commcare/cases/query/queryset/DualTableMultiMatchModelQuerySet.java
+++ b/src/main/java/org/commcare/cases/query/queryset/DualTableMultiMatchModelQuerySet.java
@@ -1,10 +1,16 @@
 package org.commcare.cases.query.queryset;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * A model query set implementation for queries which have one-to-many results.
- *
+ * <p>
  * Created by skelly on 2023/05/17
  */
 

--- a/src/main/java/org/commcare/cases/query/queryset/ModelQueryLookup.java
+++ b/src/main/java/org/commcare/cases/query/queryset/ModelQueryLookup.java
@@ -33,4 +33,13 @@ public class ModelQueryLookup implements PredicateProfile {
     public TreeReference getRootLookupRef() {
         return rootLookupRef;
     }
+
+    @Override
+    public String toString() {
+        return "ModelQueryLookup{" +
+                "key='" + key + '\'' +
+                ", rootLookupRef=" + rootLookupRef +
+                ", setLookup=" + setLookup +
+                '}';
+    }
 }

--- a/src/main/java/org/commcare/cases/query/queryset/ModelQuerySetMatcher.java
+++ b/src/main/java/org/commcare/cases/query/queryset/ModelQuerySetMatcher.java
@@ -53,4 +53,5 @@ public interface ModelQuerySetMatcher {
      */
     QuerySetLookup getQuerySetLookup(TreeReference ref);
 
+    QuerySetLookup getTransformedQuerySetLookupForOutput(QuerySetLookup lookup, TreeReference remainder);
 }

--- a/src/main/java/org/commcare/modern/engine/cases/CaseIndexTable.java
+++ b/src/main/java/org/commcare/modern/engine/cases/CaseIndexTable.java
@@ -1,6 +1,7 @@
 package org.commcare.modern.engine.cases;
 
 import org.commcare.cases.model.Case;
+import org.commcare.cases.query.queryset.DualTableMultiMatchModelQuerySet;
 import org.commcare.cases.query.queryset.DualTableSingleMatchModelQuerySet;
 
 import java.util.Collection;
@@ -15,6 +16,8 @@ public interface CaseIndexTable {
     int loadIntoIndexTable(HashMap<String, Vector<Integer>> indexCache, String indexName);
 
     DualTableSingleMatchModelQuerySet bulkReadIndexToCaseIdMatch(String indexName, Collection<Integer> cuedCases);
+
+    DualTableMultiMatchModelQuerySet bulkReadIndexToCaseIdMatchReverse(String indexName, Collection<Integer> cuedCases);
 
     LinkedHashSet<Integer> getCasesMatchingValueSet(String indexName, String[] valueSet);
 

--- a/src/main/java/org/commcare/modern/engine/cases/CaseIndexTable.java
+++ b/src/main/java/org/commcare/modern/engine/cases/CaseIndexTable.java
@@ -17,7 +17,7 @@ public interface CaseIndexTable {
 
     DualTableSingleMatchModelQuerySet bulkReadIndexToCaseIdMatch(String indexName, Collection<Integer> cuedCases);
 
-    DualTableMultiMatchModelQuerySet bulkReadIndexToCaseIdMatchReverse(String indexName, Collection<Integer> cuedCases);
+    DualTableMultiMatchModelQuerySet bulkReadCaseIdToIndexMatch(String indexName, Collection<Integer> cuedCases);
 
     LinkedHashSet<Integer> getCasesMatchingValueSet(String indexName, String[] valueSet);
 

--- a/src/main/java/org/commcare/modern/engine/cases/ReverseCaseIndexQuerySetTransform.java
+++ b/src/main/java/org/commcare/modern/engine/cases/ReverseCaseIndexQuerySetTransform.java
@@ -1,0 +1,82 @@
+package org.commcare.modern.engine.cases;
+
+import org.commcare.cases.instance.CaseInstanceTreeElement;
+import org.commcare.cases.query.QueryContext;
+import org.commcare.cases.query.queryset.*;
+import org.commcare.modern.util.PerformanceTuningUtil;
+import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.core.model.trace.EvaluationTrace;
+
+import java.util.Set;
+
+/**
+ * Created by skelly on 2023/05/17.
+ */
+public class ReverseCaseIndexQuerySetTransform implements QuerySetTransform {
+
+    private final CaseIndexTable table;
+
+    public ReverseCaseIndexQuerySetTransform(CaseIndexTable table) {
+        this.table = table;
+    }
+
+    @Override
+    public QuerySetLookup getTransformedLookup(QuerySetLookup incoming, TreeReference relativeLookup) {
+        if(incoming.getQueryModelId().equals(CaseQuerySetLookup.CASE_MODEL_ID)) {
+            if(relativeLookup.size() == 2 && "index".equals(relativeLookup.getName(0))) {
+                String indexName = relativeLookup.getName(1);
+                return new ReverseCaseIndexQuerySetLookup(indexName, incoming, table);
+            }
+        }
+        return null;
+    }
+
+
+
+    public static class ReverseCaseIndexQuerySetLookup extends DerivedCaseQueryLookup {
+        String indexName;
+        CaseIndexTable table;
+
+        public ReverseCaseIndexQuerySetLookup(String indexName, QuerySetLookup incoming, CaseIndexTable table) {
+            super(incoming);
+            this.indexName = indexName;
+            this.table = table;
+        }
+
+        @Override
+        protected ModelQuerySet loadModelQuerySet(QueryContext queryContext) {
+            EvaluationTrace trace = new EvaluationTrace("Load Query Set Transform[" +
+                    getRootLookup().getCurrentQuerySetId() + "]=>[" +
+                    this.getCurrentQuerySetId()+ "]");
+
+
+            Set<Integer> querySetBody = getRootLookup().getLookupSetBody(queryContext);
+            DualTableMultiMatchModelQuerySet ret = table.bulkReadIndexToCaseIdMatchReverse(indexName, querySetBody);
+            cacheCaseModelQuerySet(queryContext, ret);
+
+            trace.setOutcome("Loaded: " + ret.getSetBody().size());
+
+            queryContext.reportTrace(trace);
+            return ret;
+        }
+
+        private void cacheCaseModelQuerySet(QueryContext queryContext, DualTableMultiMatchModelQuerySet ret) {
+            int modelQueryMagnitude = ret.getSetBody().size();
+            if(modelQueryMagnitude > QueryContext.BULK_QUERY_THRESHOLD && modelQueryMagnitude < PerformanceTuningUtil.getMaxPrefetchCaseBlock()) {
+                queryContext.getQueryCache(RecordSetResultCache.class).
+                        reportBulkRecordSet(this.getCurrentQuerySetId(),
+                                CaseInstanceTreeElement.MODEL_NAME, ret.getSetBody());
+            }
+        }
+
+        @Override
+        public String getQueryModelId() {
+            return getRootLookup().getQueryModelId();
+        }
+
+        @Override
+        public String getCurrentQuerySetId() {
+            return getRootLookup().getCurrentQuerySetId() + "|reverse index|"+indexName;
+        }
+    }
+}

--- a/src/main/java/org/commcare/modern/engine/cases/ReverseCaseIndexQuerySetTransform.java
+++ b/src/main/java/org/commcare/modern/engine/cases/ReverseCaseIndexQuerySetTransform.java
@@ -2,7 +2,12 @@ package org.commcare.modern.engine.cases;
 
 import org.commcare.cases.instance.CaseInstanceTreeElement;
 import org.commcare.cases.query.QueryContext;
-import org.commcare.cases.query.queryset.*;
+import org.commcare.cases.query.queryset.CaseQuerySetLookup;
+import org.commcare.cases.query.queryset.DerivedCaseQueryLookup;
+import org.commcare.cases.query.queryset.DualTableMultiMatchModelQuerySet;
+import org.commcare.cases.query.queryset.ModelQuerySet;
+import org.commcare.cases.query.queryset.QuerySetLookup;
+import org.commcare.cases.query.queryset.QuerySetTransform;
 import org.commcare.modern.util.PerformanceTuningUtil;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.model.trace.EvaluationTrace;
@@ -22,8 +27,8 @@ public class ReverseCaseIndexQuerySetTransform implements QuerySetTransform {
 
     @Override
     public QuerySetLookup getTransformedLookup(QuerySetLookup incoming, TreeReference relativeLookup) {
-        if(incoming.getQueryModelId().equals(CaseQuerySetLookup.CASE_MODEL_ID)) {
-            if(relativeLookup.size() == 2 && "index".equals(relativeLookup.getName(0))) {
+        if (incoming.getQueryModelId().equals(CaseQuerySetLookup.CASE_MODEL_ID)) {
+            if (relativeLookup.size() == 2 && "index".equals(relativeLookup.getName(0))) {
                 String indexName = relativeLookup.getName(1);
                 return new ReverseCaseIndexQuerySetLookup(indexName, incoming, table);
             }
@@ -32,7 +37,9 @@ public class ReverseCaseIndexQuerySetTransform implements QuerySetTransform {
     }
 
 
-
+    /**
+     * QuerySetLookup implementation for reverse index queries
+     */
     public static class ReverseCaseIndexQuerySetLookup extends DerivedCaseQueryLookup {
         String indexName;
         CaseIndexTable table;
@@ -47,7 +54,7 @@ public class ReverseCaseIndexQuerySetTransform implements QuerySetTransform {
         protected ModelQuerySet loadModelQuerySet(QueryContext queryContext) {
             EvaluationTrace trace = new EvaluationTrace("Load Query Set Transform[" +
                     getRootLookup().getCurrentQuerySetId() + "]=>[" +
-                    this.getCurrentQuerySetId()+ "]");
+                    this.getCurrentQuerySetId() + "]");
 
 
             Set<Integer> querySetBody = getRootLookup().getLookupSetBody(queryContext);
@@ -62,10 +69,12 @@ public class ReverseCaseIndexQuerySetTransform implements QuerySetTransform {
 
         private void cacheCaseModelQuerySet(QueryContext queryContext, DualTableMultiMatchModelQuerySet ret) {
             int modelQueryMagnitude = ret.getSetBody().size();
-            if(modelQueryMagnitude > QueryContext.BULK_QUERY_THRESHOLD && modelQueryMagnitude < PerformanceTuningUtil.getMaxPrefetchCaseBlock()) {
-                queryContext.getQueryCache(RecordSetResultCache.class).
-                        reportBulkRecordSet(this.getCurrentQuerySetId(),
-                                CaseInstanceTreeElement.MODEL_NAME, ret.getSetBody());
+            if (modelQueryMagnitude > QueryContext.BULK_QUERY_THRESHOLD && modelQueryMagnitude < PerformanceTuningUtil.getMaxPrefetchCaseBlock()) {
+                queryContext.getQueryCache(RecordSetResultCache.class)
+                        .reportBulkRecordSet(
+                                this.getCurrentQuerySetId(),
+                                CaseInstanceTreeElement.MODEL_NAME, ret.getSetBody()
+                        );
             }
         }
 
@@ -76,7 +85,7 @@ public class ReverseCaseIndexQuerySetTransform implements QuerySetTransform {
 
         @Override
         public String getCurrentQuerySetId() {
-            return getRootLookup().getCurrentQuerySetId() + "|reverse index|"+indexName;
+            return getRootLookup().getCurrentQuerySetId() + "|reverse index|" + indexName;
         }
     }
 }

--- a/src/main/java/org/commcare/modern/engine/cases/ReverseCaseIndexQuerySetTransform.java
+++ b/src/main/java/org/commcare/modern/engine/cases/ReverseCaseIndexQuerySetTransform.java
@@ -58,7 +58,7 @@ public class ReverseCaseIndexQuerySetTransform implements QuerySetTransform {
 
 
             Set<Integer> querySetBody = getRootLookup().getLookupSetBody(queryContext);
-            DualTableMultiMatchModelQuerySet ret = table.bulkReadIndexToCaseIdMatchReverse(indexName, querySetBody);
+            DualTableMultiMatchModelQuerySet ret = table.bulkReadCaseIdToIndexMatch(indexName, querySetBody);
             cacheCaseModelQuerySet(queryContext, ret);
 
             trace.setOutcome("Loaded: " + ret.getSetBody().size());


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/USH-3239
## Technical Summary
This PR contains the platform changes necessary to optimize the reverse index predicate: `[index/parent = current()/@case_id]`.

This predicate is already partially optimized to do a bulk lookup for each value of `current()/@case_id`. What this PR does is fully optimize the lookups so that a single query is performed to find all the index cases for all the cases in the current scope.

This data is then cached and used for later evaluation.

## Safety Assurance

### Safety story
The safety of this should be validated by unit tests.

### Automated test coverage
This XPath evaluation code is well covered by tests and I have added tests explicitly for this optimization in the Formplayer PR. 

### QA Plan
I will put this on staging for final testing just to be safe but do not intend to open a QA ticket for it.

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
