### PR TITLE
prints error message from merge conflicting arising from cherry-picking

### DIFF
--- a/scripts/duplicate_pr.py
+++ b/scripts/duplicate_pr.py
@@ -68,14 +68,17 @@ def get_new_commits(base_branch: str, curr_branch:str, base_commit:str = None):
 def cherry_pick_new_commits(commits:list[str], branch:str):
     git = get_git()
     git.checkout(branch)
-    for commits in reversed(commits):
+    for commit in reversed(commits):
         try:
             empty_commit_message = "The previous cherry-pick is now empty"
-            git("cherry-pick", commits)
+            failed_cherry_pick = "error: could not apply"
+            git("cherry-pick", commit)
         except sh.ErrorReturnCode_1 as e:
             if empty_commit_message in e.stderr.decode():
                 git("cherry-pick", "--skip")
-
+            if failed_cherry_pick in e.stderr.decode():
+                print(red(f'''Failed to cherry-pick {commit} most likely from a merge conflict with branch {branch}. The PR will need to either be manually duplicated or rebased to resolve the merge conflict.'''))
+                raise
 
 def git_push_pr(branch:str):
     git = get_git()


### PR DESCRIPTION
## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
This change results from workflow failures similar to this one. https://github.com/dimagi/commcare-core/actions/runs/6457184507/job/17528142604

The workflow fails because the commit being cherry-picked conflicts with the branch the commit is being cherry-picked into. This can not be handled automatically and will need to be manually handled.

Secondly, the error now displays the direct commit causing the issue. Previously, the error is handled by the exception (even though it is not properly handled) so does not raise the exception and it isn't until the next command which does not get handled that throws the exception. This led to the incorrect commit being shown as the issue.

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
Only impacts internal tool and introduces error messages which does not have a safety concern.

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->
no automated tests
### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
no QA 
### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [X] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations.

### Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
