### PR TITLE
Eval entity list in Entity Screens

### DIFF
--- a/src/cli/java/org/commcare/util/cli/ApplicationHost.java
+++ b/src/cli/java/org/commcare/util/cli/ApplicationHost.java
@@ -25,6 +25,7 @@ import org.commcare.util.mocks.MockUserDataSandbox;
 import org.commcare.util.screen.CommCareSessionException;
 import org.commcare.util.screen.EntityListSubscreen;
 import org.commcare.util.screen.EntityScreen;
+import org.commcare.util.screen.EntityScreenContext;
 import org.commcare.util.screen.MenuScreen;
 import org.commcare.util.screen.MultiSelectEntityScreen;
 import org.commcare.util.screen.QueryScreen;
@@ -465,7 +466,8 @@ public class ApplicationHost {
             return getNextScreen();
         } else if (next.equals(SessionFrame.STATE_MULTIPLE_DATUM_VAL)) {
             try {
-                return new MultiSelectEntityScreen(true, true, mSession, virtualInstanceStorage, false);
+                return new MultiSelectEntityScreen(true, true, mSession, virtualInstanceStorage, false,
+                        new EntityScreenContext());
             } catch (CommCareSessionException ccse) {
                 printErrorAndContinue("Error during session execution:", ccse);
             }

--- a/src/cli/java/org/commcare/util/cli/ApplicationHost.java
+++ b/src/cli/java/org/commcare/util/cli/ApplicationHost.java
@@ -466,7 +466,7 @@ public class ApplicationHost {
             return getNextScreen();
         } else if (next.equals(SessionFrame.STATE_MULTIPLE_DATUM_VAL)) {
             try {
-                return new MultiSelectEntityScreen(true, true, mSession, virtualInstanceStorage, false,
+                return new MultiSelectEntityScreen(true, true, mSession, virtualInstanceStorage,
                         new EntityScreenContext());
             } catch (CommCareSessionException ccse) {
                 printErrorAndContinue("Error during session execution:", ccse);

--- a/src/cli/java/org/commcare/util/screen/EntityListSubscreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityListSubscreen.java
@@ -33,7 +33,7 @@ public class EntityListSubscreen extends Subscreen<EntityScreen> {
     private static final int SCREEN_WIDTH = 100;
 
     private final TreeReference[] entitiesRefs;
-    private final String[] rows;
+    private String[] rows;
     private final String mHeader;
 
     private final Vector<Action> actions;
@@ -54,7 +54,6 @@ public class EntityListSubscreen extends Subscreen<EntityScreen> {
         references.copyInto(entitiesRefs);
         actions = shortDetail.getCustomActions(context);
         initEntities(context, shortDetail);
-        rows = getRows(shortDetail);
     }
 
     private void initEntities(EvaluationContext context, Detail shortDetail) {
@@ -172,6 +171,9 @@ public class EntityListSubscreen extends Subscreen<EntityScreen> {
 
     @Override
     public String[] getOptions() {
+        if (rows == null) {
+            rows = getRows(shortDetail);
+        }
         return rows;
     }
 

--- a/src/cli/java/org/commcare/util/screen/EntityListSubscreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityListSubscreen.java
@@ -52,7 +52,7 @@ public class EntityListSubscreen extends Subscreen<EntityScreen> {
         rows = getRows(mChoices, context, shortDetail);
     }
 
-    public static String[] getRows(TreeReference[] references,
+    private static String[] getRows(TreeReference[] references,
             EvaluationContext evaluationContext,
             Detail detail) {
         String[] rows = new String[references.length];

--- a/src/cli/java/org/commcare/util/screen/EntityListSubscreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityListSubscreen.java
@@ -14,11 +14,8 @@ import org.commcare.suite.model.DetailField;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.model.trace.AccumulatingReporter;
-import org.javarosa.core.model.trace.EvaluationTraceReporter;
 import org.javarosa.core.model.trace.ReducingTraceReporter;
-import org.javarosa.core.model.utils.InstrumentationUtils;
 import org.javarosa.core.util.DataUtil;
-import org.javarosa.xpath.XPathException;
 
 import java.io.PrintStream;
 import java.util.ArrayList;
@@ -69,15 +66,14 @@ public class EntityListSubscreen extends Subscreen<EntityScreen> {
             entities.add(nodeEntityFactory.getEntity(reference));
         }
         nodeEntityFactory.prepareEntities(entities);
-        filterEntities(entityScreenContext);
+        filterEntities(entityScreenContext, nodeEntityFactory);
         sortEntities(entityScreenContext);
     }
 
-    private void filterEntities(EntityScreenContext entityScreenContext) {
+    private void filterEntities(EntityScreenContext entityScreenContext, NodeEntityFactory nodeEntityFactory) {
         String searchText = entityScreenContext.getSearchText();
         boolean isFuzzySearchEnabled = entityScreenContext.isFuzzySearch();
         if (searchText != null && !"".equals(searchText)) {
-            NodeEntityFactory nodeEntityFactory = new NodeEntityFactory(shortDetail, rootContext);
             EntityStringFilterer filterer = new EntityStringFilterer(searchText.split(" "),
                     nodeEntityFactory, entities, isFuzzySearchEnabled);
             entities = filterer.buildMatchList();

--- a/src/cli/java/org/commcare/util/screen/EntityListSubscreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityListSubscreen.java
@@ -3,6 +3,9 @@ package org.commcare.util.screen;
 import static org.commcare.util.screen.MultiSelectEntityScreen.USE_SELECTED_VALUES;
 
 import org.commcare.cases.entity.Entity;
+import org.commcare.cases.entity.EntitySortNotificationInterface;
+import org.commcare.cases.entity.EntitySorter;
+import org.commcare.cases.entity.EntityStringFilterer;
 import org.commcare.cases.entity.NodeEntityFactory;
 import org.commcare.modern.util.Pair;
 import org.commcare.suite.model.Action;
@@ -33,6 +36,7 @@ public class EntityListSubscreen extends Subscreen<EntityScreen> {
     private static final int SCREEN_WIDTH = 100;
 
     private final TreeReference[] entitiesRefs;
+    private final EntityScreenContext entityScreenContext;
     private String[] rows;
     private final String mHeader;
 
@@ -45,24 +49,64 @@ public class EntityListSubscreen extends Subscreen<EntityScreen> {
     private List<Entity<TreeReference>> entities;
 
     public EntityListSubscreen(Detail shortDetail, Vector<TreeReference> references, EvaluationContext context,
-            boolean handleCaseIndex) throws CommCareSessionException {
+            boolean handleCaseIndex, EntityScreenContext entityScreenContext) throws CommCareSessionException {
         mHeader = createHeader(shortDetail, context);
         this.shortDetail = shortDetail;
         this.rootContext = context;
         this.entitiesRefs = new TreeReference[references.size()];
         this.handleCaseIndex = handleCaseIndex;
+        this.entityScreenContext = entityScreenContext;
         references.copyInto(entitiesRefs);
         actions = shortDetail.getCustomActions(context);
-        initEntities(context, shortDetail);
+        initEntities(context, shortDetail, entityScreenContext);
     }
 
-    private void initEntities(EvaluationContext context, Detail shortDetail) {
+    private void initEntities(EvaluationContext context, Detail shortDetail,
+            EntityScreenContext entityScreenContext) {
         NodeEntityFactory nodeEntityFactory = new NodeEntityFactory(shortDetail, context);
         entities = new ArrayList<>();
         for (TreeReference reference : entitiesRefs) {
             entities.add(nodeEntityFactory.getEntity(reference));
         }
         nodeEntityFactory.prepareEntities(entities);
+        filterEntities(entityScreenContext);
+        sortEntities(entityScreenContext);
+    }
+
+    private void filterEntities(EntityScreenContext entityScreenContext) {
+        String searchText = entityScreenContext.getSearchText();
+        boolean isFuzzySearchEnabled = entityScreenContext.isFuzzySearch();
+        if (searchText != null && !"".equals(searchText)) {
+            NodeEntityFactory nodeEntityFactory = new NodeEntityFactory(shortDetail, rootContext);
+            EntityStringFilterer filterer = new EntityStringFilterer(searchText.split(" "),
+                    nodeEntityFactory, entities, isFuzzySearchEnabled);
+            entities = filterer.buildMatchList();
+        }
+    }
+
+    private void sortEntities(EntityScreenContext entityScreenContext) {
+        int sortIndex = entityScreenContext.getSortIndex();
+        int[] order;
+        boolean reverse = false;
+        if (sortIndex != 0) {
+            if (sortIndex < 0) {
+                reverse = true;
+                sortIndex = Math.abs(sortIndex);
+            }
+            // sort index is one indexed so adjust for that
+            int sortFieldIndex = sortIndex - 1;
+            order = new int[]{sortFieldIndex};
+        } else {
+            order = shortDetail.getOrderedFieldIndicesForSorting();
+            for (int i = 0; i < shortDetail.getFields().length; ++i) {
+                String header = shortDetail.getFields()[i].getHeader().evaluate();
+                if (order.length == 0 && !"".equals(header)) {
+                    order = new int[]{i};
+                }
+            }
+        }
+        java.util.Collections.sort(entities,
+                new EntitySorter(shortDetail.getFields(), reverse, order, new LogNotifier()));
     }
 
     private String[] getRows(Detail detail) {
@@ -259,5 +303,12 @@ public class EntityListSubscreen extends Subscreen<EntityScreen> {
 
     public List<Entity<TreeReference>> getEntities() {
         return entities;
+    }
+
+    private static class LogNotifier implements EntitySortNotificationInterface {
+        @Override
+        public void notifyBadFilter(String[] args) {
+
+        }
     }
 }

--- a/src/cli/java/org/commcare/util/screen/EntityListSubscreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityListSubscreen.java
@@ -275,4 +275,8 @@ public class EntityListSubscreen extends Subscreen<EntityScreen> {
         }
         return widthHint;
     }
+
+    public Vector<Action> getActions() {
+        return actions;
+    }
 }

--- a/src/cli/java/org/commcare/util/screen/EntityListSubscreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityListSubscreen.java
@@ -198,6 +198,7 @@ public class EntityListSubscreen extends Subscreen<EntityScreen> {
         out.println(ScreenUtils.pad("", maxLength + 1) + mHeader);
         out.println("===========================================================================================");
 
+        initRows();
         for (int i = 0; i < entitiesRefs.length; ++i) {
             String d = rows[i];
             out.println(ScreenUtils.pad(String.valueOf(i), maxLength) + ") " + d);
@@ -215,10 +216,14 @@ public class EntityListSubscreen extends Subscreen<EntityScreen> {
 
     @Override
     public String[] getOptions() {
+        initRows();
+        return rows;
+    }
+
+    private void initRows() {
         if (rows == null) {
             rows = getRows(shortDetail);
         }
-        return rows;
     }
 
     @Override

--- a/src/cli/java/org/commcare/util/screen/EntityListSubscreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityListSubscreen.java
@@ -6,7 +6,6 @@ import org.commcare.modern.util.Pair;
 import org.commcare.suite.model.Action;
 import org.commcare.suite.model.Detail;
 import org.commcare.suite.model.DetailField;
-import org.commcare.util.screen.MultiSelectEntityScreen;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.model.trace.AccumulatingReporter;
@@ -29,7 +28,7 @@ public class EntityListSubscreen extends Subscreen<EntityScreen> {
 
     private static final int SCREEN_WIDTH = 100;
 
-    private final TreeReference[] mChoices;
+    private final TreeReference[] entitiesRefs;
     private final String[] rows;
     private final String mHeader;
 
@@ -45,11 +44,11 @@ public class EntityListSubscreen extends Subscreen<EntityScreen> {
         mHeader = createHeader(shortDetail, context);
         this.shortDetail = shortDetail;
         this.rootContext = context;
-        this.mChoices = new TreeReference[references.size()];
+        this.entitiesRefs = new TreeReference[references.size()];
         this.handleCaseIndex = handleCaseIndex;
-        references.copyInto(mChoices);
+        references.copyInto(entitiesRefs);
         actions = shortDetail.getCustomActions(context);
-        rows = getRows(mChoices, context, shortDetail);
+        rows = getRows(entitiesRefs, context, shortDetail);
     }
 
     private static String[] getRows(TreeReference[] references,
@@ -177,11 +176,11 @@ public class EntityListSubscreen extends Subscreen<EntityScreen> {
 
     @Override
     public void prompt(PrintStream out) {
-        int maxLength = String.valueOf(mChoices.length).length();
+        int maxLength = String.valueOf(entitiesRefs.length).length();
         out.println(ScreenUtils.pad("", maxLength + 1) + mHeader);
         out.println("===========================================================================================");
 
-        for (int i = 0; i < mChoices.length; ++i) {
+        for (int i = 0; i < entitiesRefs.length; ++i) {
             String d = rows[i];
             out.println(ScreenUtils.pad(String.valueOf(i), maxLength) + ") " + d);
         }
@@ -221,7 +220,7 @@ public class EntityListSubscreen extends Subscreen<EntityScreen> {
             String debugArg = input.substring("debug ".length());
             try {
                 int chosenDebugIndex = Integer.valueOf(debugArg.trim());
-                createRow(this.mChoices[chosenDebugIndex], rootContext, shortDetail);
+                createRow(this.entitiesRefs[chosenDebugIndex], rootContext, shortDetail);
             } catch (NumberFormatException e) {
                 if ("list".equals(debugArg)) {
                     host.printNodesetExpansionTrace(new AccumulatingReporter());
@@ -244,12 +243,12 @@ public class EntityListSubscreen extends Subscreen<EntityScreen> {
                     selectedRefs = new TreeReference[selectedValues.length];
                     for (int i = 0; i < selectedValues.length; i++) {
                         int index = Integer.parseInt(selectedValues[i]);
-                        selectedRefs[i] = mChoices[index];
+                        selectedRefs[i] = entitiesRefs[index];
                     }
                 } else {
                     int index = Integer.parseInt(input);
                     selectedRefs = new TreeReference[1];
-                    selectedRefs[0] = mChoices[index];
+                    selectedRefs[0] = entitiesRefs[index];
                 }
                 host.updateSelection(input, selectedRefs);
                 return true;

--- a/src/cli/java/org/commcare/util/screen/EntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreen.java
@@ -57,7 +57,6 @@ public class EntityScreen extends CompoundScreenHost {
 
     private boolean handleCaseIndex;
     private boolean needsFullInit = true;
-    private boolean isDetailScreen = false;
 
     protected Vector<TreeReference> references;
 
@@ -86,12 +85,11 @@ public class EntityScreen extends CompoundScreenHost {
     }
 
     public EntityScreen(boolean handleCaseIndex, boolean needsFullInit, SessionWrapper session,
-            boolean isDetailScreen, EntityScreenContext entityScreenContext)
+            EntityScreenContext entityScreenContext)
             throws CommCareSessionException {
         this.handleCaseIndex = handleCaseIndex;
         this.needsFullInit = needsFullInit;
         this.setSession(session);
-        this.isDetailScreen = isDetailScreen;
         this.entityScreenContext = entityScreenContext;
     }
 
@@ -160,7 +158,7 @@ public class EntityScreen extends CompoundScreenHost {
             // if isDetailScreen or needsFullInit is not set,
             // sub screen is needed to handle actions but we can skip eval refs
             Vector<TreeReference> entityListReferences =
-                    !needsFullInit || isDetailScreen ? new Vector<>() : references;
+                    !needsFullInit || isDetailScreen() ? new Vector<>() : references;
             mCurrentScreen = new EntityListSubscreen(mShortDetail, entityListReferences, evalContext,
                     handleCaseIndex, entityScreenContext);
         }
@@ -304,10 +302,14 @@ public class EntityScreen extends CompoundScreenHost {
     }
 
     private void showDetailScreen() throws CommCareSessionException {
-        if (isDetailScreen) {
+        if (isDetailScreen()) {
             // Set entity screen to show detail and redraw
             setCurrentScreenToDetail();
         }
+    }
+
+    private boolean isDetailScreen() {
+        return entityScreenContext.getDetailSelection() != null;
     }
 
     @Trace

--- a/src/cli/java/org/commcare/util/screen/EntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreen.java
@@ -37,6 +37,7 @@ import datadog.trace.api.Trace;
  */
 public class EntityScreen extends CompoundScreenHost {
 
+    private final EntityScreenContext entityScreenContext;
     private TreeReference mCurrentSelection;
 
     private SessionWrapper mSession;
@@ -67,6 +68,7 @@ public class EntityScreen extends CompoundScreenHost {
 
     public EntityScreen(boolean handleCaseIndex) {
         this.handleCaseIndex = handleCaseIndex;
+        entityScreenContext = new EntityScreenContext();
     }
 
     /**
@@ -80,15 +82,17 @@ public class EntityScreen extends CompoundScreenHost {
     public EntityScreen(boolean handleCaseIndex, boolean needsFullInit) {
         this.handleCaseIndex = handleCaseIndex;
         this.needsFullInit = needsFullInit;
+        entityScreenContext = new EntityScreenContext();
     }
 
     public EntityScreen(boolean handleCaseIndex, boolean needsFullInit, SessionWrapper session,
-            boolean isDetailScreen)
+            boolean isDetailScreen, EntityScreenContext entityScreenContext)
             throws CommCareSessionException {
         this.handleCaseIndex = handleCaseIndex;
         this.needsFullInit = needsFullInit;
         this.setSession(session);
         this.isDetailScreen = isDetailScreen;
+        this.entityScreenContext = entityScreenContext;
     }
 
     public void evaluateAutoLaunch(String nextInput) throws CommCareSessionException {
@@ -97,7 +101,7 @@ public class EntityScreen extends CompoundScreenHost {
             if (action.isAutoLaunchAction(subContext)) {
                 // Supply an empty case list so we can "select" from it later using getEntityFromID
                 mCurrentScreen = new EntityListSubscreen(mShortDetail, new Vector<>(), evalContext,
-                        handleCaseIndex);
+                        handleCaseIndex, entityScreenContext);
                 this.autoLaunchAction = action;
             }
         }
@@ -158,7 +162,7 @@ public class EntityScreen extends CompoundScreenHost {
             Vector<TreeReference> entityListReferences =
                     !needsFullInit || isDetailScreen ? new Vector<>() : references;
             mCurrentScreen = new EntityListSubscreen(mShortDetail, entityListReferences, evalContext,
-                    handleCaseIndex);
+                    handleCaseIndex, entityScreenContext);
         }
         initialized = true;
     }
@@ -348,7 +352,7 @@ public class EntityScreen extends CompoundScreenHost {
         if (detailNodeset != null) {
             TreeReference contextualizedNodeset = detailNodeset.contextualize(this.mCurrentSelection);
             this.mCurrentScreen = new EntityListSubscreen(longDetailList[index],
-                    subContext.expandReference(contextualizedNodeset), subContext, handleCaseIndex);
+                    subContext.expandReference(contextualizedNodeset), subContext, handleCaseIndex, entityScreenContext);
         } else {
             this.mCurrentScreen = new EntityDetailSubscreen(index, longDetailList[index],
                     subContext, getDetailListTitles(subContext, this.mCurrentSelection));
@@ -482,5 +486,9 @@ public class EntityScreen extends CompoundScreenHost {
 
     public void setQueryScreen(QueryScreen queryScreen) {
         this.queryScreen = queryScreen;
+    }
+
+    public EntityScreenContext getEntityScreenContext() {
+        return entityScreenContext;
     }
 }

--- a/src/cli/java/org/commcare/util/screen/EntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreen.java
@@ -148,12 +148,17 @@ public class EntityScreen extends CompoundScreenHost {
                 if (!this.setCurrentScreenToDetail()) {
                     readyToSkip = true;
                 }
-            } else {
-                // We can simply skip evaluating Detail for entities for a detail screen
-                Vector<TreeReference> entityListReferences = isDetailScreen ? new Vector<>() : references;
-                mCurrentScreen = new EntityListSubscreen(mShortDetail, entityListReferences, evalContext,
-                        handleCaseIndex);
             }
+        }
+
+        // if readyToSkip, entity screen will not be displayed. We don't need to init the subscreen
+        if (!readyToSkip) {
+            // if isDetailScreen or needsFullInit is not set,
+            // sub screen is needed to handle actions but we can skip eval refs
+            Vector<TreeReference> entityListReferences =
+                    !needsFullInit || isDetailScreen ? new Vector<>() : references;
+            mCurrentScreen = new EntityListSubscreen(mShortDetail, entityListReferences, evalContext,
+                    handleCaseIndex);
         }
         initialized = true;
     }

--- a/src/cli/java/org/commcare/util/screen/EntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreen.java
@@ -354,7 +354,8 @@ public class EntityScreen extends CompoundScreenHost {
         if (detailNodeset != null) {
             TreeReference contextualizedNodeset = detailNodeset.contextualize(this.mCurrentSelection);
             this.mCurrentScreen = new EntityListSubscreen(longDetailList[index],
-                    subContext.expandReference(contextualizedNodeset), subContext, handleCaseIndex, entityScreenContext);
+                    subContext.expandReference(contextualizedNodeset), subContext, handleCaseIndex,
+                    entityScreenContext);
         } else {
             this.mCurrentScreen = new EntityDetailSubscreen(index, longDetailList[index],
                     subContext, getDetailListTitles(subContext, this.mCurrentSelection));

--- a/src/cli/java/org/commcare/util/screen/EntityScreenContext.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreenContext.java
@@ -1,0 +1,70 @@
+package org.commcare.util.screen;
+
+/**
+ * Holds essential meta data associated with the entity screen
+ */
+public class EntityScreenContext {
+    private final int mOffSet;
+    private final String mSearchText;
+    private final int mSortIndex;
+    private final int mCasesPerPage;
+    private final String[] mSelectedValues;
+
+    /**
+     * If requesting a case detail will be a case id, else null. When the case id is given it is used to short
+     * circuit the normal TreeReference calculation by inserting a predicate that is [@case_id = <detailSelection>]
+     */
+    private final String mDetailSelection;
+
+    private static int DEFAULT_CASES_PER_PAGE = 10;
+    private final boolean fuzzySearch;
+
+    public EntityScreenContext(int offset, String searchText, int sortIndex, int casesPerPage,
+            String[] selectedValues, String detailSelection, boolean isFuzzySearch) {
+        mOffSet = offset;
+        mSearchText = searchText;
+        mSortIndex = sortIndex;
+        mCasesPerPage = casesPerPage;
+        mSelectedValues = selectedValues;
+        mDetailSelection = detailSelection;
+        fuzzySearch = isFuzzySearch;
+    }
+
+    public EntityScreenContext() {
+        mOffSet = 0;
+        mSearchText = null;
+        mSortIndex = 0;
+        mCasesPerPage = DEFAULT_CASES_PER_PAGE;
+        mSelectedValues = null;
+        mDetailSelection = null;
+        fuzzySearch = false;
+    }
+
+    public int getOffSet() {
+        return mOffSet;
+    }
+
+    public String getSearchText() {
+        return mSearchText;
+    }
+
+    public int getSortIndex() {
+        return mSortIndex;
+    }
+
+    public int getCasesPerPage() {
+        return mCasesPerPage;
+    }
+
+    public String[] getSelectedValues() {
+        return mSelectedValues;
+    }
+
+    public String getDetailSelection() {
+        return mDetailSelection;
+    }
+
+    public boolean isFuzzySearch() {
+        return fuzzySearch;
+    }
+}

--- a/src/cli/java/org/commcare/util/screen/EntityScreenContext.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreenContext.java
@@ -24,7 +24,7 @@ public class EntityScreenContext {
         mOffSet = offset;
         mSearchText = searchText;
         mSortIndex = sortIndex;
-        mCasesPerPage = casesPerPage;
+        mCasesPerPage = casesPerPage == 0 ? DEFAULT_CASES_PER_PAGE : casesPerPage;
         mSelectedValues = selectedValues;
         mDetailSelection = detailSelection;
         fuzzySearch = isFuzzySearch;

--- a/src/cli/java/org/commcare/util/screen/EntityScreenHelper.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreenHelper.java
@@ -64,10 +64,13 @@ public class EntityScreenHelper {
             order = new int[]{sortFieldIndex};
         } else {
             order = shortDetail.getOrderedFieldIndicesForSorting();
-            for (int i = 0; i < shortDetail.getFields().length; ++i) {
-                String header = shortDetail.getFields()[i].getHeader().evaluate();
-                if (order.length == 0 && !"".equals(header)) {
-                    order = new int[]{i};
+            if (order.length == 0) {
+                for (int i = 0; i < shortDetail.getFields().length; ++i) {
+                    String header = shortDetail.getFields()[i].getHeader().evaluate();
+                    if (!"".equals(header)) {
+                        order = new int[]{i};
+                        break;
+                    }
                 }
             }
         }

--- a/src/cli/java/org/commcare/util/screen/EntityScreenHelper.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreenHelper.java
@@ -1,0 +1,85 @@
+package org.commcare.util.screen;
+
+import org.commcare.cases.entity.Entity;
+import org.commcare.cases.entity.EntitySortNotificationInterface;
+import org.commcare.cases.entity.EntitySorter;
+import org.commcare.cases.entity.EntityStringFilterer;
+import org.commcare.cases.entity.NodeEntityFactory;
+import org.commcare.suite.model.Detail;
+import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.model.instance.TreeReference;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Common methods for initialising entities
+ */
+public class EntityScreenHelper {
+
+    /**
+     * Initialises given entity references into Entity models
+     * @param context evaluation context to calculate detail fields
+     * @param detail detail definition to map the given entity references to
+     * @param entityScreenContext entity screen context
+     * @param entitiesRefs references to initialise
+     * @return List of initialised entity models
+     */
+    public static List<Entity<TreeReference>> initEntities(EvaluationContext context, Detail detail,
+            EntityScreenContext entityScreenContext, TreeReference[] entitiesRefs) {
+        NodeEntityFactory nodeEntityFactory = new NodeEntityFactory(detail, context);
+        List<Entity<TreeReference>> entities = new ArrayList<>();
+        for (TreeReference reference : entitiesRefs) {
+            entities.add(nodeEntityFactory.getEntity(reference));
+        }
+        nodeEntityFactory.prepareEntities(entities);
+        entities = filterEntities(entityScreenContext, nodeEntityFactory, entities);
+        return sortEntities(entityScreenContext, entities, detail);
+    }
+
+    private static List<Entity<TreeReference>> filterEntities(EntityScreenContext entityScreenContext, NodeEntityFactory nodeEntityFactory,
+            List<Entity<TreeReference>> entities) {
+        String searchText = entityScreenContext.getSearchText();
+        boolean isFuzzySearchEnabled = entityScreenContext.isFuzzySearch();
+        if (searchText != null && !"".equals(searchText)) {
+            EntityStringFilterer filterer = new EntityStringFilterer(searchText.split(" "),
+                    nodeEntityFactory, entities, isFuzzySearchEnabled);
+            entities = filterer.buildMatchList();
+        }
+        return entities;
+    }
+
+    private static List<Entity<TreeReference>> sortEntities(EntityScreenContext entityScreenContext, List<Entity<TreeReference>> entities,
+            Detail shortDetail) {
+        int sortIndex = entityScreenContext.getSortIndex();
+        int[] order;
+        boolean reverse = false;
+        if (sortIndex != 0) {
+            if (sortIndex < 0) {
+                reverse = true;
+                sortIndex = Math.abs(sortIndex);
+            }
+            // sort index is one indexed so adjust for that
+            int sortFieldIndex = sortIndex - 1;
+            order = new int[]{sortFieldIndex};
+        } else {
+            order = shortDetail.getOrderedFieldIndicesForSorting();
+            for (int i = 0; i < shortDetail.getFields().length; ++i) {
+                String header = shortDetail.getFields()[i].getHeader().evaluate();
+                if (order.length == 0 && !"".equals(header)) {
+                    order = new int[]{i};
+                }
+            }
+        }
+        java.util.Collections.sort(entities,
+                new EntitySorter(shortDetail.getFields(), reverse, order, new LogNotifier()));
+        return entities;
+    }
+
+    private static class LogNotifier implements EntitySortNotificationInterface {
+        @Override
+        public void notifyBadFilter(String[] args) {
+
+        }
+    }
+}

--- a/src/cli/java/org/commcare/util/screen/EntityScreenHelper.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreenHelper.java
@@ -19,10 +19,11 @@ public class EntityScreenHelper {
 
     /**
      * Initialises given entity references into Entity models
-     * @param context evaluation context to calculate detail fields
-     * @param detail detail definition to map the given entity references to
+     *
+     * @param context             evaluation context to calculate detail fields
+     * @param detail              detail definition to map the given entity references to
      * @param entityScreenContext entity screen context
-     * @param entitiesRefs references to initialise
+     * @param entitiesRefs        references to initialise
      * @return List of initialised entity models
      */
     public static List<Entity<TreeReference>> initEntities(EvaluationContext context, Detail detail,
@@ -37,7 +38,8 @@ public class EntityScreenHelper {
         return sortEntities(entityScreenContext, entities, detail);
     }
 
-    private static List<Entity<TreeReference>> filterEntities(EntityScreenContext entityScreenContext, NodeEntityFactory nodeEntityFactory,
+    private static List<Entity<TreeReference>> filterEntities(EntityScreenContext entityScreenContext,
+            NodeEntityFactory nodeEntityFactory,
             List<Entity<TreeReference>> entities) {
         String searchText = entityScreenContext.getSearchText();
         boolean isFuzzySearchEnabled = entityScreenContext.isFuzzySearch();
@@ -49,7 +51,8 @@ public class EntityScreenHelper {
         return entities;
     }
 
-    private static List<Entity<TreeReference>> sortEntities(EntityScreenContext entityScreenContext, List<Entity<TreeReference>> entities,
+    private static List<Entity<TreeReference>> sortEntities(EntityScreenContext entityScreenContext,
+            List<Entity<TreeReference>> entities,
             Detail shortDetail) {
         int sortIndex = entityScreenContext.getSortIndex();
         int[] order;

--- a/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
@@ -39,10 +39,9 @@ public class MultiSelectEntityScreen extends EntityScreen {
     public MultiSelectEntityScreen(boolean handleCaseIndex, boolean needsFullInit,
             SessionWrapper session,
             VirtualDataInstanceStorage virtualDataInstanceStorage,
-            boolean isDetailScreen,
             EntityScreenContext entityScreenContext)
             throws CommCareSessionException {
-        super(handleCaseIndex, needsFullInit, session, isDetailScreen, entityScreenContext);
+        super(handleCaseIndex, needsFullInit, session, entityScreenContext);
         this.virtualDataInstanceStorage = virtualDataInstanceStorage;
     }
 

--- a/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
@@ -39,9 +39,10 @@ public class MultiSelectEntityScreen extends EntityScreen {
     public MultiSelectEntityScreen(boolean handleCaseIndex, boolean needsFullInit,
             SessionWrapper session,
             VirtualDataInstanceStorage virtualDataInstanceStorage,
-            boolean isDetailScreen)
+            boolean isDetailScreen,
+            EntityScreenContext entityScreenContext)
             throws CommCareSessionException {
-        super(handleCaseIndex, needsFullInit, session, isDetailScreen);
+        super(handleCaseIndex, needsFullInit, session, isDetailScreen, entityScreenContext);
         this.virtualDataInstanceStorage = virtualDataInstanceStorage;
     }
 

--- a/src/main/java/org/commcare/cases/entity/EntityStringFilterer.java
+++ b/src/main/java/org/commcare/cases/entity/EntityStringFilterer.java
@@ -1,0 +1,57 @@
+package org.commcare.cases.entity;
+
+import org.commcare.modern.util.Pair;
+import org.commcare.util.EntitySortUtil;
+import org.javarosa.core.model.instance.TreeReference;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Filter entity list via all string-representable entity fields
+ */
+public class EntityStringFilterer {
+    private final String[] searchTerms;
+    private final ArrayList<Pair<Integer, Integer>> matchScores = new ArrayList<>();
+
+    private final NodeEntityFactory nodeFactory;
+    protected final List<Entity<TreeReference>> matchList;
+    protected final List<Entity<TreeReference>> fullEntityList;
+    private final boolean isFuzzySearchEnabled;
+
+    public EntityStringFilterer(String[] searchTerms,
+            NodeEntityFactory nodeFactory,
+            List<Entity<TreeReference>> fullEntityList,
+            boolean isFuzzySearchEnabled) {
+        this.isFuzzySearchEnabled = isFuzzySearchEnabled;
+        this.matchList = new ArrayList<>();
+        this.nodeFactory = nodeFactory;
+        this.fullEntityList = fullEntityList;
+        this.searchTerms = searchTerms;
+        if (searchTerms == null || searchTerms.length == 0) {
+            matchList.addAll(fullEntityList);
+        }
+    }
+
+    public List<Entity<TreeReference>> buildMatchList() {
+
+        while (!nodeFactory.isEntitySetReady()) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+
+        Locale currentLocale = Locale.getDefault();
+        EntitySortUtil.sortEntities(fullEntityList,
+                searchTerms,
+                currentLocale,
+                isFuzzySearchEnabled,
+                matchScores,
+                matchList,
+                fullEntityList::get);
+        return matchList;
+    }
+}

--- a/src/test/java/org/cli/CliTests.java
+++ b/src/test/java/org/cli/CliTests.java
@@ -148,8 +148,8 @@ public class CliTests {
                     Assert.assertTrue(output.contains("0) Name"));
                     break;
                 case 2:
-                    Assert.assertTrue(output.contains("0) Lucy"));
-                    Assert.assertTrue(output.contains("1) Jack"));
+                    Assert.assertTrue(output.contains("0) Jack"));
+                    Assert.assertTrue(output.contains("1) Lucy"));
                     break;
                 case 3:
                     Assert.assertTrue(output.contains("0) multi-select form with auto-launch case list"));


### PR DESCRIPTION
## Technical Summary

Couple Major Changes - 
1. `EntityListSubScreen` now inits, filters and sorts the entity list 
2. Adds a class `EntityListContext` to hold the necessary context for entity screens

FP - https://github.com/dimagi/formplayer/pull/1384

[Jira](https://dimagi-dev.atlassian.net/browse/USH-3165)

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

Changes are limited to CLI/FP with good test coverage for entity list screens.

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

[Detailed here](https://dimagi-dev.atlassian.net/browse/QA-5130?focusedCommentId=266271)

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
