### PR TITLE
Alt text for icons

### DIFF
--- a/src/cli/java/org/commcare/util/screen/EntityDetailSubscreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityDetailSubscreen.java
@@ -3,8 +3,10 @@ package org.commcare.util.screen;
 import org.commcare.suite.model.Detail;
 import org.commcare.suite.model.DetailField;
 import org.commcare.suite.model.Style;
+import org.commcare.suite.model.Text;
 import org.javarosa.core.model.condition.EvaluationContext;
 
+import javax.annotation.Nullable;
 import java.io.PrintStream;
 import java.util.ArrayList;
 
@@ -25,6 +27,7 @@ public class EntityDetailSubscreen extends Subscreen<EntityScreen> {
     private final Object[] data ;
     private final String[] headers;
     private final Style[] styles;
+    private final String[] altText;
     private final int mCurrentIndex;
     private Detail detail;
 
@@ -40,6 +43,7 @@ public class EntityDetailSubscreen extends Subscreen<EntityScreen> {
         ArrayList<String> headersTemporary = new ArrayList<>();
         ArrayList<Object> dataTemporary = new ArrayList<>();
         ArrayList<Style> stylesTemporary = new ArrayList<>();
+        ArrayList<String> altTextTemporary = new ArrayList<>();
 
         detail.populateEvaluationContextVariables(subContext);
 
@@ -51,6 +55,7 @@ public class EntityDetailSubscreen extends Subscreen<EntityScreen> {
                 headersTemporary.add(createHeader(field, subContext));
                 rowTemporary.add(createRow(field, subContext, data));
                 stylesTemporary.add(createStyle(field));
+                altTextTemporary.add(createAltText(field, subContext));
             }
         }
 
@@ -58,14 +63,25 @@ public class EntityDetailSubscreen extends Subscreen<EntityScreen> {
         headers = new String[rowTemporary.size()];
         data = new Object[rowTemporary.size()];
         styles = new Style[rowTemporary.size()];
+        altText = new String[rowTemporary.size()];
 
         rowTemporary.toArray(rows);
         headersTemporary.toArray(headers);
         dataTemporary.toArray(data);
         stylesTemporary.toArray(styles);
+        altTextTemporary.toArray(altText);
 
         mDetailListTitles = detailListTitles;
         mCurrentIndex = currentIndex;
+    }
+
+    @Nullable
+    private String createAltText(DetailField field, EvaluationContext ec) {
+        Text altText = field.getAltText();
+        if (altText != null) {
+            return altText.evaluate(ec);
+        }
+        return null;
     }
 
     private Style createStyle(DetailField field) {
@@ -176,5 +192,9 @@ public class EntityDetailSubscreen extends Subscreen<EntityScreen> {
 
     public Style[] getStyles() {
         return styles;
+    }
+
+    public String[] getAltText() {
+        return altText;
     }
 }

--- a/src/main/java/org/commcare/cases/entity/Entity.java
+++ b/src/main/java/org/commcare/cases/entity/Entity.java
@@ -12,6 +12,7 @@ public class Entity<T> {
     private final T t;
     private Object[] data;
     private String[] sortData;
+    private String[] altTextData;
     private boolean[] relevancyData;
     /**
      * Key used to attach external data (i.e. from case list callout) to an entity
@@ -28,7 +29,7 @@ public class Entity<T> {
     }
 
     public Entity(Object[] data, String[] sortData, boolean[] relevancyData, T t,
-                  String extraKey, boolean shouldReceiveFocus, String groupKey) {
+            String extraKey, boolean shouldReceiveFocus, String groupKey, String[] altTextData) {
         this.t = t;
         this.sortData = sortData;
         this.data = data;
@@ -36,6 +37,7 @@ public class Entity<T> {
         this.extraKey = extraKey;
         this.shouldReceiveFocus = shouldReceiveFocus;
         this.groupKey = groupKey;
+        this.altTextData = altTextData;
     }
 
     public Object getField(int i) {
@@ -86,6 +88,10 @@ public class Entity<T> {
 
     public Object[] getData() {
         return data;
+    }
+
+    public String[] getAltText() {
+        return altTextData;
     }
 
     public String[] getSortFieldPieces(int i) {

--- a/src/main/java/org/commcare/cases/entity/NodeEntityFactory.java
+++ b/src/main/java/org/commcare/cases/entity/NodeEntityFactory.java
@@ -51,6 +51,7 @@ public class NodeEntityFactory {
 
         Object[] fieldData = new Object[length];
         String[] sortData = new String[length];
+        String[] altTextData = new String[length];
         boolean[] relevancyData = new boolean[length];
         int count = 0;
         for (DetailField f : detail.getFields()) {
@@ -63,6 +64,12 @@ public class NodeEntityFactory {
                     sortData[count] = sortText.evaluate(nodeContext);
                 }
                 relevancyData[count] = f.isRelevant(nodeContext);
+                Text altText = f.getAltText();
+                if (altText == null) {
+                    altTextData[count] = null;
+                } else {
+                    altTextData[count] = altText.evaluate(nodeContext);
+                }
             } catch (XPathSyntaxException e) {
                 /**
                  * TODO: 25/06/17 remove catch blocks from here
@@ -82,7 +89,7 @@ public class NodeEntityFactory {
         }
 
         return new Entity<>(fieldData, sortData, relevancyData, data, extraKey,
-                detail.evaluateFocusFunction(nodeContext), groupKey);
+                detail.evaluateFocusFunction(nodeContext), groupKey, altTextData);
     }
 
     /**

--- a/src/main/java/org/commcare/suite/model/DetailField.java
+++ b/src/main/java/org/commcare/suite/model/DetailField.java
@@ -1,5 +1,11 @@
 package org.commcare.suite.model;
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import javax.annotation.Nullable;
+
 import org.javarosa.core.model.Constants;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.util.externalizable.DeserializationException;
@@ -12,12 +18,6 @@ import org.javarosa.xpath.XPathParseTool;
 import org.javarosa.xpath.expr.FunctionUtils;
 import org.javarosa.xpath.expr.XPathExpression;
 import org.javarosa.xpath.parser.XPathSyntaxException;
-
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-
-import javax.annotation.Nullable;
 
 /**
  * Detail Fields represent the <field> elements of a suite's detail
@@ -45,7 +45,8 @@ public class DetailField implements Externalizable {
     private String headerWidthHint = null;  // Something like "500" or "10%"
     private String templateWidthHint = null;
     private String printIdentifier;
-
+    @Nullable
+    private Text altText;
     @Nullable
     private EndpointAction endpointAction;
 
@@ -188,6 +189,7 @@ public class DetailField implements Externalizable {
         header = (Text)ExtUtil.read(in, Text.class, pf);
         template = (DetailTemplate)ExtUtil.read(in, new ExtWrapTagged(DetailTemplate.class), pf);
         sort = (Text)ExtUtil.read(in, new ExtWrapNullable(Text.class), pf);
+        altText = (Text)ExtUtil.read(in, new ExtWrapNullable(Text.class), pf);
 
         //Unfortunately I don't think there's a clean way to do this
         if (ExtUtil.readBool(in)) {
@@ -219,6 +221,7 @@ public class DetailField implements Externalizable {
         ExtUtil.write(out, header);
         ExtUtil.write(out, new ExtWrapTagged(template));
         ExtUtil.write(out, new ExtWrapNullable(sort));
+        ExtUtil.write(out, new ExtWrapNullable(altText));
 
         boolean relevantSet = relevancy != null;
         ExtUtil.writeBool(out, relevantSet);
@@ -271,6 +274,11 @@ public class DetailField implements Externalizable {
     }
 
     @Nullable
+    public Text getAltText() {
+        return altText;
+    }
+
+    @Nullable
     public EndpointAction getEndpointAction() {
         return endpointAction;
     }
@@ -311,6 +319,13 @@ public class DetailField implements Externalizable {
          */
         public void setHeader(Text header) {
             field.header = header;
+        }
+
+        /**
+         * @param altText the alt text to set
+         */
+        public void setAltText(Text altText) {
+            field.altText = altText;
         }
 
         /**

--- a/src/main/java/org/commcare/xml/DetailFieldParser.java
+++ b/src/main/java/org/commcare/xml/DetailFieldParser.java
@@ -76,7 +76,7 @@ public class DetailFieldParser extends CommCareElementParser<DetailField> {
         }
         while (nextTagInBlock("field")) {
             //sort details
-            checkNode(new String[]{"sort", "background", "endpoint_action"});
+            checkNode(new String[]{"sort", "background", "endpoint_action", "alt_text"});
 
             String name = parser.getName().toLowerCase();
 
@@ -87,6 +87,11 @@ public class DetailFieldParser extends CommCareElementParser<DetailField> {
                 skipBlock("background");
             } else if (name.equals("endpoint_action")){
                 parseEndpointAction(builder);
+            } else if (name.equals("alt_text")){
+                parser.nextTag();
+                checkNode("text");
+                Text altText = new TextParser(parser).parse();
+                builder.setAltText(altText);
             }
         }
         return builder.build();

--- a/src/test/java/org/commcare/backend/suite/model/test/AppStructureTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/AppStructureTests.java
@@ -234,6 +234,14 @@ public class AppStructureTests {
     }
 
     @Test
+    public void testDetailWithAltText() {
+        Detail detail = mApp.getSession().getPlatform().getDetail("m0_case_short");
+        DetailField field = detail.getFields()[0];
+        Text altText = field.getAltText();
+        assertEquals("gold star", altText.evaluate());
+    }
+
+    @Test
     public void testDetailWithBorder() {
         Detail detail = mApp.getSession().getPlatform().getDetail("m0_case_short");
         DetailField field1 = detail.getFields()[0];

--- a/src/test/resources/app_structure/app_strings.txt
+++ b/src/test/resources/app_structure/app_strings.txt
@@ -1,2 +1,3 @@
 m0_no_items_text=Empty List
 m0_select_text=Continue With Case
+m0.case_short.case_starred_1.alt_text.k0=gold star

--- a/src/test/resources/app_structure/suite.xml
+++ b/src/test/resources/app_structure/suite.xml
@@ -83,6 +83,15 @@
           <xpath function="case_name"/>
         </text>
       </sort>
+      <alt_text>
+        <text>
+          <xpath function="$k0">
+            <variable name="k0">
+              <locale id="m0.case_short.case_starred_1.alt_text.k0"/>
+            </variable>
+          </xpath>
+        </text>
+      </alt_text>
       <endpoint_action endpoint_id="case_list" background="true"/>
     </field>
   </detail>


### PR DESCRIPTION
## Product Description
Adds parsing and model storage for an `alt_text` node in the suite, which uses a regular `text` element to map to text strings. This element is expected to appear as part of a `field` and is nullable since it is not automatically set in HQ.

## Technical Summary
[USH-3933](https://dimagi.atlassian.net/browse/USH-3933)
https://github.com/dimagi/commcare-hq/pull/34044
https://github.com/dimagi/formplayer/pull/1536

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
Added a test for parsing alt_text node and returning correct value from app strings.

### QA Plan
QA with the other linked PRs.

### Special deploy instructions
To be deployed as part of https://github.com/dimagi/formplayer/pull/1536.

### Rollback instructions
Would be rolled back as part of https://github.com/dimagi/formplayer/pull/1536.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
