### PR TITLE
Fixes for Date Range Widget for Case Search screen

### DIFF
--- a/src/main/java/org/commcare/util/DateRangeUtils.java
+++ b/src/main/java/org/commcare/util/DateRangeUtils.java
@@ -1,0 +1,81 @@
+package org.commcare.util;
+
+import org.commcare.modern.util.Pair;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+import javax.annotation.Nullable;
+
+public class DateRangeUtils {
+
+    // Changing this will require changing this format on ES end as well
+    public static final String DATE_RANGE_ANSWER_PREFIX = "__range__";
+    public static final String DATE_RANGE_ANSWER_DELIMITER = "__";
+    public static final String DATE_RANGE_ANSWER_HUMAN_READABLE_DELIMITER = " to ";
+    private static final String DATE_FORMAT = "yyyy-MM-dd";
+
+    /**
+     * @param humanReadableDateRange human readable fomat for date range as 'startDate to endDate'
+     * @return a Pair of start time and end time that can be supplied to MaterialDatePicker to set a date range,
+     * @throws ParseException if the given humanReadableDateRange is not in 'yyyy-mm-dd to yyyy-mm-dd' format
+     */
+    @Nullable
+    public static Pair<Long, Long> parseHumanReadableDate(String humanReadableDateRange) throws ParseException {
+        if (humanReadableDateRange.contains(DATE_RANGE_ANSWER_HUMAN_READABLE_DELIMITER)) {
+            String[] humanReadableDateRangeSplit = humanReadableDateRange.split(DATE_RANGE_ANSWER_HUMAN_READABLE_DELIMITER);
+            if (humanReadableDateRangeSplit.length == 2) {
+                SimpleDateFormat sdf = new SimpleDateFormat(DATE_FORMAT, Locale.US);
+                Date startDate = sdf.parse(humanReadableDateRangeSplit[0]);
+                Date endDate = sdf.parse(humanReadableDateRangeSplit[1]);
+                return new Pair<>(getTimeFromDateOffsettingTz(startDate), getTimeFromDateOffsettingTz(endDate));
+            }
+        }
+        throw new ParseException("Argument " + humanReadableDateRange + " should be formatted as 'yyyy-mm-dd to yyyy-mm-dd'", 0);
+    }
+
+    private static Long getTimeFromDateOffsettingTz(Date date) {
+        return date.getTime() - date.getTimezoneOffset() * 60 * 1000;
+    }
+
+    /**
+     * Formats __range__startDate__endDate as 'startDate to EndDate'
+     *
+     * @param dateRangeAnswer A date range value in form of '__range__startDate__endDate'
+     * @return human readable format 'startDate to EndDate' for given dateRangeAnswer
+     */
+    public static String getHumanReadableDateRange(String dateRangeAnswer) {
+        if (dateRangeAnswer != null && dateRangeAnswer.startsWith(DATE_RANGE_ANSWER_PREFIX)) {
+            String[] dateRangeSplit = dateRangeAnswer.split(DATE_RANGE_ANSWER_DELIMITER);
+            if (dateRangeSplit.length == 4) {
+                return getHumanReadableDateRange(dateRangeSplit[2], dateRangeSplit[3]);
+            }
+        }
+        return dateRangeAnswer;
+    }
+
+
+    // Formats as 'startDate to endDate'
+    public static String getHumanReadableDateRange(String startDate, String endDate) {
+        return startDate + DATE_RANGE_ANSWER_HUMAN_READABLE_DELIMITER + endDate;
+    }
+
+    // Formats as '__range__startDate__endDate'
+    public static String formatDateRangeAnswer(String startDate, String endDate) {
+        return DATE_RANGE_ANSWER_PREFIX + startDate + DATE_RANGE_ANSWER_DELIMITER + endDate;
+    }
+
+    public static String formatDateRangeAnswer(String humanReadableDateRange) throws ParseException {
+        Pair<Long, Long> selection = DateRangeUtils.parseHumanReadableDate(humanReadableDateRange);
+        String startDate = DateRangeUtils.getDateFromTime(selection.first);
+        String endDate = DateRangeUtils.getDateFromTime(selection.second);
+        return DATE_RANGE_ANSWER_PREFIX + startDate + DATE_RANGE_ANSWER_DELIMITER + endDate;
+    }
+
+    // Convers given time as yyyy-mm-dd
+    public static String getDateFromTime(Long time) {
+        return new SimpleDateFormat(DATE_FORMAT, Locale.US).format(new Date(time));
+    }
+}

--- a/src/test/java/org/commcare/util/DateRangeUtilsTest.java
+++ b/src/test/java/org/commcare/util/DateRangeUtilsTest.java
@@ -1,0 +1,18 @@
+package org.commcare.util;
+
+import junit.framework.TestCase;
+
+import org.junit.Test;
+
+import java.text.ParseException;
+
+public class DateRangeUtilsTest extends TestCase {
+
+    @Test
+    public void testDateConversion() throws ParseException {
+        String dateRange = "2020-02-15 to 2021-03-18";
+        String formattedDateRange = DateRangeUtils.formatDateRangeAnswer(dateRange);
+        assertEquals("__range__2020-02-15__2021-03-18", formattedDateRange);
+        assertEquals(dateRange, DateRangeUtils.getHumanReadableDateRange(formattedDateRange));
+    }
+}


### PR DESCRIPTION
## Product Description

Fixes date range widget 
https://dimagi.atlassian.net/browse/QA-6604

## Technical Summary

Date Range widget on mobile had a few bugs related to default value handling.It was assuming that the default values will be set in the form `__range__startDate_endDate` while we set those as human readable dates for ex - `concat(date(today()-60) , ' to ' , date(today()))` . This error doesn't surface for FP as this date conversion is done by JS code on Web Apps which is not great as well since it leads to mobile and Web Apps having separate implementation for the same functionality.  

## Safety Assurance

### Safety story

Test for date conversion included in PR, will go through QA testing

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).

cross-request: https://github.com/dimagi/commcare-android/pull/2779