### PR TITLE
Mixed repeat group support for Web Apps

### DIFF
--- a/src/main/java/org/javarosa/core/model/GroupDef.java
+++ b/src/main/java/org/javarosa/core/model/GroupDef.java
@@ -116,6 +116,10 @@ public class GroupDef implements IFormElement {
         return isRepeat;
     }
 
+    public boolean isNonCountedRepeat() {
+        return isRepeat && getCountReference() == null;
+    }
+
     public void setIsRepeat(boolean repeat) {
         this.isRepeat = repeat;
     }

--- a/src/main/java/org/javarosa/form/api/FormEntryModel.java
+++ b/src/main/java/org/javarosa/form/api/FormEntryModel.java
@@ -91,6 +91,10 @@ public class FormEntryModel {
         IFormElement element = form.getChild(index);
         if (element instanceof GroupDef) {
             if (((GroupDef)element).isRepeat()) {
+                if (((GroupDef)element).getCountReference() == null) {
+                    // non counted repeat
+                    return FormEntryController.EVENT_REPEAT_JUNCTURE;
+                }
                 if (repeatStructure != REPEAT_STRUCTURE_NON_LINEAR && form.getMainInstance().resolveReference(form.getChildInstanceRef(index)) == null) {
                     return FormEntryController.EVENT_PROMPT_NEW_REPEAT;
                 } else if (repeatStructure == REPEAT_STRUCTURE_NON_LINEAR && index.getElementMultiplicity() == TreeReference.INDEX_REPEAT_JUNCTURE) {
@@ -426,10 +430,9 @@ public class FormEntryModel {
                 multiplicities.addElement(0);
                 elements.addElement((i == -1 ? form : elements.elementAt(i)).getChild(0));
 
-                if (repeatStructure == REPEAT_STRUCTURE_NON_LINEAR) {
-                    if (elements.lastElement() instanceof GroupDef && ((GroupDef)elements.lastElement()).isRepeat()) {
-                        multiplicities.setElementAt(TreeReference.INDEX_REPEAT_JUNCTURE, multiplicities.size() - 1);
-                    }
+                if (elements.lastElement() instanceof GroupDef
+                        && ((GroupDef)elements.lastElement()).isNonCountedRepeat()) {
+                    multiplicities.setElementAt(TreeReference.INDEX_REPEAT_JUNCTURE, multiplicities.size() - 1);
                 }
 
                 return;
@@ -467,10 +470,9 @@ public class FormEntryModel {
                 multiplicities.setElementAt(0, i);
                 elements.setElementAt(parent.getChild(curIndex + 1), i);
 
-                if (repeatStructure == REPEAT_STRUCTURE_NON_LINEAR) {
-                    if (elements.lastElement() instanceof GroupDef && ((GroupDef)elements.lastElement()).isRepeat()) {
-                        multiplicities.setElementAt(TreeReference.INDEX_REPEAT_JUNCTURE, multiplicities.size() - 1);
-                    }
+                if (elements.lastElement() instanceof GroupDef
+                        && ((GroupDef)elements.lastElement()).isNonCountedRepeat()) {
+                    multiplicities.setElementAt(TreeReference.INDEX_REPEAT_JUNCTURE, multiplicities.size() - 1);
                 }
 
                 return;


### PR DESCRIPTION

## Product Description
There are 2 kinds of repeat groups we support - 1. with no count (user clicks add new repeat to add new group) 2. With count pre-defined. Today Web App supports both of these if you only add one of these kind in the form. But if you add both of these kinds of repeat in a single form, the non counted repeat groups don’t show up at all on web apps. This change is to address support for mixed repeat group in a form on Web Apps.

## Technical Summary

The PR makes a simple change to not rely on `repeatStructure` passed to the [FormEntryModel](https://github.com/dimagi/commcare-core/blob/master/src/main/java/org/javarosa/form/api/FormEntryModel.java#L63) to determine whether the code should follow counted or non counted behaviour.  FP always init the formEntryModel `repeatStructure` as `REPEAT_STRUCTURE_NON_LINEAR` today but [changes it to](https://github.com/dimagi/commcare-core/blob/master/src/main/java/org/javarosa/form/api/FormEntryModel.java#L73) `REPEAT_STRUCTURE_LINEAR` when a counted repeat group is present. This in turn causes the behaviour to be different when a counted repeat group is present in the form along with the non counted repeat group. 

Since a form can have both kinds of repeat groups for different questions, initialising the form model with a particular repeat structure and then navigating the question nodes based on that for all kinds of repeat groups seems to be the root of the problem to me. This PR tries to disregard the repeat structure at certain places and instead directly check for `count` reference defined on the repeat group to fix the issue for mixed repeat groups. 

## Safety Assurance

### Safety story

- Will be [QA'ed](https://dimagi-dev.atlassian.net/browse/QA-5542) both on mobile and Web Apps to test for any regressions

### Automated test coverage

TBD

### QA Plan
https://dimagi-dev.atlassian.net/browse/QA-5542

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
