### PR TITLE
Performance fix for Case List Loading with Cache enabled

### DIFF
--- a/src/main/java/org/commcare/cases/entity/AsyncNodeEntityFactory.java
+++ b/src/main/java/org/commcare/cases/entity/AsyncNodeEntityFactory.java
@@ -157,7 +157,9 @@ public class AsyncNodeEntityFactory extends NodeEntityFactory {
                 if (foregroundWithoutLazyLoading || (foregroundWithLazyLoading && !field.isLazyLoading()) || (
                         inBackground && field.isCacheEnabled())) {
                     e.getField(col);
-                    e.getSortField(col);
+                    if (field.getSort() != null) {
+                        e.getSortField(col);
+                    }
                 }
             }
             if (i % 100 == 0) {


### PR DESCRIPTION
## Technical Summary

https://dimagi.atlassian.net/browse/SC-4402

Calling `getSortField` for detail fields without a sort block results into un-needed calculations for the sort field resulting in a performance downside for case list loads. 

## Safety Assurance

### Safety story

Behind Cache and Lazy Load feature flag, small change
Tested that sorting works correctly after this change


### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced data sorting behavior to apply ordering only when valid criteria are defined. This change helps prevent unnecessary processing and improves overall efficiency and reliability in how data is organized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->