### PR TITLE
Make FormIndex serializable

### DIFF
--- a/src/main/java/org/javarosa/core/model/FormIndex.java
+++ b/src/main/java/org/javarosa/core/model/FormIndex.java
@@ -472,7 +472,7 @@ public class FormIndex implements Externalizable {
         endOfForm = ExtUtil.readBool(in);
         localIndex = ExtUtil.readInt(in);
         instanceIndex = ExtUtil.readInt(in);
-        reference = (TreeReference)ExtUtil.read(in, TreeReference.class, pf);
+        reference = (TreeReference)ExtUtil.read(in, new ExtWrapNullable(TreeReference.class), pf);
         nextLevel = (FormIndex)ExtUtil.read(in, new ExtWrapNullable(FormIndex.class), pf);
     }
 
@@ -482,7 +482,7 @@ public class FormIndex implements Externalizable {
         ExtUtil.writeBool(out, endOfForm);
         ExtUtil.writeNumeric(out, localIndex);
         ExtUtil.writeNumeric(out, instanceIndex);
-        ExtUtil.write(out, reference);
+        ExtUtil.write(out, new ExtWrapNullable(reference));
         ExtUtil.write(out, new ExtWrapNullable(nextLevel));
     }
 }

--- a/src/main/java/org/javarosa/core/model/FormIndex.java
+++ b/src/main/java/org/javarosa/core/model/FormIndex.java
@@ -1,7 +1,15 @@
 package org.javarosa.core.model;
 
 import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.core.util.externalizable.DeserializationException;
+import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.ExtWrapNullable;
+import org.javarosa.core.util.externalizable.Externalizable;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import java.util.Vector;
 
 /**
@@ -22,7 +30,7 @@ import java.util.Vector;
  *
  * @author Clayton Sims
  */
-public class FormIndex {
+public class FormIndex implements Externalizable {
 
     private boolean beginningOfForm = false;
     private boolean endOfForm = false;
@@ -30,7 +38,7 @@ public class FormIndex {
     /**
      * The index of the questiondef in the current context
      */
-    private final int localIndex;
+    private int localIndex;
 
     /**
      * The multiplicity of the current instance of a repeated question or group
@@ -43,6 +51,10 @@ public class FormIndex {
     private FormIndex nextLevel;
 
     private TreeReference reference;
+
+    // needed for serialization
+    public FormIndex(){
+    }
 
     public static FormIndex createBeginningOfFormIndex() {
         FormIndex begin = new FormIndex(-1, null);
@@ -452,5 +464,25 @@ public class FormIndex {
             cur = cur.getNextLevel();
             i++;
         }
+    }
+
+    @Override
+    public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
+        beginningOfForm = ExtUtil.readBool(in);
+        endOfForm = ExtUtil.readBool(in);
+        localIndex = ExtUtil.readInt(in);
+        instanceIndex = ExtUtil.readInt(in);
+        reference = (TreeReference)ExtUtil.read(in, TreeReference.class, pf);
+        nextLevel = (FormIndex)ExtUtil.read(in, new ExtWrapNullable(FormIndex.class), pf);
+    }
+
+    @Override
+    public void writeExternal(DataOutputStream out) throws IOException {
+        ExtUtil.writeBool(out, beginningOfForm);
+        ExtUtil.writeBool(out, endOfForm);
+        ExtUtil.writeNumeric(out, localIndex);
+        ExtUtil.writeNumeric(out, instanceIndex);
+        ExtUtil.write(out, reference);
+        ExtUtil.write(out, new ExtWrapNullable(nextLevel));
     }
 }


### PR DESCRIPTION
## Product Description
This PR makes the `FormIndex` class serializable in order to save its objects in SharedPreferences and allow an automatic restoration of the user session when the session expires or CommCare is force closed.

## Technical Summary
Context: [Graceful Session Pause](https://docs.google.com/document/d/1j5ume0J0UwwraijxGw-Pq-8ZYFC7L07cKb7CXL30poo/edit)

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [ ] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations.

### Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
