### PR TITLE
Jt/visually segmented case search group

### DIFF
--- a/src/cli/java/org/commcare/util/screen/QueryScreen.java
+++ b/src/cli/java/org/commcare/util/screen/QueryScreen.java
@@ -45,7 +45,7 @@ public class QueryScreen extends Screen {
 
     private RemoteQuerySessionManager remoteQuerySessionManager;
     protected OrderedHashtable<String, QueryPrompt> userInputDisplays;
-    protected OrderedHashtable<String, QueryGroup> groupHeaders;
+    protected Hashtable<String, QueryGroup> groupHeaders;
     private SessionWrapper sessionWrapper;
     private String[] fields;
     private String mTitle;
@@ -265,7 +265,7 @@ public class QueryScreen extends Screen {
         return userInputDisplays;
     }
 
-    public OrderedHashtable<String, QueryGroup> getGroupHeaders() {
+    public Hashtable<String, QueryGroup> getGroupHeaders() {
         return groupHeaders;
     }
 

--- a/src/cli/java/org/commcare/util/screen/QueryScreen.java
+++ b/src/cli/java/org/commcare/util/screen/QueryScreen.java
@@ -18,6 +18,7 @@ import org.commcare.session.CommCareSession;
 import org.commcare.session.RemoteQuerySessionManager;
 import org.commcare.suite.model.RemoteQueryDatum;
 import org.commcare.suite.model.QueryPrompt;
+import org.commcare.suite.model.QueryGroup;
 import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.ExternalDataInstanceSource;
 import org.javarosa.core.services.locale.Localization;
@@ -44,6 +45,7 @@ public class QueryScreen extends Screen {
 
     private RemoteQuerySessionManager remoteQuerySessionManager;
     protected OrderedHashtable<String, QueryPrompt> userInputDisplays;
+    protected OrderedHashtable<String, QueryGroup> groupHeaders;
     private SessionWrapper sessionWrapper;
     private String[] fields;
     private String mTitle;
@@ -94,6 +96,7 @@ public class QueryScreen extends Screen {
         mTitle = getTitleLocaleString();
         description = getDescriptionLocaleString();
         dynamicSearch = getQueryDatum().getDynamicSearch();
+        groupHeaders = getQueryDatum().getUserQueryGroupHeaders();
     }
 
     private String getTitleLocaleString() {
@@ -260,6 +263,10 @@ public class QueryScreen extends Screen {
 
     public OrderedHashtable<String, QueryPrompt> getUserInputDisplays() {
         return userInputDisplays;
+    }
+
+    public OrderedHashtable<String, QueryGroup> getGroupHeaders() {
+        return groupHeaders;
     }
 
     public String getCurrentMessage() {

--- a/src/cli/java/org/commcare/util/screen/QueryScreen.java
+++ b/src/cli/java/org/commcare/util/screen/QueryScreen.java
@@ -269,6 +269,17 @@ public class QueryScreen extends Screen {
         return groupHeaders;
     }
 
+    public Hashtable<String, String> evalGroupHeaders() {
+        Hashtable<String, String> queryGroupMap = new Hashtable<>();
+        for (Map.Entry<String, QueryGroup> entry : groupHeaders.entrySet()) {
+            String key = entry.getKey();
+            QueryGroup queryGroupItem = entry.getValue();
+            String text = queryGroupItem.getDisplay().getText().evaluate(sessionWrapper.getEvaluationContext());
+            queryGroupMap.put(key, text);
+        }
+        return queryGroupMap;
+    }
+
     public String getCurrentMessage() {
         return currentMessage;
     }

--- a/src/main/java/org/commcare/suite/model/QueryGroup.java
+++ b/src/main/java/org/commcare/suite/model/QueryGroup.java
@@ -1,0 +1,43 @@
+package org.commcare.suite.model;
+
+import org.javarosa.core.util.externalizable.DeserializationException;
+import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.Externalizable;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+// Model for <group> node
+public class QueryGroup implements Externalizable {
+
+    private String key;
+    private DisplayUnit display;
+
+    public QueryGroup(String key, DisplayUnit display) {
+        this.key = key;
+        this.display = display;
+    }
+
+    @Override
+    public void readExternal(DataInputStream in, PrototypeFactory pf)
+            throws IOException, DeserializationException {
+        key = (String)ExtUtil.read(in, String.class, pf);
+        display = (DisplayUnit)ExtUtil.read(in, DisplayUnit.class, pf);
+    }
+
+    @Override
+    public void writeExternal(DataOutputStream out) throws IOException {
+        ExtUtil.write(out, key);
+        ExtUtil.write(out, display);
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public DisplayUnit getDisplay() {
+        return display;
+    }
+}

--- a/src/main/java/org/commcare/suite/model/QueryGroup.java
+++ b/src/main/java/org/commcare/suite/model/QueryGroup.java
@@ -15,6 +15,10 @@ public class QueryGroup implements Externalizable {
     private String key;
     private DisplayUnit display;
 
+    @SuppressWarnings("unused")
+    public QueryGroup() {
+    }
+
     public QueryGroup(String key, DisplayUnit display) {
         this.key = key;
         this.display = display;

--- a/src/main/java/org/commcare/suite/model/QueryPrompt.java
+++ b/src/main/java/org/commcare/suite/model/QueryPrompt.java
@@ -74,6 +74,9 @@ public class QueryPrompt implements Externalizable {
     @Nullable
     private QueryPromptCondition validation;
 
+    @Nullable
+    private String groupKey;
+
     @SuppressWarnings("unused")
     public QueryPrompt() {
     }
@@ -81,7 +84,7 @@ public class QueryPrompt implements Externalizable {
     public QueryPrompt(String key, String appearance, String input, String receive,
             String hidden, DisplayUnit display, ItemsetBinding itemsetBinding,
             XPathExpression defaultValueExpr, boolean allowBlankValue, XPathExpression exclude,
-            QueryPromptCondition required, QueryPromptCondition validation) {
+            QueryPromptCondition required, QueryPromptCondition validation, String groupKey) {
         this.key = key;
         this.appearance = appearance;
         this.input = input;
@@ -94,6 +97,7 @@ public class QueryPrompt implements Externalizable {
         this.exclude = exclude;
         this.required = required;
         this.validation = validation;
+        this.groupKey = groupKey;
     }
 
     @Override
@@ -111,6 +115,7 @@ public class QueryPrompt implements Externalizable {
         exclude = (XPathExpression)ExtUtil.read(in, new ExtWrapNullable(new ExtWrapTagged()), pf);
         validation = (QueryPromptCondition)ExtUtil.read(in, new ExtWrapNullable(QueryPromptCondition.class), pf);
         required = (QueryPromptCondition)ExtUtil.read(in, new ExtWrapNullable(QueryPromptCondition.class), pf);
+        groupKey = (String)ExtUtil.read(in, new ExtWrapNullable(String.class), pf);
     }
 
     @Override
@@ -128,6 +133,7 @@ public class QueryPrompt implements Externalizable {
         ExtUtil.write(out, new ExtWrapNullable(exclude == null ? null : new ExtWrapTagged(exclude)));
         ExtUtil.write(out, new ExtWrapNullable(validation));
         ExtUtil.write(out, new ExtWrapNullable(required));
+        ExtUtil.write(out, new ExtWrapNullable(groupKey));
     }
 
     public String getKey() {
@@ -184,6 +190,11 @@ public class QueryPrompt implements Externalizable {
     @Nullable
     public QueryPromptCondition getValidation() {
         return validation;
+    }
+
+    @Nullable
+    public String getGroupKey() {
+        return groupKey;
     }
 
     /**

--- a/src/main/java/org/commcare/suite/model/RemoteQueryDatum.java
+++ b/src/main/java/org/commcare/suite/model/RemoteQueryDatum.java
@@ -1,6 +1,7 @@
 package org.commcare.suite.model;
 
 import org.javarosa.core.util.OrderedHashtable;
+import java.util.Hashtable;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.ExtWrapBase;
@@ -28,7 +29,7 @@ import java.util.List;
 public class RemoteQueryDatum extends SessionDatum {
     private List<QueryData> hiddenQueryValues;
     private OrderedHashtable<String, QueryPrompt> userQueryPrompts;
-    private OrderedHashtable<String, QueryGroup> userQueryGroupHeaders;
+    private Hashtable<String, QueryGroup> userQueryGroupHeaders;
     private boolean useCaseTemplate;
     private boolean defaultSearch;
     private boolean dynamicSearch;
@@ -48,7 +49,7 @@ public class RemoteQueryDatum extends SessionDatum {
             List<QueryData> hiddenQueryValues,
                             OrderedHashtable<String, QueryPrompt> userQueryPrompts,
                             boolean useCaseTemplate, boolean defaultSearch, boolean dynamicSearch, Text title, Text description,
-                            OrderedHashtable<String, QueryGroup> userQueryGroupHeaders) {
+                            Hashtable<String, QueryGroup> userQueryGroupHeaders) {
         super(storageInstance, url.toString());
         this.hiddenQueryValues = hiddenQueryValues;
         this.userQueryPrompts = userQueryPrompts;
@@ -64,7 +65,7 @@ public class RemoteQueryDatum extends SessionDatum {
         return userQueryPrompts;
     }
 
-    public OrderedHashtable<String, QueryGroup> getUserQueryGroupHeaders() {
+    public Hashtable<String, QueryGroup> getUserQueryGroupHeaders() {
         return userQueryGroupHeaders;
     }
 
@@ -112,7 +113,7 @@ public class RemoteQueryDatum extends SessionDatum {
                 (OrderedHashtable<String, QueryPrompt>)ExtUtil.read(in,
                         new ExtWrapMap(String.class, QueryPrompt.class, ExtWrapMap.TYPE_ORDERED), pf);
         userQueryGroupHeaders =
-                (OrderedHashtable<String, QueryGroup>)ExtUtil.read(in,
+                (Hashtable<String, QueryGroup>)ExtUtil.read(in,
                         new ExtWrapMap(String.class, QueryGroup.class, ExtWrapMap.TYPE_ORDERED), pf);
         title = (Text) ExtUtil.read(in, new ExtWrapNullable(Text.class), pf);
         description = (Text) ExtUtil.read(in, new ExtWrapNullable(Text.class), pf);

--- a/src/main/java/org/commcare/suite/model/RemoteQueryDatum.java
+++ b/src/main/java/org/commcare/suite/model/RemoteQueryDatum.java
@@ -28,6 +28,7 @@ import java.util.List;
 public class RemoteQueryDatum extends SessionDatum {
     private List<QueryData> hiddenQueryValues;
     private OrderedHashtable<String, QueryPrompt> userQueryPrompts;
+    private OrderedHashtable<String, QueryGroup> userQueryGroupHeaders;
     private boolean useCaseTemplate;
     private boolean defaultSearch;
     private boolean dynamicSearch;
@@ -46,10 +47,12 @@ public class RemoteQueryDatum extends SessionDatum {
     public RemoteQueryDatum(URL url, String storageInstance,
             List<QueryData> hiddenQueryValues,
                             OrderedHashtable<String, QueryPrompt> userQueryPrompts,
-                            boolean useCaseTemplate, boolean defaultSearch, boolean dynamicSearch, Text title, Text description) {
+                            boolean useCaseTemplate, boolean defaultSearch, boolean dynamicSearch, Text title, Text description,
+                            OrderedHashtable<String, QueryGroup> userQueryGroupHeaders) {
         super(storageInstance, url.toString());
         this.hiddenQueryValues = hiddenQueryValues;
         this.userQueryPrompts = userQueryPrompts;
+        this.userQueryGroupHeaders = userQueryGroupHeaders;
         this.useCaseTemplate = useCaseTemplate;
         this.defaultSearch = defaultSearch;
         this.dynamicSearch = dynamicSearch;
@@ -59,6 +62,10 @@ public class RemoteQueryDatum extends SessionDatum {
 
     public OrderedHashtable<String, QueryPrompt> getUserQueryPrompts() {
         return userQueryPrompts;
+    }
+
+    public OrderedHashtable<String, QueryGroup> getUserQueryGroupHeaders() {
+        return userQueryGroupHeaders;
     }
 
     public List<QueryData> getHiddenQueryValues() {
@@ -104,6 +111,9 @@ public class RemoteQueryDatum extends SessionDatum {
         userQueryPrompts =
                 (OrderedHashtable<String, QueryPrompt>)ExtUtil.read(in,
                         new ExtWrapMap(String.class, QueryPrompt.class, ExtWrapMap.TYPE_ORDERED), pf);
+        userQueryGroupHeaders =
+                (OrderedHashtable<String, QueryGroup>)ExtUtil.read(in,
+                        new ExtWrapMap(String.class, QueryGroup.class, ExtWrapMap.TYPE_ORDERED), pf);
         title = (Text) ExtUtil.read(in, new ExtWrapNullable(Text.class), pf);
         description = (Text) ExtUtil.read(in, new ExtWrapNullable(Text.class), pf);
         useCaseTemplate = ExtUtil.readBool(in);
@@ -116,6 +126,7 @@ public class RemoteQueryDatum extends SessionDatum {
         super.writeExternal(out);
         ExtUtil.write(out, new ExtWrapList(hiddenQueryValues, new ExtWrapTagged()));
         ExtUtil.write(out, new ExtWrapMap(userQueryPrompts));
+        ExtUtil.write(out, new ExtWrapMap(userQueryGroupHeaders));
         ExtUtil.write(out, new ExtWrapNullable(title));
         ExtUtil.write(out, new ExtWrapNullable(description));
         ExtUtil.writeBool(out, useCaseTemplate);

--- a/src/main/java/org/commcare/suite/model/RemoteQueryDatum.java
+++ b/src/main/java/org/commcare/suite/model/RemoteQueryDatum.java
@@ -47,8 +47,8 @@ public class RemoteQueryDatum extends SessionDatum {
      */
     public RemoteQueryDatum(URL url, String storageInstance,
             List<QueryData> hiddenQueryValues,
-                            OrderedHashtable<String, QueryPrompt> userQueryPrompts,
-                            boolean useCaseTemplate, boolean defaultSearch, boolean dynamicSearch, Text title, Text description,
+                            OrderedHashtable<String, QueryPrompt> userQueryPrompts, boolean useCaseTemplate,
+                            boolean defaultSearch, boolean dynamicSearch, Text title, Text description,
                             Hashtable<String, QueryGroup> userQueryGroupHeaders) {
         super(storageInstance, url.toString());
         this.hiddenQueryValues = hiddenQueryValues;

--- a/src/main/java/org/commcare/xml/QueryGroupParser.java
+++ b/src/main/java/org/commcare/xml/QueryGroupParser.java
@@ -1,0 +1,38 @@
+package org.commcare.xml;
+
+import org.commcare.suite.model.DisplayUnit;
+import org.commcare.suite.model.QueryGroup;
+import org.javarosa.xml.util.InvalidStructureException;
+import org.javarosa.xml.util.UnfullfilledRequirementsException;
+import org.kxml2.io.KXmlParser;
+import org.xmlpull.v1.XmlPullParserException;
+
+import java.io.IOException;
+
+public class QueryGroupParser extends CommCareElementParser<QueryGroup> {
+
+    private static final String NAME_PROMPT = "group";
+    private static final String ATTR_KEY = "key";
+    private static final String NAME_DISPLAY = "display";
+
+    public QueryGroupParser(KXmlParser parser) {
+        super(parser);
+    }
+
+    @Override
+    public QueryGroup parse() throws InvalidStructureException, IOException, XmlPullParserException,
+            UnfullfilledRequirementsException {
+        checkNode("group");
+
+        String key = parser.getAttributeValue(null, ATTR_KEY);
+        DisplayUnit display = null;
+    
+        while (nextTagInBlock(NAME_PROMPT)) {
+            if (NAME_DISPLAY.equalsIgnoreCase(parser.getName())) {
+                display = parseDisplayBlock();
+            }
+        }
+
+        return new QueryGroup(key, display);
+    }
+}

--- a/src/main/java/org/commcare/xml/QueryGroupParser.java
+++ b/src/main/java/org/commcare/xml/QueryGroupParser.java
@@ -22,7 +22,7 @@ public class QueryGroupParser extends CommCareElementParser<QueryGroup> {
     @Override
     public QueryGroup parse() throws InvalidStructureException, IOException, XmlPullParserException,
             UnfullfilledRequirementsException {
-        checkNode("group");
+        checkNode(NAME_GROUP);
 
         String key = parser.getAttributeValue(null, ATTR_KEY);
         DisplayUnit display = null;

--- a/src/main/java/org/commcare/xml/QueryGroupParser.java
+++ b/src/main/java/org/commcare/xml/QueryGroupParser.java
@@ -11,7 +11,7 @@ import java.io.IOException;
 
 public class QueryGroupParser extends CommCareElementParser<QueryGroup> {
 
-    private static final String NAME_GROUP = "group";
+    public static final String NAME_GROUP = "group";
     private static final String ATTR_KEY = "key";
     private static final String NAME_DISPLAY = "display";
 

--- a/src/main/java/org/commcare/xml/QueryGroupParser.java
+++ b/src/main/java/org/commcare/xml/QueryGroupParser.java
@@ -30,7 +30,17 @@ public class QueryGroupParser extends CommCareElementParser<QueryGroup> {
         while (nextTagInBlock(NAME_GROUP)) {
             if (NAME_DISPLAY.equalsIgnoreCase(parser.getName())) {
                 display = parseDisplayBlock();
+            } else {
+                throw new InvalidStructureException(
+                        "Unrecognised node " + parser.getName() + "in validation for group " + key);
             }
+        }
+
+        if (key == null) {
+            throw new InvalidStructureException("<group> block must define a 'key' attribute", parser);
+        }
+        if (display == null) {
+            throw new InvalidStructureException("<group> block must define a <display> element", parser);
         }
 
         return new QueryGroup(key, display);

--- a/src/main/java/org/commcare/xml/QueryGroupParser.java
+++ b/src/main/java/org/commcare/xml/QueryGroupParser.java
@@ -11,7 +11,7 @@ import java.io.IOException;
 
 public class QueryGroupParser extends CommCareElementParser<QueryGroup> {
 
-    private static final String NAME_PROMPT = "group";
+    private static final String NAME_GROUP = "group";
     private static final String ATTR_KEY = "key";
     private static final String NAME_DISPLAY = "display";
 
@@ -27,7 +27,7 @@ public class QueryGroupParser extends CommCareElementParser<QueryGroup> {
         String key = parser.getAttributeValue(null, ATTR_KEY);
         DisplayUnit display = null;
     
-        while (nextTagInBlock(NAME_PROMPT)) {
+        while (nextTagInBlock(NAME_GROUP)) {
             if (NAME_DISPLAY.equalsIgnoreCase(parser.getName())) {
                 display = parseDisplayBlock();
             }

--- a/src/main/java/org/commcare/xml/QueryPromptParser.java
+++ b/src/main/java/org/commcare/xml/QueryPromptParser.java
@@ -40,6 +40,7 @@ public class QueryPromptParser extends CommCareElementParser<QueryPrompt> {
     private static final String ATTR_REQUIRED = "required";
     private static final String ATTR_VALIDATION_TEST = "test";
     private static final String NAME_TEXT = "text";
+    private static final String ATTR_GROUP_KEY = "group_key";
 
     public QueryPromptParser(KXmlParser parser) {
         super(parser);
@@ -60,6 +61,7 @@ public class QueryPromptParser extends CommCareElementParser<QueryPrompt> {
         XPathExpression defaultValue = xpathPropertyValue(defaultValueString);
         String excludeValueString = parser.getAttributeValue(null, ATTR_EXCLUDE);
         XPathExpression exclude = xpathPropertyValue(excludeValueString);
+        String groupKey = parser.getAttributeValue(null, ATTR_GROUP_KEY);
         XPathExpression oldRequired = xpathPropertyValue(parser.getAttributeValue(null, ATTR_REQUIRED));
 
         QueryPromptCondition validation = null;
@@ -86,7 +88,7 @@ public class QueryPromptParser extends CommCareElementParser<QueryPrompt> {
 
         return new QueryPrompt(key, appearance, input, receive, hidden, display,
                 itemsetBinding, defaultValue, allowBlankValue, exclude,
-                required, validation);
+                required, validation, groupKey);
     }
 
     private QueryPromptCondition parseRequiredBlock(String key)

--- a/src/main/java/org/commcare/xml/SessionDatumParser.java
+++ b/src/main/java/org/commcare/xml/SessionDatumParser.java
@@ -147,8 +147,8 @@ public class SessionDatumParser extends CommCareElementParser<SessionDatum> {
                 nextTagInBlock("description");
                 description = new TextParser(parser).parse();
             } else if (QueryGroupParser.NAME_GROUP.equals(tagName)){
-                String key = parser.getAttributeValue(null, "key");
-                groupPrompts.put(key, new QueryGroupParser(parser).parse());
+                QueryGroup queryGroup = new QueryGroupParser(parser).parse();
+                groupPrompts.put(queryGroup.getKey(), queryGroup);
             }
         }
         return new RemoteQueryDatum(queryUrl, queryResultStorageInstance, hiddenQueryValues,

--- a/src/main/java/org/commcare/xml/SessionDatumParser.java
+++ b/src/main/java/org/commcare/xml/SessionDatumParser.java
@@ -146,7 +146,7 @@ public class SessionDatumParser extends CommCareElementParser<SessionDatum> {
             } else if ("description".equals(tagName)) {
                 nextTagInBlock("description");
                 description = new TextParser(parser).parse();
-            } else if ("group".equals(tagName)){
+            } else if (QueryGroupParser.NAME_GROUP.equals(tagName)){
                 String key = parser.getAttributeValue(null, "key");
                 groupPrompts.put(key, new QueryGroupParser(parser).parse());
             }

--- a/src/main/java/org/commcare/xml/SessionDatumParser.java
+++ b/src/main/java/org/commcare/xml/SessionDatumParser.java
@@ -6,6 +6,7 @@ import org.commcare.suite.model.EntityDatum;
 import org.commcare.suite.model.FormIdDatum;
 import org.commcare.suite.model.MultiSelectEntityDatum;
 import org.commcare.suite.model.QueryData;
+import org.commcare.suite.model.QueryGroup;
 import org.commcare.suite.model.QueryPrompt;
 import org.commcare.suite.model.RemoteQueryDatum;
 import org.commcare.suite.model.SessionDatum;
@@ -129,6 +130,7 @@ public class SessionDatumParser extends CommCareElementParser<SessionDatum> {
         boolean dynamicSearch = "true".equals(parser.getAttributeValue(null, "dynamic_search"));
         Text title = null;
         Text description = null;
+        OrderedHashtable<String, QueryGroup> groupPrompts = new OrderedHashtable<>();
         ArrayList<QueryData> hiddenQueryValues = new ArrayList<QueryData>();
         while (nextTagInBlock("query")) {
             String tagName = parser.getName();
@@ -143,9 +145,12 @@ public class SessionDatumParser extends CommCareElementParser<SessionDatum> {
             } else if ("description".equals(tagName)) {
                 nextTagInBlock("description");
                 description = new TextParser(parser).parse();
+            } else if ("group".equals(tagName)){
+                String key = parser.getAttributeValue(null, "key");
+                groupPrompts.put(key, new QueryGroupParser(parser).parse());
             }
         }
         return new RemoteQueryDatum(queryUrl, queryResultStorageInstance, hiddenQueryValues,
-            userQueryPrompts, useCaseTemplate, defaultSearch, dynamicSearch, title, description);
+            userQueryPrompts, useCaseTemplate, defaultSearch, dynamicSearch, title, description, groupPrompts);
     }
 }

--- a/src/main/java/org/commcare/xml/SessionDatumParser.java
+++ b/src/main/java/org/commcare/xml/SessionDatumParser.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Hashtable;
 
 /**
  * @author ctsims
@@ -130,7 +131,7 @@ public class SessionDatumParser extends CommCareElementParser<SessionDatum> {
         boolean dynamicSearch = "true".equals(parser.getAttributeValue(null, "dynamic_search"));
         Text title = null;
         Text description = null;
-        OrderedHashtable<String, QueryGroup> groupPrompts = new OrderedHashtable<>();
+        Hashtable<String, QueryGroup> groupPrompts = new Hashtable<>();
         ArrayList<QueryData> hiddenQueryValues = new ArrayList<QueryData>();
         while (nextTagInBlock("query")) {
             String tagName = parser.getName();

--- a/src/test/java/org/commcare/xml/QueryDataParserTest.java
+++ b/src/test/java/org/commcare/xml/QueryDataParserTest.java
@@ -143,4 +143,14 @@ public class QueryDataParserTest {
         } catch (InvalidStructureException ignored) {
         }
     }
+
+    @Test
+    public void testParseValueData_withGroupKeyAttribute()
+            throws InvalidStructureException, XmlPullParserException,
+            IOException, UnfullfilledRequirementsException {
+        String query = "<prompt key=\"name\" group_key=\"group_header_1\"></prompt>";
+        QueryPromptParser parser = ParserTestUtils.buildParser(query, QueryPromptParser.class);
+        QueryPrompt queryData = parser.parse();
+        assertEquals("group_header_1", queryData.getGroupKey());
+    }
 }

--- a/src/test/java/org/commcare/xml/QueryDataParserTest.java
+++ b/src/test/java/org/commcare/xml/QueryDataParserTest.java
@@ -159,7 +159,9 @@ public class QueryDataParserTest {
     public void testParseValueData_withGroup()
             throws InvalidStructureException, XmlPullParserException,
             IOException, UnfullfilledRequirementsException {
-        String query = "<group key=\"group_header_0\"></group>";
+        String query = "<group key=\"group_header_0\">"
+                + "<display><text><locale id=\"search_property.m0.group_header_0\"/></text></display>"
+                + "</group>";
         QueryGroupParser parser = ParserTestUtils.buildParser(query, QueryGroupParser.class);
         QueryGroup queryData = parser.parse();
         assertEquals("group_header_0", queryData.getKey());

--- a/src/test/java/org/commcare/xml/QueryDataParserTest.java
+++ b/src/test/java/org/commcare/xml/QueryDataParserTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.fail;
 
 import org.commcare.suite.model.QueryData;
 import org.commcare.suite.model.QueryPrompt;
+import org.commcare.suite.model.QueryGroup;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.xml.util.InvalidStructureException;
@@ -152,5 +153,15 @@ public class QueryDataParserTest {
         QueryPromptParser parser = ParserTestUtils.buildParser(query, QueryPromptParser.class);
         QueryPrompt queryData = parser.parse();
         assertEquals("group_header_1", queryData.getGroupKey());
+    }
+
+    @Test
+    public void testParseValueData_withGroup()
+            throws InvalidStructureException, XmlPullParserException,
+            IOException, UnfullfilledRequirementsException {
+        String query = "<group key=\"group_header_0\"></group>";
+        QueryGroupParser parser = ParserTestUtils.buildParser(query, QueryGroupParser.class);
+        QueryGroup queryData = parser.parse();
+        assertEquals("group_header_0", queryData.getKey());
     }
 }


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->
Parses the `group` block and populates a new `queryGroup` model. Also parses a `group_key` from `prompt` block and stores that in `queryPrompt` model. Both are added to the `RemoteQueryDatum`.

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
[Tech Spec](https://docs.google.com/document/d/1syEA-HC5g1FOjZ6m8DlfBspzKn9hKvq0zbMNbIWzQVE/edit#heading=h.d7s2sycdfk92) 
[Jira Ticket  
](https://dimagi-dev.atlassian.net/browse/USH-3826)[Research Doc
](https://docs.google.com/document/d/1ZkN0_ta8jEjQ5IYHLIduBN6ZFcVEjfSIQrN3AQgBVgw/edit#heading=h.x97repjoa0f2)

Formplayer PR: https://github.com/dimagi/formplayer/pull/1511
HQ PR: https://github.com/dimagi/commcare-hq/pull/33828

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
Locally tested. 
In parsing suite, the new `group` block and `group-key` for `prompt` block are optional so will not affect existing applications where these blocks do not exist.
`groupKey` in `queryPrompt` model is nullable. `groupPrompts` passed to `remoteQueryDatum` is instantiated as empty OrderedHashtable.

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->
Will add tests

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
Will [QA](https://dimagi-dev.atlassian.net/browse/QA-5881)

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [X] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations.

### Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
