### PR TITLE
Rc/validate required case search input

### DIFF
--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -287,7 +287,11 @@ public class RemoteQuerySessionManager {
                 errors.put(key, queryPrompt.getValidationMessage(ec));
             }
             if (StringUtils.isEmpty(value) && queryPrompt.isRequired(ec)) {
-                errors.put(key, queryPrompt.DEFAULT_REQUIRED_ERROR);
+                String message = queryPrompt.getRequiredMessage(ec);
+                if (message.replace('\u00A0',' ').isBlank()) {
+                    message = queryPrompt.DEFAULT_REQUIRED_ERROR;
+                }
+                errors.put(key,  message);
             }
         }
     }

--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -271,8 +271,8 @@ public class RemoteQuerySessionManager {
             String key = (String)en.nextElement();
             QueryPrompt queryPrompt = userInputDisplays.get(key);
             boolean isRequired = queryPrompt.isRequired(ec);
-            String value = userAnswers.get(key);
             requiredPrompts.put(key, isRequired);
+            String value = userAnswers.get(key);
             TreeReference currentRef = getReferenceToInstanceNode(instanceId, key);
             if (!StringUtils.isEmpty(value) && queryPrompt.isInvalidInput(new EvaluationContext(ec, currentRef))) {
                 errors.put(key, queryPrompt.getValidationMessage(ec));

--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -258,22 +258,11 @@ public class RemoteQuerySessionManager {
     public void refreshInputDependentState() {
         refreshItemSetChoices();
         validateUserAnswers();
-        recalculateRequired();
     }
 
-    private void recalculateRequired() {
-        requiredPrompts = new Hashtable<>();
-        OrderedHashtable<String, QueryPrompt> userInputDisplays = getNeededUserInputDisplays();
-        EvaluationContext ec = getEvaluationContextWithUserInputInstance();
-        for (Enumeration en = userInputDisplays.keys(); en.hasMoreElements(); ) {
-            String key = (String)en.nextElement();
-            QueryPrompt queryPrompt = userInputDisplays.get(key);
-            boolean isRequired = queryPrompt.isRequired(ec);
-            requiredPrompts.put(key, isRequired);
-        }
-    }
 
     private void validateUserAnswers() {
+        requiredPrompts = new Hashtable<>();
         errors = new Hashtable<>();
         OrderedHashtable<String, QueryPrompt> userInputDisplays = getNeededUserInputDisplays();
         String instanceId = VirtualInstances.makeSearchInputInstanceID(getSearchInstanceReferenceId());
@@ -281,12 +270,14 @@ public class RemoteQuerySessionManager {
         for (Enumeration en = userInputDisplays.keys(); en.hasMoreElements(); ) {
             String key = (String)en.nextElement();
             QueryPrompt queryPrompt = userInputDisplays.get(key);
+            boolean isRequired = queryPrompt.isRequired(ec);
             String value = userAnswers.get(key);
+            requiredPrompts.put(key, isRequired);
             TreeReference currentRef = getReferenceToInstanceNode(instanceId, key);
             if (!StringUtils.isEmpty(value) && queryPrompt.isInvalidInput(new EvaluationContext(ec, currentRef))) {
                 errors.put(key, queryPrompt.getValidationMessage(ec));
             }
-            if (StringUtils.isEmpty(value) && queryPrompt.isRequired(ec)) {
+            if (StringUtils.isEmpty(value) && isRequired) {
                 String message = queryPrompt.getRequiredMessage(ec);
                 if (message.replace('\u00A0',' ').isBlank()) {
                     message = queryPrompt.DEFAULT_REQUIRED_ERROR;

--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -286,6 +286,9 @@ public class RemoteQuerySessionManager {
             if (!StringUtils.isEmpty(value) && queryPrompt.isInvalidInput(new EvaluationContext(ec, currentRef))) {
                 errors.put(key, queryPrompt.getValidationMessage(ec));
             }
+            if (StringUtils.isEmpty(value) && queryPrompt.isRequired(ec)) {
+                errors.put(key, queryPrompt.DEFAULT_REQUIRED_ERROR);
+            }
         }
     }
 

--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -279,9 +279,6 @@ public class RemoteQuerySessionManager {
             }
             if (StringUtils.isEmpty(value) && isRequired) {
                 String message = queryPrompt.getRequiredMessage(ec);
-                if (message.replace('\u00A0',' ').isBlank()) {
-                    message = queryPrompt.DEFAULT_REQUIRED_ERROR;
-                }
                 errors.put(key,  message);
             }
         }

--- a/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
@@ -277,7 +277,7 @@ public class CaseClaimModelTests {
     public void testErrorsWithUserInput_noInput() throws Exception {
         testErrorsWithUserInput(
                 ImmutableMap.of(),
-                ImmutableMap.of(),
+                ImmutableMap.of("age", "Sorry, this response is required!", "dob", "Sorry, this response is required!"),
                 null
         );
     }
@@ -286,7 +286,7 @@ public class CaseClaimModelTests {
     public void testErrorsWithUserInput_EmptyInput() throws Exception {
         testErrorsWithUserInput(
                 ImmutableMap.of("age", "", "another_age", ""),
-                ImmutableMap.of(),
+                ImmutableMap.of("age", "Sorry, this response is required!"),
                 null
         );
     }

--- a/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
@@ -277,7 +277,7 @@ public class CaseClaimModelTests {
     public void testErrorsWithUserInput_noInput() throws Exception {
         testErrorsWithUserInput(
                 ImmutableMap.of(),
-                ImmutableMap.of("age", "Sorry, this response is required!", "dob", "Sorry, this response is required!"),
+                ImmutableMap.of("age", "One of age or DOB is required", "dob", "One of age or DOB is required"),
                 null
         );
     }
@@ -286,7 +286,7 @@ public class CaseClaimModelTests {
     public void testErrorsWithUserInput_EmptyInput() throws Exception {
         testErrorsWithUserInput(
                 ImmutableMap.of("age", "", "another_age", ""),
-                ImmutableMap.of("age", "Sorry, this response is required!"),
+                ImmutableMap.of("age", "One of age or DOB is required"),
                 null
         );
     }


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->
This adds additional validated that covers required case search inputs. Users will now see a 
Before:
<img width="400" alt="Screenshot 2023-08-15 at 10 49 49 AM" src="https://github.com/dimagi/commcare-core/assets/42388648/5d12fde3-a97e-450b-b48c-89954233daf7">

After:
<img width="400" alt="Screenshot 2023-08-15 at 3 35 41 PM" src="https://github.com/dimagi/commcare-core/assets/42388648/4890c284-cbe8-48a0-bac3-d1000f3cb4e3">

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
jira ticket: https://dimagi-dev.atlassian.net/browse/USH-3131

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->
test were updated here to handle required validation errors

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
no QA planned

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
