### PR TITLE
remove title from header if null

### DIFF
--- a/src/main/java/org/javarosa/form/api/FormEntryCaption.java
+++ b/src/main/java/org/javarosa/form/api/FormEntryCaption.java
@@ -292,7 +292,7 @@ public class FormEntryCaption {
                 }
             }
             if (caption == null) {
-                return title + " " + ix + "/" + count;
+                return title == null ? ix + "/" + count : title + " " + ix + "/" + count;
             }
 
             Hashtable<String, Object> vars = new Hashtable<>();


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->
Currently in web apps if there is no `Display Text` provided for a `Repeat Group` "null" will be displayed in the header for repeats. This keeps the string "null" out of the repeat headers.

Before:
<img width="600" alt="Screenshot 2023-08-01 at 10 24 44 AM" src="https://github.com/dimagi/commcare-core/assets/42388648/bbc00a80-973f-4207-beb5-d7b12d947639">

After:
<img width="600" alt="Screenshot 2023-08-01 at 10 20 00 AM" src="https://github.com/dimagi/commcare-core/assets/42388648/1fd7bec8-19c7-4b8b-b7fd-866954f5482d">

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
jira ticket: https://dimagi-dev.atlassian.net/browse/USH-3424

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
Only changes how text is displayed in the case that `title` is null. 
tested locally

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->
don't appear to be tests that specifically cover repetition text.

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
no QA planned

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
