### PR TITLE
Adds to allItems even if parent menu is not valid

### DIFF
--- a/src/main/java/org/commcare/suite/model/MenuLoader.java
+++ b/src/main/java/org/commcare/suite/model/MenuLoader.java
@@ -15,9 +15,7 @@ import org.javarosa.xpath.expr.FunctionUtils;
 import org.javarosa.xpath.expr.XPathExpression;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
-import java.util.HashMap;
 import java.util.Hashtable;
-import java.util.Map;
 import java.util.Set;
 import java.util.Vector;
 
@@ -80,9 +78,8 @@ public class MenuLoader {
             for (Menu m : s.getMenus()) {
                 try {
                     if (m.getId().equals(menuID)) {
-                        if (menuIsRelevant(sessionWrapper, m) && menuAssertionsPass(sessionWrapper, m)) {
-                            addRelevantCommandEntries(sessionWrapper, m, items, badges, map, includeBadges, allItems);
-                        }
+                        boolean addToItems = menuIsRelevant(sessionWrapper, m) && menuAssertionsPass(sessionWrapper, m);
+                        addRelevantCommandEntries(sessionWrapper, m, items, badges, map, includeBadges, allItems, addToItems);
                     } else {
                         addUnaddedMenu(sessionWrapper, menuID, m, items, badges, hideTrainingRoot, includeBadges, allItems);
                     }
@@ -190,7 +187,8 @@ public class MenuLoader {
             Vector<String> badges,
             Hashtable<String, Entry> map,
             boolean includeBadges,
-            Vector<MenuDisplayable> allItems)
+            Vector<MenuDisplayable> allItems,
+            boolean addToItems)
             throws XPathSyntaxException {
         xPathErrorMessage = "";
         for (String command : m.getCommandIds()) {
@@ -228,7 +226,9 @@ public class MenuLoader {
                 }
             }
 
-            items.add(e);
+            if (addToItems) {
+                items.add(e);
+            }
             if (includeBadges) {
                 badges.add(e.getTextForBadge(sessionWrapper.getEvaluationContext(e.getCommandId())).blockingGet());
             }


### PR DESCRIPTION
## Product Description

[JIRA](https://dimagi-dev.atlassian.net/browse/USH-3886)


## Technical Summary

The `allItems` list was not adding a non relevant menu if the parent menu itself is non relevant. This PR calls the add to the menu even if menu is not valid. 

## Safety Assurance

Only affects smart links , tested with https://github.com/dimagi/formplayer/pull/1497

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
None

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
