### PR TITLE
Pass query params to HTTP requests that don't require authentication

### DIFF
--- a/src/main/java/org/commcare/core/network/CommCareNetworkServiceGenerator.java
+++ b/src/main/java/org/commcare/core/network/CommCareNetworkServiceGenerator.java
@@ -140,6 +140,10 @@ public class CommCareNetworkServiceGenerator {
         return createCommCareNetworkService(null, false, true, ImmutableMultimap.of());
     }
 
+    public static CommCareNetworkService createNoAuthCommCareNetworkService(Multimap<String, String> params) {
+        return createCommCareNetworkService(null, false, true, params);
+    }
+
     private static boolean isValidRedirect(HttpUrl url, HttpUrl newUrl) {
         // unless it's https, don't worry about it
         if (!url.scheme().equals("https")) {


### PR DESCRIPTION
## Product Description
This PR fixes an issue that is causing the `app_id` in the response body of the Recovery Measures GET request to be `null`. 
```
{
    "latest_apk_version": "2.53.1",
    "latest_ccz_version": 127,
    "app_id": null,
    "recovery_measures": [
        {
            "sequence_number": 9,
            "type": "app_reinstall_and_update",
            "app_version_min": 128,
            "app_version_max": 131
        }
    ]
}
```

cross-request: https://github.com/dimagi/commcare-android/pull/2793
Ticket: https://dimagi.atlassian.net/browse/QA-6606

## Safety Assurance

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
