### PR TITLE
Partially reverse "Make language slug available via session metadata"

### DIFF
--- a/src/cli/java/org/commcare/util/screen/EntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreen.java
@@ -233,12 +233,8 @@ public class EntityScreen extends CompoundScreenHost {
         if (mShortDetail == null) {
             throw new CommCareSessionException("Missing detail definition for: " + detailId);
         }
-        EntityScreenContext context = getEntityScreenContext();
-        String locale = null;
-        if (context != null) {
-            locale = context.getLocale();
-        }
-        evalContext = mSession.getEvaluationContextWithLocale(locale);
+
+        evalContext = mSession.getEvaluationContext();
     }
 
     @Trace

--- a/src/cli/java/org/commcare/util/screen/EntityScreenContext.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreenContext.java
@@ -9,7 +9,6 @@ public class EntityScreenContext extends ScreenContext{
     private final int mSortIndex;
     private final int mCasesPerPage;
     private final String[] mSelectedValues;
-    private final String mLocale;
 
     /**
      * If requesting a case detail will be a case id, else null. When the case id is given it is used to short
@@ -21,14 +20,13 @@ public class EntityScreenContext extends ScreenContext{
     private final boolean fuzzySearch;
 
     public EntityScreenContext(int offset, String searchText, int sortIndex, int casesPerPage,
-            String[] selectedValues, String locale, String detailSelection, boolean isFuzzySearch) {
+            String[] selectedValues, String detailSelection, boolean isFuzzySearch) {
         super(true);
         mOffSet = offset;
         mSearchText = searchText;
         mSortIndex = sortIndex;
         mCasesPerPage = casesPerPage == 0 ? DEFAULT_CASES_PER_PAGE : casesPerPage;
         mSelectedValues = selectedValues;
-        mLocale = locale;
         mDetailSelection = detailSelection;
         fuzzySearch = isFuzzySearch;
     }
@@ -44,7 +42,6 @@ public class EntityScreenContext extends ScreenContext{
         mSortIndex = 0;
         mCasesPerPage = DEFAULT_CASES_PER_PAGE;
         mSelectedValues = null;
-        mLocale = null;
         mDetailSelection = null;
         fuzzySearch = false;
     }
@@ -67,10 +64,6 @@ public class EntityScreenContext extends ScreenContext{
 
     public String[] getSelectedValues() {
         return mSelectedValues;
-    }
-
-    public String getLocale() {
-        return mLocale;
     }
 
     public String getDetailSelection() {

--- a/src/main/java/org/commcare/core/process/CommCareInstanceInitializer.java
+++ b/src/main/java/org/commcare/core/process/CommCareInstanceInitializer.java
@@ -74,7 +74,7 @@ public class CommCareInstanceInitializer extends InstanceInitializationFactory {
 
     @Override
     @Nonnull
-    public InstanceRoot generateRoot(ExternalDataInstance instance, String locale) {
+    public InstanceRoot generateRoot(ExternalDataInstance instance) {
         String ref = instance.getReference();
         if (ref.contains(LedgerInstanceTreeElement.MODEL_NAME)) {
             return setupLedgerData(instance);
@@ -83,7 +83,7 @@ public class CommCareInstanceInitializer extends InstanceInitializationFactory {
         } else if (ref.contains("fixture")) {
             return setupFixtureData(instance);
         } else if (instance.getReference().contains("session")) {
-            return setupSessionData(instance, locale);
+            return setupSessionData(instance);
         } else if (ref.startsWith(ExternalDataInstance.JR_REMOTE_REFERENCE)) {
             return setupExternalDataInstance(instance, ref, SessionFrame.STATE_QUERY_REQUEST);
         } else if (ref.startsWith(JR_SELECTED_ENTITIES_REFERENCE)) {
@@ -236,7 +236,7 @@ public class CommCareInstanceInitializer extends InstanceInitializationFactory {
         }
     }
 
-    protected InstanceRoot setupSessionData(ExternalDataInstance instance, String locale) {
+    protected InstanceRoot setupSessionData(ExternalDataInstance instance) {
         if (this.mPlatform == null) {
             throw new RuntimeException("Cannot generate session instance with undeclared platform!");
         }
@@ -244,13 +244,17 @@ public class CommCareInstanceInitializer extends InstanceInitializationFactory {
         TreeElement root =
                 SessionInstanceBuilder.getSessionInstance(sessionWrapper.getFrame(), getDeviceId(),
                         getVersionString(), getCurrentDrift(), u.getUsername(), u.getUniqueId(),
-                        u.getProperties(), getWindowWidth(), locale);
+                        u.getProperties(), getWindowWidth(), getLocale());
         root.setParent(instance.getBase());
         return new ConcreteInstanceRoot(root);
     }
 
     protected String getWindowWidth() {
         return sessionWrapper.getWindowWidth();
+    }
+
+    protected String getLocale() {
+        return Localization.getCurrentLocale();
     }
 
     protected long getCurrentDrift() {

--- a/src/main/java/org/commcare/modern/session/SessionWrapper.java
+++ b/src/main/java/org/commcare/modern/session/SessionWrapper.java
@@ -63,14 +63,10 @@ public class SessionWrapper extends CommCareSession implements SessionWrapperInt
         return getEvaluationContext(getIIF());
     }
 
-    public EvaluationContext getEvaluationContextWithLocale(String locale) {
-        return getEvaluationContext(getIIF(), locale);
-    }
-
     @Override
     public EvaluationContext getRestrictedEvaluationContext(String commandId,
                                                             Set<String> instancesToInclude) {
-        return getEvaluationContext(getIIF(), commandId, instancesToInclude, null);
+        return getEvaluationContext(getIIF(), commandId, instancesToInclude);
     }
 
     @Override
@@ -85,7 +81,7 @@ public class SessionWrapper extends CommCareSession implements SessionWrapperInt
      * @return The evaluation context relevant for the provided command id
      */
     public EvaluationContext getEvaluationContext(String commandId) {
-        return getEvaluationContext(getIIF(), commandId, null, null);
+        return getEvaluationContext(getIIF(), commandId, null);
     }
 
     public CommCareInstanceInitializer getIIF() {

--- a/src/main/java/org/commcare/session/CommCareSession.java
+++ b/src/main/java/org/commcare/session/CommCareSession.java
@@ -614,11 +614,7 @@ public class CommCareSession {
      * @return Evaluation context for current session state
      */
     public EvaluationContext getEvaluationContext(InstanceInitializationFactory iif) {
-        return this.getEvaluationContext(iif, getCommand(), null, null);
-    }
-
-    public EvaluationContext getEvaluationContext(InstanceInitializationFactory iif, String locale) {
-        return this.getEvaluationContext(iif, getCommand(), null, locale);
+        return this.getEvaluationContext(iif, getCommand(), null);
     }
 
     /**
@@ -630,8 +626,7 @@ public class CommCareSession {
      */
     public EvaluationContext getEvaluationContext(InstanceInitializationFactory iif,
             String command,
-            Set<String> instancesToInclude,
-            String locale) {
+            Set<String> instancesToInclude) {
         if (command == null) {
             return new EvaluationContext(null);
         }
@@ -666,7 +661,7 @@ public class CommCareSession {
 
         for (Enumeration en = instancesInScope.keys(); en.hasMoreElements(); ) {
             String key = (String)en.nextElement();
-            instancesInScope.put(key, instancesInScope.get(key).initialize(iif, key, locale));
+            instancesInScope.put(key, instancesInScope.get(key).initialize(iif, key));
         }
         addInstancesFromFrame(instancesInScope, iif);
 

--- a/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/src/main/java/org/javarosa/core/model/FormDef.java
@@ -1451,7 +1451,7 @@ public class FormDef implements IFormElement, IMetaData,
         for (Enumeration en = formInstances.keys(); en.hasMoreElements(); ) {
             String instanceId = (String)en.nextElement();
             DataInstance instance = formInstances.get(instanceId);
-            formInstances.put(instanceId, instance.initialize(factory, instanceId, null));
+            formInstances.put(instanceId, instance.initialize(factory, instanceId));
         }
         setEvaluationContext(this.exprEvalContext);
 

--- a/src/main/java/org/javarosa/core/model/instance/DataInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/DataInstance.java
@@ -279,7 +279,7 @@ public abstract class DataInstance<T extends AbstractTreeElement<T>> implements 
         this.recordid = recordid;
     }
 
-    public abstract DataInstance initialize(InstanceInitializationFactory initializer, String instanceId, String locale);
+    public abstract DataInstance initialize(InstanceInitializationFactory initializer, String instanceId);
 
     public CacheHost getCacheHost() {
         return mCacheHost;

--- a/src/main/java/org/javarosa/core/model/instance/ExternalDataInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/ExternalDataInstance.java
@@ -137,17 +137,13 @@ public class ExternalDataInstance extends DataInstance {
     }
 
     @Override
-    public DataInstance initialize(InstanceInitializationFactory initializer, String instanceId, String locale) {
+    public DataInstance initialize(InstanceInitializationFactory initializer, String instanceId) {
         base = new InstanceBase(instanceId);
-        InstanceRoot instanceRoot = initializer.generateRoot(this, locale);
+        InstanceRoot instanceRoot = initializer.generateRoot(this);
         // this indirectly calls `this.copyFromSource` via the InstanceRoot so that we call the
         // correct method based on the type
         instanceRoot.setupNewCopy(this);
         return initializer.getSpecializedExternalDataInstance(this);
-    }
-
-    public DataInstance initialize(InstanceInitializationFactory initializer, String instanceId) {
-        return initialize(initializer, instanceId, null);
     }
 
     public void copyFromSource(InstanceRoot instanceRoot) {

--- a/src/main/java/org/javarosa/core/model/instance/FormInstance.java
+++ b/src/main/java/org/javarosa/core/model/instance/FormInstance.java
@@ -245,15 +245,11 @@ public class FormInstance extends DataInstance<TreeElement> implements Persistab
     }
 
     @Override
-    public DataInstance initialize(InstanceInitializationFactory initializer, String instanceId, String locale) {
+    public DataInstance initialize(InstanceInitializationFactory initializer, String instanceId) {
         this.instanceid = instanceId;
         root.setInstanceName(instanceId);
 
         return this;
-    }
-
-    public DataInstance initialize(InstanceInitializationFactory initializer, String instanceId) {
-        return initialize(initializer, instanceId, null);
     }
 
     @Override

--- a/src/main/java/org/javarosa/core/model/instance/InstanceInitializationFactory.java
+++ b/src/main/java/org/javarosa/core/model/instance/InstanceInitializationFactory.java
@@ -17,7 +17,7 @@ public class InstanceInitializationFactory {
     }
 
     @Nonnull
-    public InstanceRoot generateRoot(ExternalDataInstance instance, String locale) {
+    public InstanceRoot generateRoot(ExternalDataInstance instance) {
         return ConcreteInstanceRoot.NULL;
     }
 }

--- a/src/test/java/org/commcare/backend/suite/model/test/QueryModelTests.java
+++ b/src/test/java/org/commcare/backend/suite/model/test/QueryModelTests.java
@@ -78,12 +78,12 @@ public class QueryModelTests {
         // test loading instance with new ref
         ExternalDataInstance instance = new ExternalDataInstance("jr://instance/search-input/registry1",
                 "custom-id");
-        Assert.assertNotNull(session.getIIF().generateRoot(instance, null).getRoot());
+        Assert.assertNotNull(session.getIIF().generateRoot(instance).getRoot());
 
         // test that we can still load instances using the legacy ref
         ExternalDataInstance legacyInstance = new ExternalDataInstance("jr://instance/search-input",
                 "search-input:registry1");
-        Assert.assertNotNull(session.getIIF().generateRoot(legacyInstance, null).getRoot());
+        Assert.assertNotNull(session.getIIF().generateRoot(legacyInstance).getRoot());
     }
 
     @NotNull

--- a/src/test/java/org/commcare/test/utilities/TestInstanceInitializer.java
+++ b/src/test/java/org/commcare/test/utilities/TestInstanceInitializer.java
@@ -31,7 +31,7 @@ public class TestInstanceInitializer extends InstanceInitializationFactory {
     }
 
     @Override
-    public InstanceRoot generateRoot(ExternalDataInstance instance, String locale) {
+    public InstanceRoot generateRoot(ExternalDataInstance instance) {
         String ref = instance.getReference();
         if (ref.contains(CaseInstanceTreeElement.MODEL_NAME)) {
             CaseInstanceTreeElement root = new CaseInstanceTreeElement(instance.getBase(), sandbox.getCaseStorage());

--- a/src/test/java/org/javarosa/core/model/instance/test/DummyInstanceInitializationFactory.java
+++ b/src/test/java/org/javarosa/core/model/instance/test/DummyInstanceInitializationFactory.java
@@ -18,7 +18,7 @@ public class DummyInstanceInitializationFactory extends InstanceInitializationFa
         return instance;
     }
     @Override
-    public InstanceRoot generateRoot(ExternalDataInstance instance, String locale) {
+    public InstanceRoot generateRoot(ExternalDataInstance instance) {
         throw new RuntimeException("Loading external instances isn't supported " +
                 "using this instance initialization factory.");
     }

--- a/src/translate/java/org/javarosa/engine/MockupProviderFactory.java
+++ b/src/translate/java/org/javarosa/engine/MockupProviderFactory.java
@@ -29,7 +29,7 @@ public class MockupProviderFactory extends InstanceInitializationFactory {
     }
 
     @Override
-    public InstanceRoot generateRoot(ExternalDataInstance instance, String locale) {
+    public InstanceRoot generateRoot(ExternalDataInstance instance) {
         String ref = instance.getReference();
 
         if(instances.containsKey(ref)) {


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->

Users will still be able to reference the current screen's language slug using `instance('commcaresession')/session/context/applanguage`

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->

Shubham pointed out there is an existing function `Localization.getCurrentLocale()` that eliminates the need for convoluted ways to pass along the locale value from the initial `BaseResponseBean`.

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

Tested locally and on staging. No data impact as the metadata refreshes with every navigation request. 

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

Will have delivery try out their tests once more before merging. 

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
