### PR TITLE
Make sure step id, value and type are non-null

### DIFF
--- a/src/main/java/org/commcare/suite/model/StackFrameStep.java
+++ b/src/main/java/org/commcare/suite/model/StackFrameStep.java
@@ -1,5 +1,6 @@
 package org.commcare.suite.model;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 
@@ -71,6 +72,9 @@ public class StackFrameStep implements Externalizable {
     }
 
     public StackFrameStep(String type, String id, String value) {
+        Preconditions.checkNotNull(type, "Can't create a Stack Frame Step with null type");
+        Preconditions.checkNotNull(id, "Can't create a Stack Frame Step with null id");
+        Preconditions.checkNotNull(value, "Can't create a Stack Frame Step with null value");
         this.elementType = type;
         this.id = id;
         this.value = value;
@@ -240,8 +244,8 @@ public class StackFrameStep implements Externalizable {
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         this.elementType = ExtUtil.readString(in);
-        this.id = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
-        this.value = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
+        this.id = ExtUtil.readString(in);
+        this.value = ExtUtil.readString(in);
         this.valueIsXpath = ExtUtil.readBool(in);
         this.extras = (Multimap<String, Object>)ExtUtil.read(in, new ExtWrapMultiMap(String.class), pf);
         this.dataInstanceSources = (Hashtable<String, ExternalDataInstanceSource>)ExtUtil.read(in, new ExtWrapMap(String.class, ExternalDataInstanceSource.class), pf);
@@ -250,8 +254,8 @@ public class StackFrameStep implements Externalizable {
     @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.writeString(out, elementType);
-        ExtUtil.writeString(out, ExtUtil.emptyIfNull(id));
-        ExtUtil.writeString(out, ExtUtil.emptyIfNull(value));
+        ExtUtil.writeString(out, id);
+        ExtUtil.writeString(out, value);
         ExtUtil.writeBool(out, valueIsXpath);
         ExtUtil.write(out, new ExtWrapMultiMap(extras));
         ExtUtil.write(out, new ExtWrapMap(dataInstanceSources));


### PR DESCRIPTION
## Technical Summary

[Jira](https://dimagi-dev.atlassian.net/browse/QA-5355)

With Case List Grouping Feature, we add a new computed datum for a form as - 

`<datum id="case_id_parent_ids" function="join(' ', distinct-values(instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id]/index/parent))"/>`

If a case have no parent, this evaluates to a empty string which on deserialization was getting coverted to Null value and ultimately resulting into [the exception here](https://github.com/dimagi/commcare-core/blob/master/src/main/java/org/javarosa/core/model/data/UncastData.java#L33)

Since the null values in the session frame already results into an error like above, I feel confident for platform to enforce their non-nullability upfront and more explicitly. Doing this allows us to support for empty string values explicitly by treating them different than null values while serialisation. 

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

This can result into some faulty apps breakign upfront while menu navigation instead of a form submission but I think that should be ok.

Going to test this on staging with a normal app. 

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->
None
### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
None
### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
