### PR TITLE
Added TokenAuth subclass of AuthInfo.

### DIFF
--- a/src/main/java/org/commcare/core/network/AuthInfo.java
+++ b/src/main/java/org/commcare/core/network/AuthInfo.java
@@ -10,6 +10,8 @@ public abstract class AuthInfo {
     public String password;
     public boolean wrapDomain;
 
+    public String bearerToken;
+
     public static class NoAuth extends AuthInfo {
 
     }
@@ -24,7 +26,6 @@ public abstract class AuthInfo {
             this.password = password;
             this.wrapDomain = wrapDomain;
         }
-
     }
 
     // Auth with the currently-logged in user
@@ -32,4 +33,9 @@ public abstract class AuthInfo {
 
     }
 
+    public static class TokenAuth extends AuthInfo {
+        public TokenAuth(String token) {
+            bearerToken = token;
+        }
+    }
 }


### PR DESCRIPTION
## Technical Summary
Added a new subclass to AuthInfo called TokenAuth, which holds a bearer token and can be used for token authentication when communicating with a server. This will be used for SSO-related calls.

## Safety Assurance

### Safety story
Simple data class, limited effect. 

### QA Plan
No testing necessary.

### Special deploy instructions
- [x ] This PR can be deployed after merge with no further considerations.

### Rollback instructions
- [x ] This PR can be reverted after deploy with no further considerations.

### Review

- [x ] The set of people pinged as reviewers is appropriate for the level of risk of the change.
