### PR TITLE
Fix backward compatibility for Stack Query Datum

### DIFF
--- a/src/main/java/org/commcare/suite/model/StackFrameStep.java
+++ b/src/main/java/org/commcare/suite/model/StackFrameStep.java
@@ -218,6 +218,10 @@ public class StackFrameStep implements Externalizable {
                 extras.forEach((key, value) -> {
                     if (value instanceof QueryData) {
                         defined.addExtra(key, ((QueryData)value).getValues(ec));
+                    } else if (value instanceof XPathExpression) {
+                        // only to maintain backward compatibility with old serialised app db state, can be removed in
+                        // subsequent deploys
+                        defined.addExtra(key, FunctionUtils.toString(((XPathExpression)value).eval(ec)));
                     } else {
                         throw new RuntimeException("Invalid data type for step extra " + key);
                     }


### PR DESCRIPTION
## Technical Summary

[Jira](https://dimagi-dev.atlassian.net/browse/SUPPORT-17607)

[Sentry](https://dimagi.sentry.io/issues/4476776766/?project=142105&query=is%3Aunresolved+invalid+data+type&referrer=issue-stream&statsPeriod=14d&stream_index=0)

We added a new model for stack query data in [this PR](https://github.com/dimagi/commcare-core/pull/1328/files) but we need to retain the processing over old model to support existing app serialised states which will have quer data in the old model until app DBs gets refreshed on FP. 

## Safety Assurance

Retains old code for stack query datum processing which should already have been working. 

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

Ran the [FP side tests](https://github.com/dimagi/formplayer/commit/d0cd2816fb3f30c2324eec918e2fa4feb7444696) again that tests for stack query evaluation.

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
