### PR TITLE
remove stream() APIs

### DIFF
--- a/src/main/java/org/commcare/suite/model/StackFrameStep.java
+++ b/src/main/java/org/commcare/suite/model/StackFrameStep.java
@@ -26,11 +26,11 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * @author ctsims
@@ -145,10 +145,13 @@ public class StackFrameStep implements Externalizable {
     }
 
     public Map<String, DataInstance> getInstances(InstanceInitializationFactory iif) {
-        return dataInstanceSources.values().stream().map((source) -> {
-            ExternalDataInstance instance = source.toInstance();
-            return instance.initialize(iif, source.getInstanceId());
-        }).collect(Collectors.toMap(DataInstance::getInstanceId, value -> value));
+        HashMap<String, DataInstance> instances = new HashMap<>();
+        for (ExternalDataInstanceSource source : dataInstanceSources.values()) {
+            ExternalDataInstance instance = (ExternalDataInstance)source.toInstance()
+                    .initialize(iif, source.getInstanceId());
+            instances.put(instance.getInstanceId(), instance);
+        }
+        return instances;
     }
 
     /**


### PR DESCRIPTION
## Technical Summary
Replace stream() APIs as Android is not able to support Java8 Apis on older devices and crashes with - 

````
java.lang.NoSuchMethodError: No interface method stream()Ljava/util/stream/Stream; in class Ljava/util/Collection; or its super classes (declaration of 'java.util.Collection' appears in /system/framework/core-libart.jar)
	at org.commcare.suite.model.StackFrameStep.getInstances(StackFrameStep.java:148)
````

We tried adding the support for these APIs in https://github.com/dimagi/commcare-android/pull/2686 but ran into issues with `java/util/stream/Collector` not present in the Android apk. 

Since this is breaking Android code in master for older Android versions today, I am simply replacing the code to not use these APIs. 

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

No Op, change will be verified with existing tests on Android and core

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
