### PR TITLE
Fix menu instances Accumulation for menus with same ids

### DIFF
--- a/src/main/java/org/commcare/session/CommCareSession.java
+++ b/src/main/java/org/commcare/session/CommCareSession.java
@@ -633,7 +633,6 @@ public class CommCareSession {
         Vector<Entry> entries = getEntriesForCommand(command);
         Vector<Menu> menus = getMenusForCommand(command);
 
-        Menu menu = null;
         Entry entry = null;
         Hashtable<String, DataInstance> instancesInScope = new Hashtable<>();
         Hashtable<String, DataInstance> menuInstances = null;
@@ -649,8 +648,7 @@ public class CommCareSession {
             }
         }
 
-        if (!menus.isEmpty()) {
-            menu = menus.elementAt(0);
+        for (Menu menu : menus) {
             if (menu != null) {
                 menuInstances = menu.getInstances(instancesToInclude);
             }

--- a/src/test/java/org/commcare/backend/session/test/MenuTests.java
+++ b/src/test/java/org/commcare/backend/session/test/MenuTests.java
@@ -2,7 +2,10 @@ package org.commcare.backend.session.test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
+import org.commcare.modern.session.SessionWrapper;
+import org.commcare.session.CommCareSession;
 import org.commcare.suite.model.AssertionSet;
 import org.commcare.suite.model.Menu;
 import org.commcare.suite.model.Suite;
@@ -11,6 +14,8 @@ import org.commcare.test.utilities.MockApp;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.List;
 
 /**
  * Tests for assertions in menus
@@ -35,5 +40,19 @@ public class MenuTests {
         Text assertionFailures = assertions.getAssertionFailure(ec);
         assertNotNull(assertions);
         assertEquals("custom_assertion.m0.0", assertionFailures.getArgument());
+    }
+
+    /**
+     * When there are multiple menu blocks with same ids, we should accumulate the required instances from all
+     * of the menus and their contained entries
+     */
+    @Test
+    public void testMenuInstances_WhenMenuHaveSameIds() {
+        SessionWrapper currentSession = appWithMenuAssertions.getSession();
+        EvaluationContext ec = currentSession.getEvaluationContext(currentSession.getIIF(), "m3", null);
+        List<String> instanceIds = ec.getInstanceIds();
+        assertEquals(2, instanceIds.size());
+        assertTrue(instanceIds.contains("my_instance"));
+        assertTrue(instanceIds.contains("casedb"));
     }
 }

--- a/src/test/resources/app_structure/suite.xml
+++ b/src/test/resources/app_structure/suite.xml
@@ -244,9 +244,10 @@
     <text>Menu</text>
     <command id="m0-f0"/>
   </menu>
-  <menu id="m3">
+  <menu id="m3" relevant="count(instance('my_instance'))>0">
     <text>Menu</text>
     <command id="m0-f1"/>
+    <instance id="my_instance" src="my_instance_source"/>
   </menu>
   <endpoint id="case_list" respect-relevancy="false">
     <argument id="selected_cases" instance-id="selected_cases" instance-src="jr://instance/selected-entities"/>


### PR DESCRIPTION
## Product Description

https://dimagi.atlassian.net/browse/SC-3993

Fixes a regression with CommCare 2.54 that caused incorrect menu instances evaluation when there are multiple menus with same id in the suite.xml

## Technical Summary

This is a regression that was introduced with custom assertions work ([FP](https://github.com/dimagi/commcare-core/pull/1267) and [HQ](https://github.com/dimagi/commcare-hq/pull/32842)) which re-organised how we define instances for menus in suite.xml. With these changes, we were only looking for menu instances in the first menu with a specific id. So if there is a suite config like below - 

````
<menu id="root" relevant="instance('casedb')/casedb/case[@case_type ='commcare-user']/date_of_last_submission != today()" style="grid">
    <text>
      <locale id="modules.m0"/>
    </text>
    <command id="m0-f0"/>
    <instance id="casedb" src="jr://instance/casedb"/>
</menu>

<menu id="root" relevant="instance('item-list:polio_app_settings')/polio_app_settings_list/polio_app_settings[ID = 'settings']/show_registration = 1" style="grid">    
    <command id="m1-f0"/>
    <instance id="casedb" src="jr://instance/casedb"/>
    <instance id="item-list:polio_app_settings" src="jr://fixture/item-list:polio_app_settings"/>
</menu>
````

while evaluating the relevant condition for second menu with `instance('item-list:polio_app_settings')`, we were only adding instances from the first menu (casedb) and skipping the instances from relevant menu resulting into an instance not found error. 

This PR makes a change to look for instances in all menus with a given command id and not only the first one.

## Safety Assurance

### Safety story

- This is an additive change which adds more instances to the eval context which should not have any side effects while calculating xpath.  I am not worried about performance either with this change as the code to populate instance should be a quick O(n) loop without any exponentiality. 

- Tested Locally that the change indeed fix the issue described in the JIra linked above. 

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

PR adds a test to verify the issue

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
No QA
### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).
