### PR TITLE
Small fix for Stack frame extras

### DIFF
--- a/src/main/java/org/commcare/suite/model/StackFrameStep.java
+++ b/src/main/java/org/commcare/suite/model/StackFrameStep.java
@@ -220,7 +220,7 @@ public class StackFrameStep implements Externalizable {
                 StackFrameStep defined = new StackFrameStep(elementType, id, evaluateValue(ec));
                 extras.forEach((key, value) -> {
                     if (value instanceof QueryData) {
-                        defined.addExtra(key, ((QueryData)value).getValues(ec));
+                        defined.getExtras().putAll(key, ((QueryData)value).getValues(ec));
                     } else if (value instanceof XPathExpression) {
                         // only to maintain backward compatibility with old serialised app db state, can be removed in
                         // subsequent deploys

--- a/src/test/java/org/commcare/backend/suite/model/test/StackFrameStepTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/StackFrameStepTests.java
@@ -181,11 +181,10 @@ public class StackFrameStepTests {
         StackFrameStep queryFrame = steps.get(2);
         assertEquals(SessionFrame.STATE_QUERY_REQUEST, queryFrame.getElementType());
 
-        ImmutableMultimap.Builder<String, ImmutableList> builder = ImmutableMultimap.builder();
-        builder.put("case_type", ImmutableList.of("patient"));
-        builder.put("x_commcare_data_registry", ImmutableList.of("test"));
-        builder.put("case_id", ImmutableList.of("case_one"));
-        builder.put("case_id", ImmutableList.of("dupe1"));
+        ImmutableMultimap.Builder<String, String> builder = ImmutableMultimap.builder();
+        builder.put("case_type", "patient");
+        builder.put("x_commcare_data_registry", "test");
+        builder.putAll("case_id", ImmutableList.of("case_one", "dupe1"));
         assertEquals(builder.build(), queryFrame.getExtras());
     }
 }


### PR DESCRIPTION
## Technical Summary

Changes frame extras from a multi-map of  `String,ListOf(Object)` to `String, Object` . I think it was an oversight that we were handling map values as a listOf(Object) which with multi-map was causing value to be a listOf(ListOf(Object)) for a given key. 

This causes a big confusion today when handling these extras as there are [other places](https://github.com/dimagi/formplayer/blob/master/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java#L168) where we handle this datastructure correctly (i.e use `putAll` as in this PR on multi-map)


## Safety Assurance

Change radius is limited to smart links with query steps (inline case search). This have [good test coverage](https://github.com/dimagi/formplayer/blob/master/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseClaimTest.java#L339-L394) on FP side. 

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
None

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
