### PR TITLE
Fix repeat deletion Issue by implementing Clear volatiles for tree element

### DIFF
--- a/src/main/java/org/commcare/cases/instance/StorageBackedChildElement.java
+++ b/src/main/java/org/commcare/cases/instance/StorageBackedChildElement.java
@@ -200,8 +200,11 @@ public abstract class StorageBackedChildElement<Model extends Externalizable>
 
     @Override
     public void clearVolatiles() {
-        // we should also clear the other cache implementation in this class in future
         ref = null;
+        TreeElement cache = cache();
+        if (cache != null) {
+            cache.clearVolatiles();
+        }
     }
 
     //Context Sensitive Methods

--- a/src/main/java/org/commcare/cases/instance/StorageBackedChildElement.java
+++ b/src/main/java/org/commcare/cases/instance/StorageBackedChildElement.java
@@ -200,6 +200,7 @@ public abstract class StorageBackedChildElement<Model extends Externalizable>
 
     @Override
     public void clearVolatiles() {
+        // we should also clear the other cache implementation in this class in future
         ref = null;
     }
 

--- a/src/main/java/org/commcare/cases/instance/StorageBackedChildElement.java
+++ b/src/main/java/org/commcare/cases/instance/StorageBackedChildElement.java
@@ -198,6 +198,10 @@ public abstract class StorageBackedChildElement<Model extends Externalizable>
         return ref;
     }
 
+    @Override
+    public void clearVolatiles() {
+        ref = null;
+    }
 
     //Context Sensitive Methods
     @Override

--- a/src/main/java/org/commcare/cases/instance/StorageInstanceTreeElement.java
+++ b/src/main/java/org/commcare/cases/instance/StorageInstanceTreeElement.java
@@ -208,6 +208,11 @@ public abstract class StorageInstanceTreeElement<Model extends Externalizable, T
         return cachedRef;
     }
 
+    @Override
+    public void clearVolatiles() {
+        cachedRef = null;
+    }
+
     private void expireCachedRef() {
         cachedRef = null;
     }

--- a/src/main/java/org/commcare/cases/instance/StorageInstanceTreeElement.java
+++ b/src/main/java/org/commcare/cases/instance/StorageInstanceTreeElement.java
@@ -211,6 +211,11 @@ public abstract class StorageInstanceTreeElement<Model extends Externalizable, T
     @Override
     public void clearVolatiles() {
         cachedRef = null;
+        if (elements != null) {
+            for (T element : elements) {
+                element.clearVolatiles();
+            }
+        }
     }
 
     private void expireCachedRef() {

--- a/src/main/java/org/commcare/cases/query/QuerySensitiveTreeElementWrapper.java
+++ b/src/main/java/org/commcare/cases/query/QuerySensitiveTreeElementWrapper.java
@@ -132,6 +132,11 @@ public class QuerySensitiveTreeElementWrapper<T extends AbstractTreeElement> imp
     }
 
     @Override
+    public void clearVolatiles() {
+        wrapped.clearVolatiles();
+    }
+
+    @Override
     public String getName() {
         return wrapped.getName();
     }

--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -373,7 +373,7 @@ public class FormDef implements IFormElement, IMetaData,
 
         reduceTreeSiblingMultiplicities(parentElement, deleteElement);
 
-        this.getMainInstance().cleanCache();
+        this.getMainInstance().cleanCache(parentElement);
 
         triggerTriggerables(deleteRef);
         return newIndex;

--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -373,7 +373,7 @@ public class FormDef implements IFormElement, IMetaData,
 
         reduceTreeSiblingMultiplicities(parentElement, deleteElement);
 
-        this.getMainInstance().cleanCache(parentElement);
+        this.getMainInstance().cleanCache();
 
         triggerTriggerables(deleteRef);
         return newIndex;

--- a/src/main/java/org/javarosa/core/model/instance/AbstractTreeElement.java
+++ b/src/main/java/org/javarosa/core/model/instance/AbstractTreeElement.java
@@ -100,6 +100,9 @@ public interface AbstractTreeElement<T extends AbstractTreeElement> {
 
     String getNamespace();
 
+    // clear any cache maintained by the TreeElement implementation
+    void clearVolatiles();
+
     /**
      * TODO: Worst method name ever. Don't use this unless you know what's up.
      * @param predicates  possibly list of predicates to be evaluated. predicates will be removed from list if they are

--- a/src/main/java/org/javarosa/core/model/instance/ConcreteTreeElement.java
+++ b/src/main/java/org/javarosa/core/model/instance/ConcreteTreeElement.java
@@ -337,6 +337,10 @@ public class ConcreteTreeElement<T extends AbstractTreeElement> implements Abstr
         return refCache;
     }
 
+    @Override
+    public void clearVolatiles() {
+        refCache = null;
+    }
 
     @Override
     public String getName() {

--- a/src/main/java/org/javarosa/core/model/instance/ConcreteTreeElement.java
+++ b/src/main/java/org/javarosa/core/model/instance/ConcreteTreeElement.java
@@ -340,6 +340,16 @@ public class ConcreteTreeElement<T extends AbstractTreeElement> implements Abstr
     @Override
     public void clearVolatiles() {
         refCache = null;
+        if (children != null) {
+            for (T child : children) {
+                child.clearVolatiles();
+            }
+        }
+        if (attributes != null) {
+            for (T attribute : attributes) {
+                attribute.clearVolatiles();
+            }
+        }
     }
 
     @Override

--- a/src/main/java/org/javarosa/core/model/instance/DataInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/DataInstance.java
@@ -291,5 +291,16 @@ public abstract class DataInstance<T extends AbstractTreeElement<T>> implements 
 
     public void cleanCache() {
         referenceCache.clear();
+        cleanTreeElementCache(getBase());
+    }
+
+    private void cleanTreeElementCache(AbstractTreeElement<T> node) {
+        if (node == null) {
+            return;
+        }
+        node.clearVolatiles();
+        for (int i = 0; i < node.getNumChildren(); i++) {
+            cleanTreeElementCache(node.getChildAt(i));
+        }
     }
 }

--- a/src/main/java/org/javarosa/core/model/instance/DataInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/DataInstance.java
@@ -289,30 +289,11 @@ public abstract class DataInstance<T extends AbstractTreeElement<T>> implements 
         this.mCacheHost = cacheHost;
     }
 
-    public void cleanCache() {
-        cleanCache(getBase());
-    }
-
     /**
      * Cleans reference caches maintained by the instance and TreeElements contained in the contextNode
-     * @param contextNode Parent node inside the scope of which we clear the TreeElement volatiles
      */
-    public void cleanCache(AbstractTreeElement<T> contextNode) {
+    public void cleanCache() {
         referenceCache.clear();
-        cleanTreeElementCache(contextNode);
-    }
-
-    /**
-     * Loops through the node and it's children and clears their volatiles
-     * @param contextNode Parent node inside the scope of which we clear the TreeElement volatiles
-     */
-    private void cleanTreeElementCache(AbstractTreeElement<T> contextNode) {
-        if (contextNode == null) {
-            return;
-        }
-        contextNode.clearVolatiles();
-        for (int i = 0; i < contextNode.getNumChildren(); i++) {
-            cleanTreeElementCache(contextNode.getChildAt(i));
-        }
+        getBase().clearVolatiles();
     }
 }

--- a/src/main/java/org/javarosa/core/model/instance/DataInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/DataInstance.java
@@ -290,17 +290,29 @@ public abstract class DataInstance<T extends AbstractTreeElement<T>> implements 
     }
 
     public void cleanCache() {
-        referenceCache.clear();
-        cleanTreeElementCache(getBase());
+        cleanCache(getBase());
     }
 
-    private void cleanTreeElementCache(AbstractTreeElement<T> node) {
-        if (node == null) {
+    /**
+     * Cleans reference caches maintained by the instance and TreeElements contained in the contextNode
+     * @param contextNode Parent node inside the scope of which we clear the TreeElement volatiles
+     */
+    public void cleanCache(AbstractTreeElement<T> contextNode) {
+        referenceCache.clear();
+        cleanTreeElementCache(contextNode);
+    }
+
+    /**
+     * Loops through the node and it's children and clears their volatiles
+     * @param contextNode Parent node inside the scope of which we clear the TreeElement volatiles
+     */
+    private void cleanTreeElementCache(AbstractTreeElement<T> contextNode) {
+        if (contextNode == null) {
             return;
         }
-        node.clearVolatiles();
-        for (int i = 0; i < node.getNumChildren(); i++) {
-            cleanTreeElementCache(node.getChildAt(i));
+        contextNode.clearVolatiles();
+        for (int i = 0; i < contextNode.getNumChildren(); i++) {
+            cleanTreeElementCache(contextNode.getChildAt(i));
         }
     }
 }

--- a/src/main/java/org/javarosa/core/model/instance/InstanceBase.java
+++ b/src/main/java/org/javarosa/core/model/instance/InstanceBase.java
@@ -143,7 +143,9 @@ public class InstanceBase implements AbstractTreeElement<AbstractTreeElement> {
 
     @Override
     public void clearVolatiles() {
-        // nothing to clear
+        if (child != null) {
+            child.clearVolatiles();
+        }
     }
 
     @Override

--- a/src/main/java/org/javarosa/core/model/instance/InstanceBase.java
+++ b/src/main/java/org/javarosa/core/model/instance/InstanceBase.java
@@ -142,6 +142,11 @@ public class InstanceBase implements AbstractTreeElement<AbstractTreeElement> {
     }
 
     @Override
+    public void clearVolatiles() {
+        // nothing to clear
+    }
+
+    @Override
     public String getName() {
         return null;
     }

--- a/src/main/java/org/javarosa/core/model/instance/TreeElement.java
+++ b/src/main/java/org/javarosa/core/model/instance/TreeElement.java
@@ -856,6 +856,16 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
     @Override
     public void clearVolatiles() {
         refCache[0] = null;
+        if (children != null) {
+            for (TreeElement child : children) {
+                child.clearVolatiles();
+            }
+        }
+        if (attributes != null) {
+            for (TreeElement attribute : attributes) {
+                attribute.clearVolatiles();
+            }
+        }
     }
 
     public void setNamespace(String namespace) {

--- a/src/main/java/org/javarosa/core/model/instance/TreeElement.java
+++ b/src/main/java/org/javarosa/core/model/instance/TreeElement.java
@@ -753,7 +753,6 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
     //return the tree reference that corresponds to this tree element
     @Override
     public TreeReference getRef() {
-        //TODO: Expire cache somehow;
         synchronized (refCache) {
             if (refCache[0] == null) {
                 refCache[0] = TreeReference.buildRefFromTreeElement(this);
@@ -852,6 +851,11 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
     @Override
     public String getNamespace() {
         return namespace;
+    }
+
+    @Override
+    public void clearVolatiles() {
+        refCache[0] = null;
     }
 
     public void setNamespace(String namespace) {

--- a/src/test/java/org/javarosa/core/model/test/FormDefTest.java
+++ b/src/test/java/org/javarosa/core/model/test/FormDefTest.java
@@ -443,7 +443,7 @@ public class FormDefTest {
 
     // regression test for when we weren't decrementing multiplicities correctly when repeats were deleted
     @Test
-    public void testDeleteRepeatMultiplicities() throws IOException {
+    public void testDeleteRepeatMultiplicities() throws IOException, XPathSyntaxException {
         FormParseInit fpi = new FormParseInit("/multiple_repeats.xml");
         FormEntryController fec = initFormEntry(fpi, "en");
         fec.stepToNextEvent();
@@ -483,6 +483,16 @@ public class FormDefTest {
         assertEquals(root.getChildMultiplicity("question1"), 2);
         assertNotEquals(root.getChild("question1", 1), null);
 
+        EvaluationContext evalCtx = fpi.getFormDef().getEvaluationContext();
+        ExprEvalUtils.assertEqualsXpathEval("check repeat node set correctly",
+                "Second repeat, first iteration: question5", "/data/question4[1]/question5", evalCtx);
+        ExprEvalUtils.assertEqualsXpathEval("check repeat node set correctly",
+                "Second repeat, first iteration: question6", "/data/question4[1]/question6", evalCtx);
+        ExprEvalUtils.assertEqualsXpathEval("check repeat node set correctly",
+                "Second repeat, second iteration: question5", "/data/question4[2]/question5", evalCtx);
+        ExprEvalUtils.assertEqualsXpathEval("check repeat node set correctly",
+                "Second repeat, second iteration: question6", "/data/question4[2]/question6", evalCtx);
+
         fec.deleteRepeat(0);
 
         // Confirm that the deleted repeat is gone and its sibling's multiplicity reduced
@@ -491,6 +501,11 @@ public class FormDefTest {
         // Confirm that the other repeat is unchanged
         assertEquals(root.getChildMultiplicity("question1"), 2);
         assertNotEquals(root.getChild("question1", 1), null);
+
+        ExprEvalUtils.assertEqualsXpathEval("check repeat node set correctly",
+                "Second repeat, second iteration: question5", "/data/question4[1]/question5", evalCtx);
+        ExprEvalUtils.assertEqualsXpathEval("check repeat node set correctly",
+                "Second repeat, second iteration: question6", "/data/question4[1]/question6", evalCtx);
     }
 
     /**


### PR DESCRIPTION
## Technical Summary

https://dimagi.atlassian.net/browse/USH-4708 (Deleting a repeat was causing errors in resolving references for remaining repeat nodes)

After deleting a repeat, a node's reference can change due to change in repeat index of the node. Therefore we need to expire the existing cached references for TreeElements. 

## Safety Assurance

### Safety story

- Should only affect repeat deletion which is covered by test

### Automated test coverage
 
 Added in the PR plus in https://github.com/dimagi/formplayer/pull/1597

### QA Plan
None

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
