### PR TITLE
Endpoint relevancy fix for Auto Advance Menus

### DIFF
--- a/src/cli/java/org/commcare/util/screen/MenuScreen.java
+++ b/src/cli/java/org/commcare/util/screen/MenuScreen.java
@@ -50,9 +50,10 @@ public class MenuScreen extends Screen {
         }
     }
 
-    public boolean handleAutoMenuAdvance(SessionWrapper sessionWrapper) {
-        if (mChoices.length == 1) {
-            sessionWrapper.setCommand(mChoices[0].getCommandID());
+    public boolean handleAutoMenuAdvance(SessionWrapper sessionWrapper, boolean respectRelevancy) {
+        MenuDisplayable[] menuChoices = respectRelevancy ? mChoices : mAllChoices;
+        if (menuChoices.length == 1) {
+            sessionWrapper.setCommand(menuChoices[0].getCommandID());
             return true;
         }
         return false;


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/USH-3887

## Technical Summary
Fix for smart linking to a hidden form in a case list when auto-advance menu is set. Issue happens when there is a single visible form in a auto-advance menu which causes the smart link to a hidden form in the same menu to open the only visible form in the menu. This PR fixes it by taking all choices (visible or not) into account for auto-advance when `respectRelevancy` is set to `false` for a smar link. 

## Safety Assurance

- Limited blast radius to auto advance menu + smart links
- Tests in [corresponding FP PR](https://github.com/dimagi/formplayer/pull/1501)

### Automated test coverage

We have tests in FP to account for auto-advance menus and smart links both

### QA Plan
None

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
