### PR TITLE
Adds `respect-relevancy` to support Endpoints to Hidden Forms

### DIFF
--- a/src/cli/java/org/commcare/util/cli/ApplicationHost.java
+++ b/src/cli/java/org/commcare/util/cli/ApplicationHost.java
@@ -169,7 +169,7 @@ public class ApplicationHost {
             if (s instanceof SyncScreen) {
                 try {
                     s.init(mSession);
-                    s.handleInputAndUpdateSession(mSession, "", false, null);
+                    s.handleInputAndUpdateSession(mSession, "", false, null, true);
                 } catch (CommCareSessionException ccse) {
                     printErrorAndContinue("Error during session execution:", ccse);
                 }
@@ -328,7 +328,8 @@ public class ApplicationHost {
                         screenIsRedrawing = screen.handleInputAndUpdateSession(mSession,
                                                                                USE_SELECTED_VALUES,
                                                                                false,
-                                                                               selectedValues);
+                                                                               selectedValues,
+                                                                true);
                     } else {
                         if (screen instanceof EntityScreen) {
                             boolean isAction = input.startsWith("action "); // Don't wait for case detail if action
@@ -337,7 +338,7 @@ public class ApplicationHost {
                                 waitForCaseDetail = true;
                             }
                         }
-                        screenIsRedrawing = !screen.handleInputAndUpdateSession(mSession, input, false, null);
+                        screenIsRedrawing = !screen.handleInputAndUpdateSession(mSession, input, false, null, true);
                     }
                     if (!screenIsRedrawing && !waitForCaseDetail) {
                         screen = getNextScreen();

--- a/src/cli/java/org/commcare/util/screen/CompoundScreenHost.java
+++ b/src/cli/java/org/commcare/util/screen/CompoundScreenHost.java
@@ -36,7 +36,7 @@ public abstract class CompoundScreenHost extends Screen {
     @Trace
     @Override
     public boolean handleInputAndUpdateSession(CommCareSession session, String input,
-            boolean allowAutoLaunch, String[] selectedValues) throws CommCareSessionException {
+            boolean allowAutoLaunch, String[] selectedValues, boolean respectRelevancy) throws CommCareSessionException {
         if (getCurrentScreen().handleInputAndUpdateHost(input, this, allowAutoLaunch, selectedValues)) {
             this.updateSession(session);
             return true;

--- a/src/cli/java/org/commcare/util/screen/MenuScreen.java
+++ b/src/cli/java/org/commcare/util/screen/MenuScreen.java
@@ -8,8 +8,6 @@ import org.commcare.suite.model.MenuDisplayable;
 import org.commcare.suite.model.MenuLoader;
 import org.commcare.util.LoggerInterface;
 import org.javarosa.core.services.Logger;
-import org.javarosa.core.services.locale.Localization;
-import org.javarosa.core.util.NoLocalizedTextException;
 
 import java.io.PrintStream;
 import java.util.Arrays;
@@ -27,6 +25,8 @@ public class MenuScreen extends Screen {
     private SessionWrapper mSession;
 
     private MenuDisplayable[] mChoices;
+
+    private MenuDisplayable[] mAllChoices;
     private String[] badges;
 
     private String mTitle;
@@ -77,6 +77,7 @@ public class MenuScreen extends Screen {
         String root = deriveMenuRoot(session);
         MenuLoader menuLoader = new MenuLoader(session.getPlatform(), session, root, new ScreenLogger(), false, false, false);
         this.mChoices = menuLoader.getMenus();
+        this.mAllChoices = menuLoader.getAllMenus();
         this.mTitle = this.getBestTitle();
         Exception loadException = menuLoader.getLoadException();
         if (loadException != null) {
@@ -119,15 +120,16 @@ public class MenuScreen extends Screen {
     @Trace
     @Override
     public boolean handleInputAndUpdateSession(CommCareSession session, String input, boolean allowAutoLaunch,
-            String[] selectedValues) {
+            String[] selectedValues, boolean respectRelevancy) {
         try {
             int i = Integer.parseInt(input);
             String commandId;
-            MenuDisplayable menuDisplayable = mChoices[i];
+            MenuDisplayable[] choices = respectRelevancy ? mChoices : mAllChoices;
+            MenuDisplayable menuDisplayable = choices[i];
             if (menuDisplayable instanceof Entry) {
                 commandId = ((Entry)menuDisplayable).getCommandId();
             } else {
-                commandId = ((Menu)mChoices[i]).getId();
+                commandId = ((Menu)choices[i]).getId();
             }
             session.setCommand(commandId);
             return true;
@@ -139,6 +141,10 @@ public class MenuScreen extends Screen {
 
     public MenuDisplayable[] getMenuDisplayables() {
         return mChoices;
+    }
+
+    public MenuDisplayable[] getAllChoices() {
+        return mAllChoices;
     }
 
     private String getBestTitle() {

--- a/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
@@ -273,8 +273,8 @@ public class MultiSelectEntityScreen extends EntityScreen {
 
     @Override
     public boolean handleInputAndUpdateSession(CommCareSession session, String input,
-            boolean allowAutoLaunch, String[] selectedValues) throws CommCareSessionException {
-        super.handleInputAndUpdateSession(session, input, allowAutoLaunch, selectedValues);
+            boolean allowAutoLaunch, String[] selectedValues, boolean respectRelevancy) throws CommCareSessionException {
+        super.handleInputAndUpdateSession(session, input, allowAutoLaunch, selectedValues, respectRelevancy);
         return false;
     }
 

--- a/src/cli/java/org/commcare/util/screen/QueryScreen.java
+++ b/src/cli/java/org/commcare/util/screen/QueryScreen.java
@@ -9,7 +9,6 @@ import static org.commcare.suite.model.QueryPrompt.INPUT_TYPE_SELECT1;
 
 import com.google.common.collect.Multimap;
 
-import org.commcare.cases.util.StringUtils;
 import org.commcare.core.encryption.CryptUtil;
 import org.commcare.core.interfaces.VirtualDataInstanceStorage;
 import org.commcare.data.xml.VirtualInstances;
@@ -19,7 +18,6 @@ import org.commcare.session.CommCareSession;
 import org.commcare.session.RemoteQuerySessionManager;
 import org.commcare.suite.model.RemoteQueryDatum;
 import org.commcare.suite.model.QueryPrompt;
-import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.ExternalDataInstanceSource;
 import org.javarosa.core.services.locale.Localization;
@@ -33,7 +31,6 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.Map;
-import java.util.Vector;
 
 import datadog.trace.api.Trace;
 
@@ -234,7 +231,7 @@ public class QueryScreen extends Screen {
     @Trace
     @Override
     public boolean handleInputAndUpdateSession(CommCareSession session, String input, boolean allowAutoLaunch,
-            String[] selectedValues) {
+            String[] selectedValues, boolean respectRelevancy) {
         String[] answers = input.split(",");
         Hashtable<String, String> userAnswers = new Hashtable<>();
         int count = 0;

--- a/src/cli/java/org/commcare/util/screen/Screen.java
+++ b/src/cli/java/org/commcare/util/screen/Screen.java
@@ -38,16 +38,17 @@ public abstract class Screen implements OptionsScreen {
      * Based on the the input provided from the user to the command line, either update the session
      * and proceed to the next screen, or handle the input locally and ask to be redrawn
      *
-     * @param session         The current session to be mutated
-     * @param input           the input provided by the user to the command line
-     * @param allowAutoLaunch If this step is allowed to automatically launch an action,
-     *                        assuming it has an autolaunch action specified.
-     * @param selectedValues  Selected entities for a Multi Select Entity Screen
+     * @param session          The current session to be mutated
+     * @param input            the input provided by the user to the command line
+     * @param allowAutoLaunch  If this step is allowed to automatically launch an action,
+     *                         assuming it has an autolaunch action specified.
+     * @param selectedValues   Selected entities for a Multi Select Entity Screen
+     * @param respectRelevancy Whether to respect display conditions on a module or form whild handling input
      * @return True if the session was updated and the app should proceed to the next phase, false
      * if the screen wants to continue being redrawn.
      */
     public abstract boolean handleInputAndUpdateSession(CommCareSession session, String input,
-            boolean allowAutoLaunch, String[] selectedValues) throws CommCareSessionException;
+            boolean allowAutoLaunch, String[] selectedValues, boolean respectRelevancy) throws CommCareSessionException;
 
 
     /**

--- a/src/cli/java/org/commcare/util/screen/SyncScreen.java
+++ b/src/cli/java/org/commcare/util/screen/SyncScreen.java
@@ -101,7 +101,7 @@ public class SyncScreen extends Screen {
     @Trace
     @Override
     public boolean handleInputAndUpdateSession(CommCareSession commCareSession, String s, boolean allowAutoLaunch,
-            String[] selectedValues) throws CommCareSessionException {
+            String[] selectedValues, boolean respectRelevancy) throws CommCareSessionException {
         if (syncSuccessful) {
             updateSessionOnSuccess();
             Entry commandEntry = sessionWrapper.getCurrentEntry();

--- a/src/main/java/org/commcare/suite/model/Endpoint.java
+++ b/src/main/java/org/commcare/suite/model/Endpoint.java
@@ -18,6 +18,7 @@ import java.util.Vector;
 public class Endpoint implements Externalizable {
 
     String id;
+    boolean respectRelevancy;
     Vector<EndpointArgument> arguments;
     Vector<StackOperation> stackOperations;
 
@@ -25,10 +26,11 @@ public class Endpoint implements Externalizable {
     public Endpoint() {
     }
 
-    public Endpoint(String id, Vector<EndpointArgument> arguments, Vector<StackOperation> stackOperations) {
+    public Endpoint(String id, Vector<EndpointArgument> arguments, Vector<StackOperation> stackOperations, boolean respectRelevancy) {
         this.id = id;
         this.arguments = arguments;
         this.stackOperations = stackOperations;
+        this.respectRelevancy = respectRelevancy;
     }
 
     @Override
@@ -36,6 +38,7 @@ public class Endpoint implements Externalizable {
         id = ExtUtil.readString(in);
         arguments = (Vector<EndpointArgument>)ExtUtil.read(in, new ExtWrapList(EndpointArgument.class), pf);
         stackOperations = (Vector<StackOperation>)ExtUtil.read(in, new ExtWrapList(StackOperation.class), pf);
+        respectRelevancy = ExtUtil.readBool(in);
     }
 
     @Override
@@ -43,6 +46,7 @@ public class Endpoint implements Externalizable {
         ExtUtil.writeString(out, id);
         ExtUtil.write(out, new ExtWrapList(arguments));
         ExtUtil.write(out, new ExtWrapList(stackOperations));
+        ExtUtil.writeBool(out, respectRelevancy);
     }
 
     public String getId() {
@@ -57,6 +61,9 @@ public class Endpoint implements Externalizable {
         return stackOperations;
     }
 
+    public boolean isRespectRelevancy() {
+        return respectRelevancy;
+    }
 
     // Utility Functions
     public static void populateEndpointArgumentsToEvaluationContext(Endpoint endpoint, ArrayList<String> args, EvaluationContext evaluationContext) {

--- a/src/main/java/org/commcare/xml/EndpointParser.java
+++ b/src/main/java/org/commcare/xml/EndpointParser.java
@@ -22,6 +22,7 @@ public class EndpointParser extends ElementParser<Endpoint> {
     static final String NAME_ENDPOINT = "endpoint";
     private static final String NAME_ARGUMENT = "argument";
     private static final String ATTR_ARGUMENT_ID = "id";
+    private static final String ATTR_ARGUMENT_RESPECT_RELEVANCY = "respect-relevancy";
     private static final String ATTR_ARGUMENT_INSTANCE_ID = "instance-id";
     private static final String ATTR_ARGUMENT_INSTANCE_SRC = "instance-src";
 
@@ -36,6 +37,11 @@ public class EndpointParser extends ElementParser<Endpoint> {
         if (endpointId == null || endpointId.isEmpty()) {
             throw new InvalidStructureException("endpoint must define a non empty id", parser);
         }
+
+        String respectRelevancyStr = parser.getAttributeValue(null, ATTR_ARGUMENT_RESPECT_RELEVANCY);
+
+        // we are defaulting to true by checking against "false"
+        boolean respectReslevancy = !"false".equals(respectRelevancyStr);
 
         Vector<StackOperation> stackOperations = new Vector<>();
         Vector<EndpointArgument> arguments = new Vector<>();
@@ -70,6 +76,6 @@ public class EndpointParser extends ElementParser<Endpoint> {
             }
         }
 
-        return new Endpoint(endpointId, arguments, stackOperations);
+        return new Endpoint(endpointId, arguments, stackOperations, respectReslevancy);
     }
 }

--- a/src/test/java/org/commcare/backend/suite/model/test/AppStructureTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/AppStructureTests.java
@@ -5,6 +5,7 @@ import org.commcare.suite.model.AssertionSet;
 import org.commcare.suite.model.Callout;
 import org.commcare.suite.model.Detail;
 import org.commcare.suite.model.DetailField;
+import org.commcare.suite.model.Endpoint;
 import org.commcare.suite.model.EndpointAction;
 import org.commcare.suite.model.GeoOverlay;
 import org.commcare.suite.model.Global;
@@ -22,6 +23,8 @@ import org.junit.Test;
 import io.reactivex.observers.TestObserver;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -215,7 +218,18 @@ public class AppStructureTests {
         Detail detail = mApp.getSession().getPlatform().getDetail("m0_case_short");
         DetailField field = detail.getFields()[0];
         EndpointAction endpointAction = field.getEndpointAction();
-        assertEquals("case_list",endpointAction.getEndpointId());
+        String endpointActionId = endpointAction.getEndpointId();
+        assertEquals("case_list", endpointActionId);
         assertEquals(true, endpointAction.isBackground());
+
+        Endpoint endpoint = mApp.getSession().getPlatform().getEndpoint(endpointActionId);
+        assertEquals(endpoint.getId(), endpointActionId);
+        assertFalse(endpoint.isRespectRelevancy());
+    }
+
+    @Test
+    public void testDefaultEndpointRelevancy_shouldBeTrue() {
+        Endpoint endpoint = mApp.getSession().getPlatform().getEndpoint("endpoint_with_no_relevancy");
+        assertTrue(endpoint.isRespectRelevancy());
     }
 }

--- a/src/test/java/org/commcare/backend/suite/model/test/QueryModelTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/QueryModelTests.java
@@ -14,7 +14,6 @@ import org.commcare.test.utilities.MockApp;
 import org.commcare.util.screen.CommCareSessionException;
 import org.commcare.util.screen.QueryScreen;
 import org.javarosa.core.model.instance.ExternalDataInstance;
-import org.javarosa.core.model.instance.InstanceRoot;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.Before;
@@ -42,7 +41,7 @@ public class QueryModelTests {
         QueryScreen screen = setupQueryScreen(session);
 
         // perform the query
-        boolean success = screen.handleInputAndUpdateSession(session, "bob,23", false, null);
+        boolean success = screen.handleInputAndUpdateSession(session, "bob,23", false, null,true);
         Assert.assertTrue(success);
 
         // check that session datum requirement is satisfied
@@ -61,7 +60,7 @@ public class QueryModelTests {
         Assert.assertFalse(virtualDataInstanceStorage.contains(expectedInstanceStorageKey));
 
         // perform the query
-        boolean success = screen.handleInputAndUpdateSession(session, "bob,23", false, null);
+        boolean success = screen.handleInputAndUpdateSession(session, "bob,23", false, null, true);
         Assert.assertTrue(success);
 
         // check that saved instance matches expect what we expect

--- a/src/test/java/org/commcare/backend/suite/model/test/StackFrameStepTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/StackFrameStepTests.java
@@ -167,7 +167,7 @@ public class StackFrameStepTests {
         screen.init(session);
 
         // perform the query
-        boolean success = screen.handleInputAndUpdateSession(session, "", false, null);
+        boolean success = screen.handleInputAndUpdateSession(session, "", false, null, true);
         Assert.assertTrue(success);
 
         assertNull(session.getNeededDatum());

--- a/src/test/resources/app_structure/suite.xml
+++ b/src/test/resources/app_structure/suite.xml
@@ -231,12 +231,19 @@
     <text>Menu</text>
     <command id="m0-f1"/>
   </menu>
-  <endpoint id="case_list">
+  <endpoint id="case_list" respect-relevancy="false">
     <argument id="selected_cases" instance-id="selected_cases" instance-src="jr://instance/selected-entities"/>
     <stack>
       <push>
         <command value="'m0-f0'"/>
         <instance-datum id="case_id" value="$selected_cases"/>
+      </push>
+    </stack>
+  </endpoint>
+  <endpoint id="endpoint_with_no_relevancy">
+    <stack>
+      <push>
+        <command value="'m0-f0'"/>
       </push>
     </stack>
   </endpoint>


### PR DESCRIPTION
## Product Description

[JIRA](https://dimagi-dev.atlassian.net/browse/USH-3742)

Changes for https://github.com/dimagi/formplayer/pull/1484

## Technical Summary

- Adds a `respect-relevancy` attribute to session `endpoint` node to determine whether the endpoint launch should respect menu relevancy conditions

- Pass in a `respectRelevancy` method parameter to session navigation methods to allow for ignoring menu relevancy conditions during a session navigation. 

## Safety Assurance
Same as https://github.com/dimagi/formplayer/pull/1484


### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
