### PR TITLE
Parses and stores search_on_clear from suite

### DIFF
--- a/src/cli/java/org/commcare/util/screen/QueryScreen.java
+++ b/src/cli/java/org/commcare/util/screen/QueryScreen.java
@@ -62,6 +62,7 @@ public class QueryScreen extends Screen {
     private boolean defaultSearch;
 
     private boolean dynamicSearch;
+    private boolean searchOnClear;
 
     public QueryScreen(String domainedUsername, String password, PrintStream out,
             VirtualDataInstanceStorage instanceStorage, SessionUtils sessionUtils) {
@@ -96,6 +97,7 @@ public class QueryScreen extends Screen {
         mTitle = getTitleLocaleString();
         description = getDescriptionLocaleString();
         dynamicSearch = getQueryDatum().getDynamicSearch();
+        searchOnClear = getQueryDatum().isSearchOnClear();
         groupHeaders = getQueryDatum().getUserQueryGroupHeaders();
     }
 
@@ -219,6 +221,10 @@ public class QueryScreen extends Screen {
 
     public boolean getDynamicSearch() {
         return dynamicSearch;
+    }
+
+    public boolean isSearchOnClear(){
+        return searchOnClear;
     }
 
     @Override

--- a/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
+++ b/src/main/java/org/commcare/session/RemoteQuerySessionManager.java
@@ -310,6 +310,10 @@ public class RemoteQuerySessionManager {
         return queryDatum.getDynamicSearch();
     }
 
+    public boolean isSearchOnClear() {
+        return queryDatum.isSearchOnClear();
+    }
+
     // Converts a string containing space separated list of choices
     // into a string array of individual choices
     public static String[] extractMultipleChoices(String answer) {

--- a/src/main/java/org/commcare/suite/model/RemoteQueryDatum.java
+++ b/src/main/java/org/commcare/suite/model/RemoteQueryDatum.java
@@ -33,6 +33,7 @@ public class RemoteQueryDatum extends SessionDatum {
     private boolean useCaseTemplate;
     private boolean defaultSearch;
     private boolean dynamicSearch;
+    private boolean searchOnClear;
     private Text title;
     private Text description;
 
@@ -49,7 +50,7 @@ public class RemoteQueryDatum extends SessionDatum {
             List<QueryData> hiddenQueryValues,
                             OrderedHashtable<String, QueryPrompt> userQueryPrompts, boolean useCaseTemplate,
                             boolean defaultSearch, boolean dynamicSearch, Text title, Text description,
-                            Hashtable<String, QueryGroup> userQueryGroupHeaders) {
+                            Hashtable<String, QueryGroup> userQueryGroupHeaders, boolean searchOnClear) {
         super(storageInstance, url.toString());
         this.hiddenQueryValues = hiddenQueryValues;
         this.userQueryPrompts = userQueryPrompts;
@@ -57,6 +58,7 @@ public class RemoteQueryDatum extends SessionDatum {
         this.useCaseTemplate = useCaseTemplate;
         this.defaultSearch = defaultSearch;
         this.dynamicSearch = dynamicSearch;
+        this.searchOnClear = searchOnClear;
         this.title = title;
         this.description = description;
     }
@@ -95,6 +97,9 @@ public class RemoteQueryDatum extends SessionDatum {
         return dynamicSearch;
     }
 
+    public boolean isSearchOnClear() {
+        return searchOnClear;
+    }
     public Text getTitleText() {
         return title;
     }
@@ -120,6 +125,7 @@ public class RemoteQueryDatum extends SessionDatum {
         useCaseTemplate = ExtUtil.readBool(in);
         defaultSearch = ExtUtil.readBool(in);
         dynamicSearch = ExtUtil.readBool(in);
+        searchOnClear = ExtUtil.readBool(in);
     }
 
     @Override
@@ -133,6 +139,6 @@ public class RemoteQueryDatum extends SessionDatum {
         ExtUtil.writeBool(out, useCaseTemplate);
         ExtUtil.writeBool(out, defaultSearch);
         ExtUtil.writeBool(out, dynamicSearch);
-
+        ExtUtil.writeBool(out, searchOnClear);
     }
 }

--- a/src/main/java/org/commcare/xml/SessionDatumParser.java
+++ b/src/main/java/org/commcare/xml/SessionDatumParser.java
@@ -129,6 +129,7 @@ public class SessionDatumParser extends CommCareElementParser<SessionDatum> {
 
         boolean defaultSearch = "true".equals(parser.getAttributeValue(null, "default_search"));
         boolean dynamicSearch = "true".equals(parser.getAttributeValue(null, "dynamic_search"));
+        boolean searchOnClear = "true".equals(parser.getAttributeValue(null, "search_on_clear"));
         Text title = null;
         Text description = null;
         Hashtable<String, QueryGroup> groupPrompts = new Hashtable<>();
@@ -152,6 +153,7 @@ public class SessionDatumParser extends CommCareElementParser<SessionDatum> {
             }
         }
         return new RemoteQueryDatum(queryUrl, queryResultStorageInstance, hiddenQueryValues,
-            userQueryPrompts, useCaseTemplate, defaultSearch, dynamicSearch, title, description, groupPrompts);
+            userQueryPrompts, useCaseTemplate, defaultSearch, dynamicSearch, title, description, groupPrompts,
+            searchOnClear);
     }
 }

--- a/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.java
@@ -64,6 +64,8 @@ public class CaseClaimModelTests {
         Assert.assertEquals("Description text", description.evaluate());
 
         Assert.assertTrue(((RemoteQueryDatum)datum).getDynamicSearch());
+
+        Assert.assertTrue(((RemoteQueryDatum)datum).isSearchOnClear());
     }
 
     @Test

--- a/src/test/resources/case_claim_example/suite.xml
+++ b/src/test/resources/case_claim_example/suite.xml
@@ -61,7 +61,7 @@
     <instance id="casedb" src="jr://instance/casedb"/>
     <instance id="my-search-input" src="jr://instance/search-input/patients"/>
     <session>
-      <query url="https://www.fake.com/patient_search/" storage-instance="patients" dynamic_search="true">
+      <query url="https://www.fake.com/patient_search/" storage-instance="patients" dynamic_search="true" search_on_clear="true">
         <title>
           <text>
             <locale id="query.title"/>


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->
See description in [HQ PR 
](https://github.com/dimagi/commcare-hq/pull/33983)

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
[Jira Ticket](https://dimagi-dev.atlassian.net/browse/USH-4046)
[Formplayer PR](https://github.com/dimagi/formplayer/compare/jt/clear-on-search?expand=1)
[HQ PR 
](https://github.com/dimagi/commcare-hq/pull/33983)

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
tested locally

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->
adds test that instance contains the `search_on_clear` value as defined in the suite

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
no QA
### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [X] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
- [X] This PR can be reverted after deploy with no further considerations.
### Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
