### PR TITLE
Fix repeat deletion Issue

### DIFF
--- a/src/main/java/org/commcare/cases/instance/IndexedFixtureChildElement.java
+++ b/src/main/java/org/commcare/cases/instance/IndexedFixtureChildElement.java
@@ -198,7 +198,7 @@ public class IndexedFixtureChildElement extends StorageBackedChildElement<Storag
 
         StorageIndexedTreeElementModel model = parent.getModelTemplate();
 
-        TreeReference baseRefForChildElement = this.getRef().genericize();
+        TreeReference baseRefForChildElement = this.getRef(true).genericize();
 
         HashSet<String> sufficientColumns =
                 filterMetaDataForReferences(model, referencesInScope, baseRefForChildElement);

--- a/src/main/java/org/commcare/cases/instance/StorageBackedChildElement.java
+++ b/src/main/java/org/commcare/cases/instance/StorageBackedChildElement.java
@@ -191,8 +191,8 @@ public abstract class StorageBackedChildElement<Model extends Externalizable>
     }
 
     @Override
-    public TreeReference getRef() {
-        if (ref == null) {
+    public TreeReference getRef(boolean useCache) {
+        if (ref == null || !useCache) {
             ref = TreeReference.buildRefFromTreeElement(this);
         }
         return ref;

--- a/src/main/java/org/commcare/cases/instance/StorageInstanceTreeElement.java
+++ b/src/main/java/org/commcare/cases/instance/StorageInstanceTreeElement.java
@@ -201,8 +201,8 @@ public abstract class StorageInstanceTreeElement<Model extends Externalizable, T
     }
 
     @Override
-    public TreeReference getRef() {
-        if (cachedRef == null) {
+    public TreeReference getRef(boolean useCache) {
+        if (cachedRef == null || !useCache) {
             cachedRef = TreeReference.buildRefFromTreeElement(this);
         }
         return cachedRef;

--- a/src/main/java/org/commcare/cases/query/QuerySensitiveTreeElementWrapper.java
+++ b/src/main/java/org/commcare/cases/query/QuerySensitiveTreeElementWrapper.java
@@ -127,8 +127,8 @@ public class QuerySensitiveTreeElementWrapper<T extends AbstractTreeElement> imp
     }
 
     @Override
-    public TreeReference getRef() {
-        return wrapped.getRef();
+    public TreeReference getRef(boolean useCache) {
+        return wrapped.getRef(useCache);
     }
 
     @Override

--- a/src/main/java/org/commcare/cases/util/StorageBackedTreeRoot.java
+++ b/src/main/java/org/commcare/cases/util/StorageBackedTreeRoot.java
@@ -259,7 +259,7 @@ public abstract class StorageBackedTreeRoot<T extends AbstractTreeElement> imple
     }
 
     private Collection<TreeReference> buildReferencesFromFetchResults(Collection<Integer> selectedElements) {
-        TreeReference base = this.getRef();
+        TreeReference base = this.getRef(true);
 
         initStorageCache();
 

--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -440,7 +440,7 @@ public class FormDef implements IFormElement, IMetaData,
         //check the relevancy of the immediate parent
         if (relev) {
             TreeElement templNode = mainInstance.getTemplate(repeatRef);
-            TreeReference parentPath = templNode.getParent().getRef().genericize();
+            TreeReference parentPath = templNode.getParent().getRef(true).genericize();
             TreeElement parentNode = mainInstance.resolveReference(parentPath.contextualize(repeatRef));
             relev = parentNode.isRelevant();
         }
@@ -508,7 +508,7 @@ public class FormDef implements IFormElement, IMetaData,
 
     public void copyItemsetAnswer(QuestionDef q, TreeElement targetNode, IAnswerData data) throws InvalidReferenceException {
         ItemsetBinding itemset = q.getDynamicChoices();
-        TreeReference targetRef = targetNode.getRef();
+        TreeReference targetRef = targetNode.getRef(true);
         TreeReference destRef = itemset.getDestRef().contextualize(targetRef);
 
         Vector<Selection> selections = null;
@@ -532,7 +532,8 @@ public class FormDef implements IFormElement, IMetaData,
             TreeElement node = getMainInstance().resolveReference(existingNodes.elementAt(i));
 
             if (itemset.valueRef != null) {
-                String value = itemset.getRelativeValue().evalReadable(this.getMainInstance(), new EvaluationContext(exprEvalContext, node.getRef()));
+                String value = itemset.getRelativeValue().evalReadable(this.getMainInstance(), new EvaluationContext(exprEvalContext, node.getRef(
+                        true)));
                 if (selectedValues.contains(value)) {
                     existingValues.put(value, node); //cache node if in selection and already exists
                 }
@@ -868,7 +869,7 @@ public class FormDef implements IFormElement, IMetaData,
         // recursively add children of element
         for (int i = 0; i < treeElem.getNumChildren(); ++i) {
             AbstractTreeElement child = treeElem.getChildAt(i);
-            TreeReference genericChild = child.getRef().genericize();
+            TreeReference genericChild = child.getRef(true).genericize();
             if (!genericRefs.contains(genericChild)) {
                 genericRefs.add(genericChild);
             }
@@ -880,7 +881,7 @@ public class FormDef implements IFormElement, IMetaData,
             AbstractTreeElement child =
                     treeElem.getAttribute(treeElem.getAttributeNamespace(i),
                             treeElem.getAttributeName(i));
-            TreeReference genericChild = child.getRef().genericize();
+            TreeReference genericChild = child.getRef(true).genericize();
             if (!genericRefs.contains(genericChild)) {
                 genericRefs.add(genericChild);
             }
@@ -1580,7 +1581,7 @@ public class FormDef implements IFormElement, IMetaData,
 
         //so painful
         TreeElement templNode = mainInstance.getTemplate(index.getReference());
-        TreeReference parentPath = templNode.getParent().getRef().genericize();
+        TreeReference parentPath = templNode.getParent().getRef(true).genericize();
         TreeElement parentNode = mainInstance.resolveReference(parentPath.contextualize(index.getReference()));
         return parentNode.getChildMultiplicity(templNode.getName());
     }
@@ -1706,7 +1707,7 @@ public class FormDef implements IFormElement, IMetaData,
         }
 
         if (selections != null) {
-            QuestionDef q = findQuestionByRef(node.getRef(), this);
+            QuestionDef q = findQuestionByRef(node.getRef(true), this);
             if (q == null) {
                 throw new RuntimeException("FormDef.attachControlsToInstanceData: can't find question to link");
             }

--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -374,6 +374,7 @@ public class FormDef implements IFormElement, IMetaData,
         reduceTreeSiblingMultiplicities(parentElement, deleteElement);
 
         this.getMainInstance().cleanCache();
+        exprEvalContext.setUseReferenceCache(false);
 
         triggerTriggerables(deleteRef);
         return newIndex;

--- a/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
+++ b/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
@@ -94,6 +94,9 @@ public class EvaluationContext {
     // Keeps track of the overall context for the executing query stack
     private QueryContext queryContext;
 
+    // Used to disable reference cache maintained by a TreeElement node
+    private boolean useReferenceCache = true;
+
     /**
      * What element in a nodeset is the context currently pointing to?
      * Used for calculating the position() xpath function.
@@ -172,6 +175,7 @@ public class EvaluationContext {
 
         this.expressionCacher = base.expressionCacher;
         setQueryContext(base.queryContext);
+        this.useReferenceCache = base.useReferenceCache;
     }
 
     public DataInstance getInstance(String id) {
@@ -325,7 +329,7 @@ public class EvaluationContext {
         DataInstance baseInstance = retrieveInstance(ref);
         Vector<TreeReference> v = new Vector<>();
 
-        expandReferenceAccumulator(ref, baseInstance, baseInstance.getRoot().getRef(true), v, includeTemplates);
+        expandReferenceAccumulator(ref, baseInstance, baseInstance.getRoot().getRef(useReferenceCache), v, includeTemplates);
         return v;
     }
 
@@ -473,16 +477,16 @@ public class EvaluationContext {
                 for (int i = 0; i < count; i++) {
                     AbstractTreeElement child = node.getChild(childName, i);
                     if (child != null) {
-                        childSet.addElement(child.getRef(true));
+                        childSet.addElement(child.getRef(useReferenceCache));
                     } else {
                         throw new IllegalStateException("Missing or non-sequential nodes expanding a reference: " + node.getRef(
-                                true));
+                                useReferenceCache));
                     }
                 }
                 if (includeTemplates) {
                     AbstractTreeElement template = node.getChild(childName, TreeReference.INDEX_TEMPLATE);
                     if (template != null) {
-                        childSet.addElement(template.getRef(true));
+                        childSet.addElement(template.getRef(useReferenceCache));
                     }
                 }
             } else if (childMult != TreeReference.INDEX_ATTRIBUTE) {
@@ -491,7 +495,7 @@ public class EvaluationContext {
                 // appropriate child
                 AbstractTreeElement child = node.getChild(childName, childMult);
                 if (child != null) {
-                    childSet.addElement(child.getRef(true));
+                    childSet.addElement(child.getRef(useReferenceCache));
                 }
             }
         }
@@ -501,7 +505,7 @@ public class EvaluationContext {
         if (childMult == TreeReference.INDEX_ATTRIBUTE) {
             AbstractTreeElement attribute = node.getAttribute(null, childName);
             if (attribute != null) {
-                childSet.addElement(attribute.getRef(true));
+                childSet.addElement(attribute.getRef(useReferenceCache));
             }
         }
         return childSet;
@@ -827,5 +831,9 @@ public class EvaluationContext {
             }
         });
         return builder.build();
+    }
+
+    public void setUseReferenceCache(boolean useReferenceCache) {
+        this.useReferenceCache = useReferenceCache;
     }
 }

--- a/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
+++ b/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
@@ -325,7 +325,7 @@ public class EvaluationContext {
         DataInstance baseInstance = retrieveInstance(ref);
         Vector<TreeReference> v = new Vector<>();
 
-        expandReferenceAccumulator(ref, baseInstance, baseInstance.getRoot().getRef(), v, includeTemplates);
+        expandReferenceAccumulator(ref, baseInstance, baseInstance.getRoot().getRef(true), v, includeTemplates);
         return v;
     }
 
@@ -473,15 +473,16 @@ public class EvaluationContext {
                 for (int i = 0; i < count; i++) {
                     AbstractTreeElement child = node.getChild(childName, i);
                     if (child != null) {
-                        childSet.addElement(child.getRef());
+                        childSet.addElement(child.getRef(true));
                     } else {
-                        throw new IllegalStateException("Missing or non-sequential nodes expanding a reference: " + node.getRef());
+                        throw new IllegalStateException("Missing or non-sequential nodes expanding a reference: " + node.getRef(
+                                true));
                     }
                 }
                 if (includeTemplates) {
                     AbstractTreeElement template = node.getChild(childName, TreeReference.INDEX_TEMPLATE);
                     if (template != null) {
-                        childSet.addElement(template.getRef());
+                        childSet.addElement(template.getRef(true));
                     }
                 }
             } else if (childMult != TreeReference.INDEX_ATTRIBUTE) {
@@ -490,7 +491,7 @@ public class EvaluationContext {
                 // appropriate child
                 AbstractTreeElement child = node.getChild(childName, childMult);
                 if (child != null) {
-                    childSet.addElement(child.getRef());
+                    childSet.addElement(child.getRef(true));
                 }
             }
         }
@@ -500,7 +501,7 @@ public class EvaluationContext {
         if (childMult == TreeReference.INDEX_ATTRIBUTE) {
             AbstractTreeElement attribute = node.getAttribute(null, childName);
             if (attribute != null) {
-                childSet.addElement(attribute.getRef());
+                childSet.addElement(attribute.getRef(true));
             }
         }
         return childSet;

--- a/src/main/java/org/javarosa/core/model/instance/AbstractTreeElement.java
+++ b/src/main/java/org/javarosa/core/model/instance/AbstractTreeElement.java
@@ -83,7 +83,7 @@ public interface AbstractTreeElement<T extends AbstractTreeElement> {
     String getAttributeValue(String namespace, String name);
 
     //return the tree reference that corresponds to this tree element
-    TreeReference getRef();
+    TreeReference getRef(boolean useCache);
 
     String getName();
 

--- a/src/main/java/org/javarosa/core/model/instance/ConcreteTreeElement.java
+++ b/src/main/java/org/javarosa/core/model/instance/ConcreteTreeElement.java
@@ -329,9 +329,9 @@ public class ConcreteTreeElement<T extends AbstractTreeElement> implements Abstr
     TreeReference refCache;
 
     @Override
-    public TreeReference getRef() {
+    public TreeReference getRef(boolean useCache) {
         //TODO: Expire cache somehow;
-        if (refCache == null) {
+        if (refCache == null || !useCache) {
             refCache = TreeReference.buildRefFromTreeElement(this);
         }
         return refCache;

--- a/src/main/java/org/javarosa/core/model/instance/FormInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/FormInstance.java
@@ -101,7 +101,7 @@ public class FormInstance extends DataInstance<TreeElement> implements Persistab
             throw new InvalidReferenceException("Null Source reference while attempting to copy node", from);
         }
 
-        return copyNode(src, to).getRef();
+        return copyNode(src, to).getRef(true);
     }
 
     // for making new repeat instances; 'from' and 'to' must be unambiguous

--- a/src/main/java/org/javarosa/core/model/instance/InstanceBase.java
+++ b/src/main/java/org/javarosa/core/model/instance/InstanceBase.java
@@ -137,7 +137,7 @@ public class InstanceBase implements AbstractTreeElement<AbstractTreeElement> {
     }
 
     @Override
-    public TreeReference getRef() {
+    public TreeReference getRef(boolean useCache) {
         return TreeReference.rootRef();
     }
 

--- a/src/main/java/org/javarosa/core/model/instance/TreeElement.java
+++ b/src/main/java/org/javarosa/core/model/instance/TreeElement.java
@@ -727,7 +727,7 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
 
                 if (child.getMaskVar(MASK_REPEATABLE)) {
                     for (int k = 0; k < newChildren.size(); k++) {
-                        TreeElement template = f.getMainInstance().getTemplate(child.getRef());
+                        TreeElement template = f.getMainInstance().getTemplate(child.getRef(true));
                         TreeElement newChild = template.deepCopy(false);
                         newChild.setMult(k);
                         if (children == null) {
@@ -752,10 +752,10 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
 
     //return the tree reference that corresponds to this tree element
     @Override
-    public TreeReference getRef() {
+    public TreeReference getRef(boolean useCache) {
         //TODO: Expire cache somehow;
         synchronized (refCache) {
-            if (refCache[0] == null) {
+            if (refCache[0] == null || !useCache) {
                 refCache[0] = TreeReference.buildRefFromTreeElement(this);
             }
             return refCache[0];

--- a/src/main/java/org/javarosa/core/model/instance/utils/TreeUtilities.java
+++ b/src/main/java/org/javarosa/core/model/instance/utils/TreeUtilities.java
@@ -141,7 +141,7 @@ public class TreeUtilities {
                             TreeElement[] children = childAttributeHintMap.get(left).get(literalMatch);
                             if (children != null) {
                                 for (TreeElement element : children) {
-                                    predicateMatches.add(element.getRef());
+                                    predicateMatches.add(element.getRef(true));
                                 }
                             }
                             //Merge and note that this predicate is evaluated and doesn't need to be evaluated
@@ -197,7 +197,7 @@ public class TreeUtilities {
                                 Object value = FunctionUtils.InferType(attrValue);
 
                                 if (isEqOp == XPathEqExpr.testEquality(value, literalMatch)) {
-                                    predicateMatches.add(kids.elementAt(kidI).getRef());
+                                    predicateMatches.add(kids.elementAt(kidI).getRef(true));
                                 }
                             }
 

--- a/src/main/java/org/javarosa/form/api/FormEntryPrompt.java
+++ b/src/main/java/org/javarosa/form/api/FormEntryPrompt.java
@@ -73,11 +73,12 @@ public class FormEntryPrompt extends FormEntryCaption {
 
                 //determine which selections are already present in the answer
                 if (itemset.copyMode) {
-                    TreeReference destRef = itemset.getDestRef().contextualize(mTreeElement.getRef());
+                    TreeReference destRef = itemset.getDestRef().contextualize(mTreeElement.getRef(true));
                     Vector<TreeReference> subNodes = form.getEvaluationContext().expandReference(destRef);
                     for (int i = 0; i < subNodes.size(); i++) {
                         TreeElement node = form.getMainInstance().resolveReference(subNodes.elementAt(i));
-                        String value = itemset.getRelativeValue().evalReadable(form.getMainInstance(), new EvaluationContext(form.getEvaluationContext(), node.getRef()));
+                        String value = itemset.getRelativeValue().evalReadable(form.getMainInstance(), new EvaluationContext(form.getEvaluationContext(), node.getRef(
+                                true)));
                         preselectedValues.addElement(value);
                     }
                 } else {
@@ -187,7 +188,7 @@ public class FormEntryPrompt extends FormEntryCaption {
         if (mTreeElement.getConstraint() == null) {
             return null;
         } else {
-            EvaluationContext ec = new EvaluationContext(form.exprEvalContext, mTreeElement.getRef());
+            EvaluationContext ec = new EvaluationContext(form.exprEvalContext, mTreeElement.getRef(true));
             if (textForm != null) {
                 ec.setOutputTextForm(textForm);
             }
@@ -207,7 +208,7 @@ public class FormEntryPrompt extends FormEntryCaption {
         ItemsetBinding itemset = q.getDynamicChoices();
         if (itemset != null) {
             if (populatedDynamicChoices == null && shouldAttemptDynamicPopulation) {
-                form.populateDynamicChoices(itemset, mTreeElement.getRef());
+                form.populateDynamicChoices(itemset, mTreeElement.getRef(true));
                 populatedDynamicChoices = itemset.getChoices();
             }
             return populatedDynamicChoices;
@@ -436,7 +437,7 @@ public class FormEntryPrompt extends FormEntryCaption {
         //We could hide it by dispatching hints through a final abstract class instead.
         Constraint c = mTreeElement.getConstraint();
         if (c != null) {
-            hint.init(new EvaluationContext(form.exprEvalContext, mTreeElement.getRef()), c.constraint, this.form.getMainInstance());
+            hint.init(new EvaluationContext(form.exprEvalContext, mTreeElement.getRef(true)), c.constraint, this.form.getMainInstance());
         } else {
             //can't pivot what ain't there.
             throw new UnpivotableExpressionException();

--- a/src/main/java/org/javarosa/xform/parse/XFormParser.java
+++ b/src/main/java/org/javarosa/xform/parse/XFormParser.java
@@ -2592,7 +2592,8 @@ public class XFormParser {
 
                 if (!FormInstance.isHomogeneous(srcNode, dstNode)) {
                     reporter.warning(XFormParserReporter.TYPE_INVALID_STRUCTURE,
-                            "Your itemset source [" + srcNode.getRef().toString() + "] and dest [" + dstNode.getRef().toString() +
+                            "Your itemset source [" + srcNode.getRef(true).toString() + "] and dest [" + dstNode.getRef(
+                                    true).toString() +
                                     "] of appear to be incompatible!", null);
                 }
 


### PR DESCRIPTION
## Technical Summary

https://dimagi.atlassian.net/browse/USH-4708 (Deleting a repeat was causing errors in resolving references )

After deleting a repeat, a node's reference can change due to change in repeat index of the node. Therefore we need a way to not use the existing cache while resolving references. The way cache is setup today I was not able to find a way to expire it for all nodes without looping through all possible references therefore I choose to pass a flag to not use the cache. 

## Safety Assurance

### Safety story

- Impact should be limited to evaluating Xpath after delete repeats action which already seems to be a little broken at the moment. 
- Due to us not using reference cache post delete, there can be a small performance downside after deleting a repeat node for large forms. Although would not expect to be substantial. 

### Automated test coverage
 
 https://github.com/dimagi/formplayer/pull/1597

### QA Plan
None

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
