### PR TITLE
Providing API version header from server to caller when available.

### DIFF
--- a/src/main/java/org/commcare/core/interfaces/HttpResponseProcessor.java
+++ b/src/main/java/org/commcare/core/interfaces/HttpResponseProcessor.java
@@ -12,7 +12,7 @@ public interface HttpResponseProcessor {
     /**
      * Http response was in the 200s
      */
-    void processSuccess(int responseCode, InputStream responseData);
+    void processSuccess(int responseCode, InputStream responseData, String apiVersion);
 
     /**
      * Http response was in the 400s.

--- a/src/main/java/org/commcare/core/interfaces/ResponseStreamAccessor.java
+++ b/src/main/java/org/commcare/core/interfaces/ResponseStreamAccessor.java
@@ -5,4 +5,5 @@ import java.io.InputStream;
 
 public interface ResponseStreamAccessor {
     InputStream getResponseStream() throws IOException;
+    String getApiVersion();
 }

--- a/src/main/java/org/commcare/core/network/ModernHttpRequester.java
+++ b/src/main/java/org/commcare/core/network/ModernHttpRequester.java
@@ -199,13 +199,7 @@ public class ModernHttpRequester {
     }
 
     public String getApiVersion() {
-        String apiVerison = null;
-        try {
-            apiVerison = response.headers().get("x-api-current-version");
-        } catch(Exception e) {
-            //Ignore exception if API version header isn't present
-        }
-        return apiVerison;
+        return response != null ? response.headers().get("x-api-current-version") : null;
     }
 
     public static RequestBody getPostBody(Multimap<String, String> inputs) {

--- a/src/main/java/org/commcare/core/network/ModernHttpRequester.java
+++ b/src/main/java/org/commcare/core/network/ModernHttpRequester.java
@@ -153,7 +153,8 @@ public class ModernHttpRequester implements ResponseStreamAccessor {
                     responseProcessor.handleIOException(e);
                     return;
                 }
-                responseProcessor.processSuccess(responseCode, responseStream);
+                String apiVersion = streamAccessor.getApiVersion();
+                responseProcessor.processSuccess(responseCode, responseStream, apiVersion);
             } finally {
                 StreamsUtil.closeStream(responseStream);
             }
@@ -189,6 +190,17 @@ public class ModernHttpRequester implements ResponseStreamAccessor {
     @Override
     public InputStream getResponseStream() throws IOException {
         return getResponseStream(response);
+    }
+
+    @Override
+    public String getApiVersion() {
+        String apiVerison = null;
+        try {
+            apiVerison = response.headers().get("x-api-current-version");
+        } catch(Exception e) {
+            //Ignore exception if API version header isn't present
+        }
+        return apiVerison;
     }
 
     public static RequestBody getPostBody(Multimap<String, String> inputs) {


### PR DESCRIPTION
Attempts to safely retrieve the x-api-current-version header from API response payloads so calling code can do version checking.
https://dimagi.atlassian.net/browse/CCCT-239

cross-request: https://github.com/dimagi/commcare-android/pull/2757