### PR TITLE
treat string of just blank spaces as empty string

### DIFF
--- a/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
+++ b/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
@@ -256,7 +256,8 @@ public class EvaluationContext {
     public void setVariable(String name, Object value) {
         //No such thing as a null xpath variable. Empty
         //values in XPath just get converted to ""
-        if (value == null) {
+        if (value == null||
+                (value instanceof String && value.toString().trim().isEmpty())) {
             variables.put(name, "");
             return;
         }


### PR DESCRIPTION
## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
As part of [this change](https://github.com/dimagi/commcare-hq/pull/33738), multiple `data` elements will be added to the `post`.

With this example:
```
<post url="http://localhost:8000/a/jonathanlocal/phone/claim-case/" relevant="$case_id!=''">
  <data key="case_id" ref="instance('commcaresession')/session/data/case_id" exclude="count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]) != 0"/>
  <data key="case_id" ref="instance('commcaresession')/session/data/parent_id" exclude="count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/parent_id]) != 0"/>
</post>
```
If both data are blank, the string generated [here](https://github.com/dimagi/commcare-core/blob/fe5114b44ebe4128205a903be9d69d3d066baf23/src/main/java/org/commcare/suite/model/PostRequest.java#L75) results in a string containing only whitespace. This cause  `$case_id!=''` to incorrectly evaluate as `True`. This change saves a value that is a string with only whitespace as an empty string instead.

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
locally tested. Limited to values that are strings of whitespace which should not exist.
### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
no QA
### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->
Must be deployed with or before `https://github.com/dimagi/commcare-hq/pull/33738`

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
If this PR is reverted, it will break any existing apps that use inline case search with parent select (related to this [HQ change](https://github.com/dimagi/commcare-hq/pull/33738))

### Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
