### PR TITLE
Skip null values in session instance

### DIFF
--- a/src/main/java/org/commcare/session/SessionInstanceBuilder.java
+++ b/src/main/java/org/commcare/session/SessionInstanceBuilder.java
@@ -116,8 +116,10 @@ public class SessionInstanceBuilder {
 
     private static void addData(TreeElement root, String name, String data) {
         TreeElement datum = new TreeElement(name, root.getChildMultiplicity(name));
-        datum.setValue(new UncastData(data));
-        root.addChild(datum);
+        if (data != null) {
+            datum.setValue(new UncastData(data));
+            root.addChild(datum);
+        }
     }
 
 }


### PR DESCRIPTION
## Technical Summary

[Jira](https://dimagi-dev.atlassian.net/browse/QA-5355)

With Case List Grouping Feature, we add a new computed datum for a form as -

`<datum id="case_id_parent_ids" function="join(' ', distinct-values(instance('casedb')/casedb/case[@case_id = instance('commcaresession')/session/data/case_id]/index/parent))"/>`

If a case have no parent, this evaluates to a empty string which on deserialization was getting coverted to Null value and ultimately resulting into [the exception here](https://github.com/dimagi/commcare-core/blob/master/src/main/java/org/javarosa/core/model/data/UncastData.java#L33)

I think it should be safe to skip the null values from the session instance instead of crashing out. This will ultimately result into having no corrsponding node in the session xml tree which sounds like the right thing to do with null values. 


## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

Tested on staging. 
Change itself looks very safe since it just stops a null crash. 

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->
No
### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
No
### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
