### PR TITLE
Define end hash of interest for duplicating PR

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -8,7 +8,7 @@ We try to keep both these branches in sync with each other the best we can. To d
 
 1. If you are working on a Formplayer change, you will want to start by checking out `your_feature_branch` from `formplayer` as the base branch. Make changes on `your_feature_branch` and create your original PR against `formplayer` branch.
 
-2. Now you will need to duplicate this PR by making another PR against `master`. Make sure the branch for this PR is not deleted. Then create the comment `duplicate this PR`. If the PR has already been merged, comment `duplicate this PR <starting-commit-id>`. This should result in a Github Actions workflow duplicating your PR against `master`. Go to the duplicate PR, close and re-open it to run the Github checks against it. 
+2. Now you will need to duplicate this PR by making another PR against `master`. Make sure the branch for this PR is not deleted. Then create the comment `duplicate this PR`. If the PR has already been merged, comment `duplicate this PR <starting-commit-id> <ending-commit-id>`. The `ending-commit-id` should be the last non-merge commit in the PR. This should result in a Github Actions workflow duplicating your PR against `master`. Go to the duplicate PR, close and re-open it to run the Github checks against it.
 
 3. In order for us to test that your PR against `master` doesn't break anything on CommCare Android, you need to run android side tests with your PR.
 To do this - 
@@ -23,7 +23,7 @@ To do this -
 
 1. If you are working on a CommCare Android change, you will want to start by checking out `your_feature_branch` from `master` as the base branch. Make changes on `your_feature_branch` and create your original PR against `master` branch.
 
-2. Now you will need to duplicate this PR by making another PR against `formplayer`. Make sure the branch for this PR is not deleted. Then create the comment `duplicate this PR`. If the PR has already been merged, comment `duplicate this PR <starting-commit-id>`. This should result in a Github Actions workflow duplicating your PR against `formplayer`. Go to the duplicate PR, close and re-open it to run the Github checks against it. 
+2. Now you will need to duplicate this PR by making another PR against `formplayer`. Make sure the branch for this PR is not deleted. Then create the comment `duplicate this PR`. If the PR has already been merged, comment `duplicate this PR <starting-commit-id> <ending-commit-id>`. The `ending-commit-id` should be the last non-merge commit in the PR. This should result in a Github Actions workflow duplicating your PR against `formplayer`. Go to the duplicate PR, close and re-open it to run the Github checks against it.
 
 3. In order for us to test that your PR against `formplayer` doesn't break anything on Formplayer, we need to run formplayer side tests with your PR.
 To do this - 

--- a/.github/workflows/duplicate_pr.yml
+++ b/.github/workflows/duplicate_pr.yml
@@ -18,7 +18,15 @@ jobs:
         uses: actions/github-script@0.9.0
         with:
           script: |
-            const sha = context.payload.comment.body.split(" ").pop()
+            const sha = context.payload.comment.body.split(" ").reverse()[1];
+            core.setOutput('sha', sha)
+      - name: Get PR End Commit SHA
+        if: ${{ github.event.issue.pull_request.merged_at }}
+        id: end-sha
+        uses: actions/github-script@0.9.0
+        with:
+          script: |
+            const sha = context.payload.comment.body.split(" ").reverse()[0];
             core.setOutput('sha', sha)
       # https://github.com/marketplace/actions/pull-request-comment-branch
       - name: Pull Request Comment Branch
@@ -41,9 +49,10 @@ jobs:
         if: ${{ github.event.issue.pull_request.merged_at }}
         run: |
           echo Intial SHA is "${{ steps.initial-sha.outputs.sha }}"
-          python scripts/duplicate_pr.py ${{ steps.comment-branch.outputs.head_ref }} ${{ steps.comment-branch.outputs.base_ref }} --initial_sha ${initial_sha}
+          python scripts/duplicate_pr.py ${{ steps.comment-branch.outputs.head_ref }} ${{ steps.comment-branch.outputs.base_ref }} --initial_sha ${initial_sha} --end_sha ${end_sha}
         env:
           initial_sha: ${{ steps.initial-sha.outputs.sha }}
+          end_sha: ${{ steps.end-sha.outputs.sha }}
       - name: Run duplicate_pr.py script with PR not merged
         if: ${{ github.event.issue.pull_request.merged_at == null }}
         run: python scripts/duplicate_pr.py ${{ steps.comment-branch.outputs.head_ref }} ${{ steps.comment-branch.outputs.base_ref }}


### PR DESCRIPTION
## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
Resulting from this workflow failure: https://github.com/dimagi/commcare-core/actions/runs/6459548228/job/17535541395

No commits were returning from `git rev-list --no-merges --first-parent 8850102` This is because commit `af06064` has multiple parents with the `8850102` being the first. The commits of interest are not between the first parent (`8850102`) so it returns an empty list. The commits of interest in the PR to be duplicated are contained between the second parent and `af06064`. However, there is no way to know without user input. With this change, the user will also define the last non-merge commit in the PR. 

So in the linked PR, the comment that would lead to correct PR duplication would be `duplicate this PR 628e7a8 2eacb6b`
## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
Locally tested, only affects internal tool
### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->
no automated test
### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
no QA
### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [X] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations.

### Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
