### PR TITLE
Add log type for media events

### DIFF
--- a/src/main/java/org/commcare/util/LogTypes.java
+++ b/src/main/java/org/commcare/util/LogTypes.java
@@ -113,4 +113,7 @@ public class LogTypes {
     * Logs related to Firebase Cloud Messaging
     */
     public static final String TYPE_FCM = "fcm";
+
+    public static final String TYPE_MEDIA_EVENT = "media-event";
+
 }


### PR DESCRIPTION
## Product Description
This is part of a change to improve logging around audio recording events, it adds a new log type for such events.

## Technical Summary
None

## Safety Assurance

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
