### PR TITLE
Use System.lineSeparator in XmlUtil (for Windows compatibility)

### DIFF
--- a/src/test/resources/pretty_printed_xml.xml
+++ b/src/test/resources/pretty_printed_xml.xml
@@ -1,9 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?><h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/jr/xforms" xmlns:vellum="http://commcarehq.org/xforms/vellum" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<?xml version="1.0" encoding="UTF-8"?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/2002/xforms" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/jr/xforms" xmlns:vellum="http://commcarehq.org/xforms/vellum" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <h:head>
         <h:title>Basic Form</h:title>
-        <model>
+        <model xmlns="http://www.w3.org/2002/xforms">
             <instance>
-                <data name="Basic Form" uiVersion="1" version="1" xmlns:jrm="http://dev.commcarehq.org/jr/xforms">
+                <data xmlns="http://openrosa.org/formdesigner/02FD4762-52FB-404C-9AF1-5F67894D1521" name="Basic Form" uiVersion="1" version="1" xmlns:jrm="http://dev.commcarehq.org/jr/xforms">
                     <q_name/>
                     <orx:meta xmlns:cc="http://commcarehq.org/xforms">
                         <orx:deviceID/>
@@ -53,7 +54,7 @@
         </model>
     </h:head>
     <h:body>
-        <input ref="/data/q_name">
+        <input xmlns="http://www.w3.org/2002/xforms" ref="/data/q_name">
             <label ref="jr:itext('q_name-label')"/>
         </input>
     </h:body>

--- a/src/translate/java/org/javarosa/engine/xml/XmlUtil.java
+++ b/src/translate/java/org/javarosa/engine/xml/XmlUtil.java
@@ -41,6 +41,12 @@ public class XmlUtil {
             DOMConfiguration domConfig = lsSerializer.getDomConfig();
             domConfig.setParameter("format-pretty-print", true);
             domConfig.setParameter("cdata-sections", true);
+
+            // LSSerializer does not have an explicit control for ending the XML Declaration with a
+            // newline, hence the need for the property isStandalone
+            // More in https://bugs.openjdk.org/browse/JDK-8259502
+            domConfig.setParameter("http://www.oracle.com/xml/jaxp/properties/isStandalone", true);
+
             lsSerializer.setNewLine(System.lineSeparator());
             lsSerializer.write(document, lsOutput);
             return stringWriter.toString();
@@ -52,6 +58,7 @@ public class XmlUtil {
     private static Document parseXmlFile(String in) {
         try {
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            dbf.setNamespaceAware(true);
             DocumentBuilder db = dbf.newDocumentBuilder();
             InputSource is = new InputSource(new StringReader(in));
             return db.parse(is);

--- a/src/translate/java/org/javarosa/engine/xml/XmlUtil.java
+++ b/src/translate/java/org/javarosa/engine/xml/XmlUtil.java
@@ -41,7 +41,7 @@ public class XmlUtil {
             DOMConfiguration domConfig = lsSerializer.getDomConfig();
             domConfig.setParameter("format-pretty-print", true);
             domConfig.setParameter("cdata-sections", true);
-            lsSerializer.setNewLine("\n");
+            lsSerializer.setNewLine(System.lineSeparator());
             lsSerializer.write(document, lsOutput);
             return stringWriter.toString();
         } catch (Exception e) {


### PR DESCRIPTION
Replaced a usage of '\n' with System.lineSeparator() in XmlUtil.
This fixes a broken unit test when running on a Windows machine.