### PR TITLE
Revert "Rc/sccs subtitle"

### DIFF
--- a/src/cli/java/org/commcare/util/screen/QueryScreen.java
+++ b/src/cli/java/org/commcare/util/screen/QueryScreen.java
@@ -51,7 +51,6 @@ public class QueryScreen extends Screen {
     private String[] fields;
     private String mTitle;
     private String description;
-    private String resultsTitle;
     private String currentMessage;
 
     private String domainedUsername;
@@ -95,7 +94,6 @@ public class QueryScreen extends Screen {
 
         mTitle = getTitleLocaleString();
         description = getDescriptionLocaleString();
-        resultsTitle = getResultsTitleLocaleString();
     }
 
     private String getTitleLocaleString() {
@@ -114,15 +112,6 @@ public class QueryScreen extends Screen {
             description = "";
         }
         return description;
-    }
-
-    private String getResultsTitleLocaleString() {
-        try {
-            resultsTitle = getQueryDatum().getResultsTitleText().evaluate();
-        } catch (NoLocalizedTextException | NullPointerException e) {
-            resultsTitle = "";
-        }
-        return resultsTitle;
     }
 
     private String getTitleLocaleStringLegacy() {
@@ -246,10 +235,6 @@ public class QueryScreen extends Screen {
 
     public String getDescriptionText() {
         return description;
-    }
-
-    public String getResultsTitle() {
-        return resultsTitle;
     }
 
     @Override

--- a/src/main/java/org/commcare/suite/model/RemoteQueryDatum.java
+++ b/src/main/java/org/commcare/suite/model/RemoteQueryDatum.java
@@ -32,7 +32,6 @@ public class RemoteQueryDatum extends SessionDatum {
     private boolean defaultSearch;
     private Text title;
     private Text description;
-    private Text resultsTitle;
 
     @SuppressWarnings("unused")
     public RemoteQueryDatum() {
@@ -46,8 +45,7 @@ public class RemoteQueryDatum extends SessionDatum {
     public RemoteQueryDatum(URL url, String storageInstance,
             List<QueryData> hiddenQueryValues,
                             OrderedHashtable<String, QueryPrompt> userQueryPrompts,
-                            boolean useCaseTemplate, boolean defaultSearch,
-                            Text title, Text description, Text resultsTitle) {
+                            boolean useCaseTemplate, boolean defaultSearch, Text title, Text description) {
         super(storageInstance, url.toString());
         this.hiddenQueryValues = hiddenQueryValues;
         this.userQueryPrompts = userQueryPrompts;
@@ -55,7 +53,6 @@ public class RemoteQueryDatum extends SessionDatum {
         this.defaultSearch = defaultSearch;
         this.title = title;
         this.description = description;
-        this.resultsTitle = resultsTitle;
     }
 
     public OrderedHashtable<String, QueryPrompt> getUserQueryPrompts() {
@@ -92,8 +89,6 @@ public class RemoteQueryDatum extends SessionDatum {
         return description;
     }
 
-    public Text getResultsTitleText() { return resultsTitle; }
-
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf)
             throws IOException, DeserializationException {
@@ -107,7 +102,6 @@ public class RemoteQueryDatum extends SessionDatum {
         description = (Text) ExtUtil.read(in, new ExtWrapNullable(Text.class), pf);
         useCaseTemplate = ExtUtil.readBool(in);
         defaultSearch = ExtUtil.readBool(in);
-        resultsTitle = (Text) ExtUtil.read(in, new ExtWrapNullable(Text.class), pf);
         
     }
 
@@ -120,6 +114,6 @@ public class RemoteQueryDatum extends SessionDatum {
         ExtUtil.write(out, new ExtWrapNullable(description));
         ExtUtil.writeBool(out, useCaseTemplate);
         ExtUtil.writeBool(out, defaultSearch);
-        ExtUtil.write(out, new ExtWrapNullable(resultsTitle));
+
     }
 }

--- a/src/main/java/org/commcare/xml/SessionDatumParser.java
+++ b/src/main/java/org/commcare/xml/SessionDatumParser.java
@@ -128,7 +128,6 @@ public class SessionDatumParser extends CommCareElementParser<SessionDatum> {
         boolean defaultSearch = "true".equals(parser.getAttributeValue(null, "default_search"));
         Text title = null;
         Text description = null;
-        Text resultsTitle = null;
         ArrayList<QueryData> hiddenQueryValues = new ArrayList<QueryData>();
         while (nextTagInBlock("query")) {
             String tagName = parser.getName();
@@ -143,13 +142,9 @@ public class SessionDatumParser extends CommCareElementParser<SessionDatum> {
             } else if ("description".equals(tagName)) {
                 nextTagInBlock("description");
                 description = new TextParser(parser).parse();
-            } else if ("results-title".equals(tagName)) {
-                nextTagInBlock("results-title");
-                resultsTitle = new TextParser(parser).parse();
             }
         }
         return new RemoteQueryDatum(queryUrl, queryResultStorageInstance,
-                hiddenQueryValues, userQueryPrompts, useCaseTemplate, defaultSearch, title, description,
-                resultsTitle);
+                hiddenQueryValues, userQueryPrompts, useCaseTemplate, defaultSearch, title, description);
     }
 }

--- a/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
@@ -62,9 +62,6 @@ public class CaseClaimModelTests {
 
         Text description = ((RemoteQueryDatum) datum).getDescriptionText();
         Assert.assertEquals("Description text", description.evaluate());
-
-        Text resultsTitle = ((RemoteQueryDatum) datum).getResultsTitleText();
-        Assert.assertEquals("Results Title", resultsTitle.evaluate());
     }
 
     @Test

--- a/src/test/resources/case_claim_example/app_strings.txt
+++ b/src/test/resources/case_claim_example/app_strings.txt
@@ -7,4 +7,3 @@ query.age.required.message=One of age or DOB is required
 query.dob.required.message=One of age or DOB is required
 query.title=Title Label
 query.description=Description text
-query.resultsTitle=Results Title

--- a/src/test/resources/case_claim_example/suite.xml
+++ b/src/test/resources/case_claim_example/suite.xml
@@ -72,11 +72,6 @@
             <locale id="query.description"/>
           </text>
         </description>
-        <results-title>
-          <text>
-            <locale id="query.resultsTitle"/>
-          </text>
-        </results-title>
         <data key="device_id" ref="instance('session')/session/context/deviceid"/>
         <data key="patient_id" ref="if(count(instance('search-input:patients')/input/field[@name='patient_id']) > 0, concat('external_id = ', instance('search-input:patients')/input/field[@name='patient_id']), '')"/>
         <data key="patient_id_legacy" ref="if(count(instance('search-input')/input/field[@name='patient_id']) > 0, concat('external_id = ', instance('search-input')/input/field[@name='patient_id']), '')"/>


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->
Reverts https://github.com/dimagi/commcare-core/pull/1307#issue-1797608733

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
On HQ side, https://github.com/dimagi/commcare-hq/pull/33359 reverts https://github.com/dimagi/commcare-hq/pull/33261 and removes the need for a `results-title` node.

HQ Ticket: https://dimagi-dev.atlassian.net/browse/USH-3539
Relates to formplayer PR: https://github.com/dimagi/formplayer/pull/1444

## Safety Assurance
For existing builds with suites that contain the `results-title` node, they will just be ignored when parsed
### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->
removes test that covers `result-title`
### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
No QA
### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

Must be deployed with https://github.com/dimagi/formplayer/pull/1444 (reversion of https://github.com/dimagi/formplayer/pull/1425)

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations.

### Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
