### PR TITLE
update duplication instructions to merge the PR first to avoid errors

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -8,7 +8,7 @@ We try to keep both these branches in sync with each other the best we can. To d
 
 1. If you are working on a Formplayer change, you will want to start by checking out `your_feature_branch` from `formplayer` as the base branch. Make changes on `your_feature_branch` and create your original PR against `formplayer` branch.
 
-2. Now you will need to duplicate this PR by making another PR against `master`. Make sure the branch for this PR is not deleted. Then create the comment `duplicate this PR`. If the PR has already been merged, comment `duplicate this PR <starting-commit-id> <ending-commit-id>`. The `ending-commit-id` should be the last non-merge commit in the PR. This should result in a Github Actions workflow duplicating your PR against `master`. Go to the duplicate PR, close and re-open it to run the Github checks against it.
+2. Now you will need to duplicate this PR by making another PR against `master`. Make sure the branch for this PR is is merged and is not deleted. Then create the comment `duplicate this PR <starting-commit-id> <ending-commit-id>`. The `ending-commit-id` should be the last non-merge commit in the PR. This should result in a Github Actions workflow duplicating your PR against `master`. Go to the duplicate PR, close and re-open it to run the Github checks against it.
 
 3. In order for us to test that your PR against `master` doesn't break anything on CommCare Android, you need to run android side tests with your PR.
 To do this - 
@@ -23,7 +23,7 @@ To do this -
 
 1. If you are working on a CommCare Android change, you will want to start by checking out `your_feature_branch` from `master` as the base branch. Make changes on `your_feature_branch` and create your original PR against `master` branch.
 
-2. Now you will need to duplicate this PR by making another PR against `formplayer`. Make sure the branch for this PR is not deleted. Then create the comment `duplicate this PR`. If the PR has already been merged, comment `duplicate this PR <starting-commit-id> <ending-commit-id>`. The `ending-commit-id` should be the last non-merge commit in the PR. This should result in a Github Actions workflow duplicating your PR against `formplayer`. Go to the duplicate PR, close and re-open it to run the Github checks against it.
+2. Now you will need to duplicate this PR by making another PR against `formplayer`. Make sure the branch for this PR is is merged and is not deleted. Then create the comment `duplicate this PR <starting-commit-id> <ending-commit-id>`. The `ending-commit-id` should be the last non-merge commit in the PR. This should result in a Github Actions workflow duplicating your PR against `formplayer`. Go to the duplicate PR, close and re-open it to run the Github checks against it.
 
 3. In order for us to test that your PR against `formplayer` doesn't break anything on Formplayer, we need to run formplayer side tests with your PR.
 To do this - 


### PR DESCRIPTION
The starting and ending commit Id is required regardless if PR is merged. Also, clarify instructions to merge the PR first to avoid a stale duplicated PR.