### PR TITLE
Retrieve HTTP error message from server

### DIFF
--- a/src/main/java/org/commcare/core/network/AuthInfo.java
+++ b/src/main/java/org/commcare/core/network/AuthInfo.java
@@ -19,7 +19,13 @@ public abstract class AuthInfo {
             this.username = username;
             this.password = password;
         }
+    }
 
+    public static class BasicAuth extends AuthInfo {
+        public BasicAuth(String username, String password) {
+            this.username = username;
+            this.password = password;
+        }
     }
 
     // Auth with the currently-logged in user

--- a/src/main/java/org/commcare/core/network/ModernHttpRequester.java
+++ b/src/main/java/org/commcare/core/network/ModernHttpRequester.java
@@ -87,7 +87,19 @@ public class ModernHttpRequester implements ResponseStreamAccessor {
         }
         try {
             response = makeRequest();
-            processResponse(responseProcessor, response.code(), this);
+
+            String errorMessage = null;
+            try {
+                ResponseBody body = response.errorBody();
+                if(body != null) {
+                    errorMessage = body.string();
+                }
+            }
+            catch(Exception e) {
+                //Ignore exception when we can't retrieve an error message
+            }
+
+            processResponse(responseProcessor, response.code(), errorMessage, this);
         } catch (IOException e) {
             e.printStackTrace();
             responseProcessor.handleIOException(e);
@@ -143,6 +155,7 @@ public class ModernHttpRequester implements ResponseStreamAccessor {
 
     public static void processResponse(HttpResponseProcessor responseProcessor,
                                        int responseCode,
+                                       String errorMessage,
                                        ResponseStreamAccessor streamAccessor) {
         if (responseCode >= 200 && responseCode < 300) {
             InputStream responseStream = null;


### PR DESCRIPTION
## Technical Summary
Added some code that attempts to retrieve an error message from an HTTP server response for debugging purposes. The code is wrapped in a try-catch where the catch is ignored, ensuring that nothing else will break if the new code is unable to retrieve an error message.

## Safety Assurance

### Safety story
Wrapped the new code in a try-catch with an empty catch body, such that any problem while attempting to retrieve the error message will be ignored.

### Special deploy instructions
- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations.

### Review
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
