### PR TITLE
Restored 3-input constructor for SessionWrapper (to preserve mobile b…

### DIFF
--- a/src/main/java/org/commcare/modern/session/SessionWrapper.java
+++ b/src/main/java/org/commcare/modern/session/SessionWrapper.java
@@ -41,6 +41,10 @@ public class SessionWrapper extends CommCareSession implements SessionWrapperInt
     public SessionWrapper(CommCareSession session, CommCarePlatform platform, UserSandbox sandbox, String windowWidth) {
         this(session, platform, sandbox, null, windowWidth);
     }
+
+    public SessionWrapper(CommCareSession session, CommCarePlatform platform, UserSandbox sandbox) {
+        this(session, platform, sandbox, null, null);
+    }
     
     public SessionWrapper(CommCarePlatform platform, UserSandbox sandbox) {
         super(platform);


### PR DESCRIPTION
Restored 3-input constructor for SessionWrapper (to preserve mobile build).

This change is to fix the mobile build, after a recent commit changed a constructor for SessionWrapper to take a new field called windowWidth. This field is only stored by the wrapper for later external access, and is never used by the mobile code. So I added a new 3-input constructor that then passes null for the windowWidth.