### PR TITLE
Added BasicAuth subclass of AuthInfo, to support basic HTTP auth.

### DIFF
--- a/src/main/java/org/commcare/core/network/AuthInfo.java
+++ b/src/main/java/org/commcare/core/network/AuthInfo.java
@@ -19,7 +19,13 @@ public abstract class AuthInfo {
             this.username = username;
             this.password = password;
         }
+    }
 
+    public static class BasicAuth extends AuthInfo {
+        public BasicAuth(String username, String password) {
+            this.username = username;
+            this.password = password;
+        }
     }
 
     // Auth with the currently-logged in user


### PR DESCRIPTION
## Technical Summary
Added a dedicated BasicAuth class that the Android code can use to perform basic HTTP auth without any additional wrapping. The Android code does a type check on the AuthInfo to determine what credentials to send up, and other sub-classes involve additional steps that don't work for basic auth.

## Safety Assurance

### Safety story
Simply adding a class here for commcare-android to use.

### Automated test coverage
No new tests.

### Special deploy instructions
- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations.

### Review
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
