### PR TITLE
Adds method to check for non counted Repeat Group at current index

### DIFF
--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -55,7 +55,6 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Vector;
 
@@ -1854,5 +1853,14 @@ public class FormDef implements IFormElement, IMetaData,
         } else {
             return sendCalloutHandler.performHttpCalloutForResponse(url, paramMap);
         }
+    }
+
+    // Checks if the form element at given form Index belongs to a non counted repeat
+    public boolean isNonCountedRepeat(FormIndex formIndex) {
+        IFormElement currentElement = getChild(formIndex);
+        if (currentElement instanceof GroupDef && ((GroupDef)currentElement).isRepeat()) {
+            return ((GroupDef)currentElement).getCountReference() == null;
+        }
+        return false;
     }
 }

--- a/src/main/java/org/javarosa/form/api/FormEntryModel.java
+++ b/src/main/java/org/javarosa/form/api/FormEntryModel.java
@@ -625,4 +625,8 @@ public class FormEntryModel {
         return TraceSerialization.serializeEvaluationTrace(indexDebug.get(category),
                 TraceSerialization.TraceInfoType.FULL_PROFILE, false);
     }
+
+    public boolean isNonCountedRepeat() {
+        return getForm().isNonCountedRepeat(getFormIndex());
+    }
 }


### PR DESCRIPTION
## Technical Summary

Adds method to check for non counted Repeat Group at current index to support [FP commit here]() 

## Safety Assurance

Just a supporting method with only usage in [FP PR](https://github.com/dimagi/formplayer/pull/1567) to determine whether a repeat supports delete operation

### Automated test coverage

Added in FP [commit here](https://github.com/dimagi/formplayer/pull/1567/commits/0166a043de872efb1fc84202580edc31965b8da8)

### QA Plan

None


### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
