### PR TITLE
Fix Levenshtein distance algorithm

### DIFF
--- a/src/main/java/org/commcare/cases/util/StringUtils.java
+++ b/src/main/java/org/commcare/cases/util/StringUtils.java
@@ -119,7 +119,7 @@ public class StringUtils {
         for (int j = 1; j < len1; j++) {
 
             // initial cost of skipping prefix in String s1
-            newcost[0] = j - 1;
+            newcost[0] = j;
 
             // transformation cost for each letter in s0
             for (int i = 1; i < len0; i++) {

--- a/src/test/java/org/commcare/util/reference/test/FuzzySearchTest.java
+++ b/src/test/java/org/commcare/util/reference/test/FuzzySearchTest.java
@@ -30,5 +30,8 @@ public class FuzzySearchTest {
         // false even though we have an exact substring match,
         // Cuz fuzzy search starts checking from 0th location.
         Assert.assertFalse(StringUtils.fuzzyMatch("Test", "CrazyTest").first);
+
+        // false since aply and cape has a difference of 3 edits add 'c', remove 'l', replace 'y' with 'e'
+        Assert.assertFalse(StringUtils.fuzzyMatch("aply", "cape").first);
     }
 }


### PR DESCRIPTION
## Product Description
This PR fixes a small issue with the Levenshtein distance calculation, which was causing the fuzzy search to return false positives. For instance, the difference between `aply` into `cape` was previously 2 while it should be 3, and because our distance threshold is set at 2, the cape was a valid value for `aply`.

Another look to the [source of the algorithm](https://en.wikibooks.org/wiki/Algorithm_Implementation/Strings/Levenshtein_distance), I could also confirm that this [was initially incorrect](https://en.wikibooks.org/w/index.php?title=Algorithm_Implementation/Strings/Levenshtein_distance&oldid=2612649#Java):
```
		// initial cost of skipping prefix in String s1
		newcost[0]=j-1;
```
 and later on updated to the current form:
```
		// initial cost of skipping prefix in String s1
		newcost[0]=j;
```
</td>
</tr>
</table>

Ticket: https://dimagi.atlassian.net/browse/SAAS-15738

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->

## Safety Assurance

### Automated test coverage
There are unit tests around this feature and they seem to have not been affected by this change.

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [X] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations.

### Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
