### PR TITLE
Add form loading time metadata to form submissions

### DIFF
--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -141,6 +141,7 @@ public class FormDef implements IFormElement, IMetaData,
     private ActionController actionController;
     //If this instance is just being edited, don't fire end of form events
     private boolean isCompletedInstance;
+    private boolean newInstance;
 
     private boolean mProfilingEnabled = false;
     private boolean useExpressionCaching;
@@ -1376,6 +1377,12 @@ public class FormDef implements IFormElement, IMetaData,
         }
     }
 
+    public void finilizeInitialization() {
+        if (newInstance) {
+            actionController.triggerActionsFromEvent(Action.EVENT_XFORMS_MODEL_CONSTRUCT_DONE, this);
+        }
+    }
+
     /**
      * Reads the form definition object from the supplied stream.
      *
@@ -1465,6 +1472,7 @@ public class FormDef implements IFormElement, IMetaData,
             actionController.triggerActionsFromEvent(Action.EVENT_XFORMS_READY, this);
         }
         this.isCompletedInstance = isCompletedInstance;
+        this.newInstance = newInstance;
         if (!isReadOnly) {
             initAllTriggerables();
         }

--- a/src/main/java/org/javarosa/core/model/actions/Action.java
+++ b/src/main/java/org/javarosa/core/model/actions/Action.java
@@ -18,11 +18,12 @@ public abstract class Action implements Externalizable {
 
     // Events that can trigger an action
     public static final String EVENT_XFORMS_READY = "xforms-ready";
+    public static final String EVENT_XFORMS_MODEL_CONSTRUCT_DONE = "xforms-model-construct-done";
     public static final String EVENT_XFORMS_REVALIDATE = "xforms-revalidate";
     public static final String EVENT_JR_INSERT = "jr-insert";
     public static final String EVENT_QUESTION_VALUE_CHANGED = "xforms-value-changed";
     private static final String[] allEvents = new String[]{EVENT_JR_INSERT,
-            EVENT_QUESTION_VALUE_CHANGED, EVENT_XFORMS_READY, EVENT_XFORMS_REVALIDATE};
+            EVENT_QUESTION_VALUE_CHANGED, EVENT_XFORMS_READY, EVENT_XFORMS_REVALIDATE, EVENT_XFORMS_MODEL_CONSTRUCT_DONE};
 
     private String name;
 


### PR DESCRIPTION
## Product Description
This PR enhances the implementation of the XForms specification by adding support to [xforms-model-construct-done](https://www.w3.org/TR/xforms11/#evt-modelConstructDone) events. The `xforms-model-construct-done` event is to be triggered when the form is fully loaded and ready to be used, which in conjuction with `timeStarNumeric` (computed during [xforms-ready](https://www.w3.org/TR/xforms11/#evt-ready)) will in turn be used to calculate form load time.

Ticket: https://dimagi.atlassian.net/browse/SC-3590
cross-request: https://github.com/dimagi/commcare-android/pull/2767


### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
