### PR TITLE
Isolate LazyNodeset lock from evaluated object

### DIFF
--- a/src/main/java/org/javarosa/xpath/XPathLazyNodeset.java
+++ b/src/main/java/org/javarosa/xpath/XPathLazyNodeset.java
@@ -28,9 +28,8 @@ import java.util.Vector;
  */
 public class XPathLazyNodeset extends XPathNodeset {
 
-    //Since we're using this as a lock, we need to be very careful to ensure that each
-    //nodeset gets its own new object.
-    private Boolean evaluated = Boolean.valueOf(false);
+    private Object evalLock = new Object();
+    private boolean evaluated = false;
     private final TreeReference unExpandedRef;
 
     /**
@@ -43,7 +42,7 @@ public class XPathLazyNodeset extends XPathNodeset {
 
 
     private void performEvaluation() {
-        synchronized (evaluated) {
+        synchronized (evalLock) {
             if (evaluated) {
                 return;
             }
@@ -57,7 +56,7 @@ public class XPathLazyNodeset extends XPathNodeset {
                 }
             }
             this.setReferences(nodes);
-            evaluated = Boolean.valueOf(true);
+            evaluated = true;
         }
     }
 
@@ -69,7 +68,7 @@ public class XPathLazyNodeset extends XPathNodeset {
      */
     @Override
     public Object unpack() {
-        synchronized (evaluated) {
+        synchronized (evalLock) {
             if (evaluated) {
                 return super.unpack();
             }


### PR DESCRIPTION
## Product Description
Performance improvement with no user facing impact.

## Technical Summary
Years ago we ran across an issue and realized that the `synchronized` call protecting lazy nodeset evaluations was wrapping a static global object, which meant that independent LazyNodesets would be blocked from concurrent evaluation on the same runtime. 

This was fixed in #645 by making the evaluated member a unique object for each lazy nodeset instance. Unfortunately that was a shortsighted approach, as the Boolean object constructor was marked for deprecation in Java 9 and the current non-deprecated Boolean class has no matching semantics available to guarantee a unique object instance. #1202 unintentionally re-introduced the global locking semantics when the deprecated call was removed and replaced as per the javadoc guidance. 

Recent profiling in Formplayer has surfaced clear instances where the requests are blocking on this lock, and CPU / Wall Clock time have significant drift. 
![image](https://github.com/dimagi/commcare-core/assets/155066/2d1c7652-2fdd-45b0-ba6b-073bbff44779)

This time I'm separating the lock and outcome semantics entirely, which is what I should have done the first time rather than leaving a comment. It would be worth reviewing whether there are better available locks for this purpose, but this pattern (vanilla `Object` member) is common across our other synchronized uses so I'm not inclined to block on that for now. 

## Safety Assurance

### Safety story
I've tested this change against the test suite, and the semantics introduced are the same as were present in the period between 2017 and 2022, which was thoroughly used. 

I am not introducing new tests to confirm independent locking or replicating the failure condition in regression because the previous failure was the result of overloading intent for class member. We don't generally apply a pattern to confirm that objects with synchronized locks are working as intended. 

### Automated test coverage
This existing code is well covered by tests, which are passing. 

### QA Plan
n/a

### Special deploy instructions
Formplayer will need to have its head updated after this change is merged.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations.

### Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
