### PR TITLE
Fix case list search

### DIFF
--- a/src/main/java/org/commcare/cases/entity/AsyncEntity.java
+++ b/src/main/java/org/commcare/cases/entity/AsyncEntity.java
@@ -177,7 +177,7 @@ public class AsyncEntity extends Entity<TreeReference> {
         } catch (IOException e) {
             Logger.exception("Error while getting sort field", e);
         }
-        return null;
+        return sortData[i];
     }
 
     @Override

--- a/src/main/java/org/commcare/cases/entity/AsyncEntity.java
+++ b/src/main/java/org/commcare/cases/entity/AsyncEntity.java
@@ -169,15 +169,14 @@ public class AsyncEntity extends Entity<TreeReference> {
                                 sortData[i] = "<invalid xpath: " + xpe.getMessage() + ">";
                             }
                         }
-                        return sortData[i];
                     }
-                    return sortData[i];
                 }
+                return sortData[i];
             }
         } catch (IOException e) {
             Logger.exception("Error while getting sort field", e);
         }
-        return sortData[i];
+        return null;
     }
 
     @Override


### PR DESCRIPTION
## Product Description
Users have reported issues with the case list search feature after updating to CommCare 2.54, claiming that it's not filtering cases as expected. After some investigation, it was noted that the issue is related to [AsyncEntities](https://github.com/dimagi/commcare-core/blob/master/src/main/java/org/commcare/cases/entity/AsyncEntity.java) used by features such as `Case Tile templates` and `Lazy load case list`. Currently, when a user tries to search for a case, even when a case with properties matching the search key is present, the case list comes out empty, trying to delete the search key also results in an empty case list:
<video width="200" src="https://github.com/user-attachments/assets/e741a0ac-885c-4f3e-a995-ec44d54fce13"/>

### Details about the bug
When filtering case data, the method [EntitySortUtil.sortEntities()](https://github.com/dimagi/commcare-core/blob/7cc09320ce920bf89b7b43255fd8850fb6c172c7/src/main/java/org/commcare/util/EntitySortUtil.java#L19) is called, within this method, CommCare loops through all case list properties of each case and retrieves data by using [getNormalizedField()](https://github.com/dimagi/commcare-core/blob/7cc09320ce920bf89b7b43255fd8850fb6c172c7/src/main/java/org/commcare/util/EntitySortUtil.java#L39). In the AsyncEntity implementation, this method calls [getSortField()](https://github.com/dimagi/commcare-core/blob/7cc09320ce920bf89b7b43255fd8850fb6c172c7/src/main/java/org/commcare/cases/entity/AsyncEntity.java#L126) which is supposed to return previously loaded sort data or retrieve it from the cache, and here lies the issue, when a [value exists](https://github.com/dimagi/commcare-core/blob/7cc09320ce920bf89b7b43255fd8850fb6c172c7/src/main/java/org/commcare/cases/entity/AsyncEntity.java#L138), the [method returns _null_](https://github.com/dimagi/commcare-core/blob/7cc09320ce920bf89b7b43255fd8850fb6c172c7/src/main/java/org/commcare/cases/entity/AsyncEntity.java#L180) instead of the existing value, causing the entire list to be _empty_. It seems that during a [previous refactoring work](https://github.com/dimagi/commcare-android/pull/2732/files#diff-d476e37c4974d18e4f48dbf935a5462cf5437dbc4e18ae41e3685044cda98c9d), the sort field was mistakenly set to default to `null`, this PR corrects that. 

Ticket: https://dimagi.atlassian.net/browse/SUPPORT-22191

## Safety Assurance

### Safety story
Not applicable, maybe a note to QA to ensure that this is included in the scope of the Regression tests plan.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations.

### Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
