### PR TITLE
Removes db lock from Async Entity to fix a deadlock

### DIFF
--- a/src/main/java/org/commcare/cases/entity/AsyncEntity.java
+++ b/src/main/java/org/commcare/cases/entity/AsyncEntity.java
@@ -17,8 +17,6 @@ import org.javarosa.xpath.expr.FunctionUtils;
 import org.javarosa.xpath.expr.XPathExpression;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
-import java.io.Closeable;
-import java.io.IOException;
 import java.util.Enumeration;
 import java.util.Hashtable;
 
@@ -59,15 +57,7 @@ public class AsyncEntity extends Entity<TreeReference> {
     private final EntityStorageCache mEntityStorageCache;
 
     /*
-     * the Object's lock. NOTE: _DO NOT LOCK ANY CODE WHICH READS/WRITES THE CACHE
-     * UNTIL YOU HAVE A LOCK FOR THE DB!
-     * 
-     * The lock is for the integrity of this object, not the larger environment, 
-     * and any DB access has its own implict lock between threads, so it's easy
-     * to accidentally deadlock if you don't already have the db lock
-     * 
-     * Basically you should never be calling mEntityStorageCache from inside of
-     * a lock that 
+     * the Object's lock for the integrity of this object
      */
     private final Object mAsyncLock = new Object();
 
@@ -118,32 +108,25 @@ public class AsyncEntity extends Entity<TreeReference> {
                 data[i] = evaluateField(i);
                 return data[i];
             }
-        }
-        try (Closeable ignored = mEntityStorageCache != null ? mEntityStorageCache.lockCache() : null) {
-            synchronized (mAsyncLock) {
-                if (data[i] == null) {
-                    String cacheKey = null;
-                    if (mEntityStorageCache != null && mCacheIndex != null) {
-                        cacheKey = mEntityStorageCache.getCacheKey(mDetailId, String.valueOf(i), TYPE_NORMAL_FIELD);
-                        // Return from the cache if we have a value
-                        String value = mEntityStorageCache.retrieveCacheValue(mCacheIndex, cacheKey);
-                        if (value != null) {
-                            data[i] = value;
-                            return data[i];
-                        }
-                    }
-                    // Otherwise evaluate, cache and return the value
-                    data[i] = evaluateField(i);
-                    if (mEntityStorageCache != null && mCacheIndex != null) {
-                        mEntityStorageCache.cache(mCacheIndex, cacheKey, String.valueOf(data[i]));
+            String cacheKey = null;
+            if (data[i] == null) {
+                if (mEntityStorageCache != null && mCacheIndex != null) {
+                    cacheKey = mEntityStorageCache.getCacheKey(mDetailId, String.valueOf(i),
+                            TYPE_NORMAL_FIELD);
+                    // Return from the cache if we have a value
+                    String value = mEntityStorageCache.retrieveCacheValue(mCacheIndex, cacheKey);
+                    if (value != null) {
+                        data[i] = value;
+                        return data[i];
                     }
                 }
-                return data[i];
             }
-        } catch (IOException e) {
-            Logger.exception("Error while getting field", e);
+            data[i] = evaluateField(i);
+            if (mEntityStorageCache != null && mCacheIndex != null) {
+                mEntityStorageCache.cache(mCacheIndex, cacheKey, String.valueOf(data[i]));
+            }
         }
-        return null;
+        return data[i];
     }
 
     private Object evaluateField(int i) {
@@ -178,43 +161,37 @@ public class AsyncEntity extends Entity<TreeReference> {
                 evaluateSortData(i);
                 return sortData[i];
             }
-        }
-        try (Closeable ignored = mEntityStorageCache != null ? mEntityStorageCache.lockCache() : null) {
-            //get our second lock.
-            synchronized (mAsyncLock) {
-                if (sortData[i] == null) {
-                    Text sortText = fields[i].getSort();
-                    if (sortText == null) {
-                        return null;
+
+            String cacheKey = null;
+            if (sortData[i] == null) {
+                Text sortText = fields[i].getSort();
+                if (sortText == null) {
+                    return null;
+                }
+
+                if (mEntityStorageCache != null) {
+                    if (cacheEnabled) {
+                        cacheKey = mEntityStorageCache.getCacheKey(mDetailId, String.valueOf(i),
+                                TYPE_SORT_FIELD);
+                    } else {
+                        // old cache and index
+                        cacheKey = i + "_" + TYPE_SORT_FIELD;
                     }
-                    String cacheKey;
-                    if (mEntityStorageCache != null) {
-                        if (cacheEnabled) {
-                            cacheKey = mEntityStorageCache.getCacheKey(mDetailId, String.valueOf(i),
-                                    TYPE_SORT_FIELD);
-                        } else {
-                            // old cache and index
-                            cacheKey = i + "_" + TYPE_SORT_FIELD;
+                    if (mCacheIndex != null) {
+                        //Check the cache!
+                        String value = mEntityStorageCache.retrieveCacheValue(mCacheIndex, cacheKey);
+                        if (value != null) {
+                            this.setSortData(i, value);
+                            return sortData[i];
                         }
-                        if (mCacheIndex != null) {
-                            //Check the cache!
-                            String value = mEntityStorageCache.retrieveCacheValue(mCacheIndex, cacheKey);
-                            if (value != null) {
-                                this.setSortData(i, value);
-                                return sortData[i];
-                            }
-                            // sort data not in search field cache; load and store it
-                            evaluateSortData(i);
-                            mEntityStorageCache.cache(mCacheIndex, cacheKey, sortData[i]);
-                        }
+
                     }
                 }
-                return sortData[i];
             }
-        } catch (IOException e) {
-            Logger.exception("Error while getting sort field", e);
+            evaluateSortData(i);
+            mEntityStorageCache.cache(mCacheIndex, cacheKey, sortData[i]);
+            return sortData[i];
         }
-        return null;
     }
 
     private void evaluateSortData(int i) {
@@ -331,7 +308,7 @@ public class AsyncEntity extends Entity<TreeReference> {
     @Override
     public String getGroupKey() {
         if (mDetailGroup != null) {
-            return  (String)mDetailGroup.getFunction().eval(context);
+            return (String)mDetailGroup.getFunction().eval(context);
         }
         return null;
     }

--- a/src/main/java/org/commcare/cases/entity/AsyncEntity.java
+++ b/src/main/java/org/commcare/cases/entity/AsyncEntity.java
@@ -189,7 +189,9 @@ public class AsyncEntity extends Entity<TreeReference> {
                 }
             }
             evaluateSortData(i);
-            mEntityStorageCache.cache(mCacheIndex, cacheKey, sortData[i]);
+            if (mEntityStorageCache != null && mCacheIndex != null) {
+                mEntityStorageCache.cache(mCacheIndex, cacheKey, sortData[i]);
+            }
             return sortData[i];
         }
     }


### PR DESCRIPTION
## Product Description

https://dimagi.atlassian.net/browse/SC-4427

Bug fix: Loading up cache in a background thread causes a deadlock when any other thread is evaluating Xpath expressions involving the user database. 

## Technical Summary
On calling evaluate on Xpath expression involving `instance(casedb)`, the general order of locking currently is  

- [db lock](https://github.com/dimagi/commcare-core/blob/master/src/main/java/org/commcare/cases/entity/AsyncEntity.java#L122)
- [Async Entity Local lock](https://github.com/dimagi/commcare-core/blob/master/src/main/java/org/commcare/cases/entity/AsyncEntity.java#L123)
- [xpath cache lock](https://github.com/dimagi/commcare-core/blob/master/src/main/java/org/commcare/cases/instance/StorageBackedChildElement.java)
- implicit db access lock in the [SqlStorage layer](https://github.com/dimagi/commcare-android/blob/master/app/src/org/commcare/models/database/SqlStorage.java#L465) triggered by Sqlite Cursor manipulation (eg. Cursor.close) 

Now when another process calls eval on another Xpath expression with instance('casedb') the locking order is - 
- [xpath cache lock](https://github.com/dimagi/commcare-core/blob/master/src/main/java/org/commcare/cases/instance/StorageBackedChildElement.java)
- implicit db access lock

This causes a deadlock given the two threads get locks on Xpath cache and db in different relative orders.

Example thread dump:

Thread 1: Background worker to prime cache

````
androidx.work-2@34407" prio=5 tid=0x5f nid=NA waiting for monitor entry
  java.lang.Thread.State: BLOCKED
	 waiting for AsyncTask #4@35031 to release lock on <0x890a> (a org.javarosa.core.util.Interner)
	  at org.commcare.cases.instance.CaseChildElement.cache(CaseChildElement.java:89)
	  at org.commcare.cases.instance.CaseChildElement.prepareForUseInCurrentContext(CaseChildElement.java:282)
	  at org.commcare.cases.util.QueryUtils.prepareSensitiveObjectForUseInCurrentContext(QueryUtils.java:37)
	  at org.javarosa.core.model.instance.DataInstance.resolveReference(DataInstance.java:105)
	  at org.javarosa.xpath.expr.XPathPathExpr.getRefValue(XPathPathExpr.java:232)
	  at org.javarosa.xpath.XPathLazyNodeset.unpack(XPathLazyNodeset.java:103)
	  - locked <0x890c> (a java.lang.Object)
	  at org.javarosa.xpath.expr.FunctionUtils.unpack(FunctionUtils.java:429)
	  at org.commcare.cases.util.StorageBackedTreeRoot.collectNativePredicateProfiles(StorageBackedTreeRoot.java:150)
	  at org.commcare.cases.util.StorageBackedTreeRoot.tryBatchChildFetch(StorageBackedTreeRoot.java:104)
	  at org.javarosa.core.model.condition.EvaluationContext.expandReferenceAccumulator(EvaluationContext.java:383)
	  at org.javarosa.core.model.condition.EvaluationContext.expandReference(EvaluationContext.java:328)
	  at org.javarosa.core.model.condition.EvaluationContext.expandReference(EvaluationContext.java:303)
	  at org.javarosa.xpath.XPathLazyNodeset.performEvaluation(XPathLazyNodeset.java:49)
	  - locked <0x890d> (a java.lang.Object)
	  at org.javarosa.xpath.XPathLazyNodeset.unpack(XPathLazyNodeset.java:94)
	  at org.javarosa.xpath.expr.FunctionUtils.unpack(FunctionUtils.java:429)
	  at org.javarosa.xpath.expr.FunctionUtils.toString(FunctionUtils.java:307)
	  at org.javarosa.xpath.expr.XPathStringFunc.evalBody(XPathStringFunc.java:22)
	  at org.javarosa.xpath.expr.XPathFuncExpr.evalRaw(XPathFuncExpr.java:55)
	  at org.javarosa.xpath.expr.XPathExpression.eval(XPathExpression.java:44)
	  at org.commcare.suite.model.Text.evaluate(Text.java:315)
	  at org.commcare.suite.model.Text.evaluate(Text.java:311)
	  at org.commcare.suite.model.Text.evaluate(Text.java:54)
	  at org.commcare.cases.entity.AsyncEntity.evaluateField(AsyncEntity.java:152)
	  at org.commcare.cases.entity.AsyncEntity.getField(AsyncEntity.java:136)
 ````
 
 Thread 2: Normal Entity List without caching enabled loading case list in an Async Task:
 
 ````
 "AsyncTask #4@35031" prio=5 tid=0x65 nid=NA waiting
  java.lang.Thread.State: WAITING
	 blocks Thread-4@33479
	 blocks androidx.work-2@34407
	  at jdk.internal.misc.Unsafe.park(Unsafe.java:-1)
	  at java.util.concurrent.locks.LockSupport.park(LockSupport.java:211)
	  at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:715)
	  at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:938)
	  at java.util.concurrent.locks.ReentrantLock$Sync.lock(ReentrantLock.java:153)
	  at java.util.concurrent.locks.ReentrantLock.lock(ReentrantLock.java:322)
	  at net.sqlcipher.database.SQLiteDatabase.lock(SQLiteDatabase.java:570)
	  at net.sqlcipher.database.SQLiteProgram.close(SQLiteProgram.java:329)
	  at net.sqlcipher.database.SQLiteCursor.close(SQLiteCursor.java:553)
	  at android.database.CursorWrapper.close(CursorWrapper.java:55)
	  at org.commcare.models.database.SqlStorage.readBytes(SqlStorage.java:473)
	  at org.commcare.models.database.SqlStorage.read(SqlStorage.java:460)
	  at org.commcare.models.database.SqlStorage.read(SqlStorage.java:44)
	  at org.commcare.cases.instance.StorageInstanceTreeElement.getElementSingular(StorageInstanceTreeElement.java:343)
	  at org.commcare.cases.instance.StorageInstanceTreeElement.getElement(StorageInstanceTreeElement.java:316)
	  at org.commcare.cases.instance.CaseChildElement.cache(CaseChildElement.java:100)
	  - locked <0x890a> (a org.javarosa.core.util.Interner)
	  at org.commcare.cases.instance.CaseChildElement.prepareForUseInCurrentContext(CaseChildElement.java:282)
	  at org.commcare.cases.util.QueryUtils.prepareSensitiveObjectForUseInCurrentContext(QueryUtils.java:37)
	  at org.javarosa.core.model.instance.DataInstance.resolveReference(DataInstance.java:105)
	  at org.javarosa.xpath.expr.XPathPathExpr.getRefValue(XPathPathExpr.java:232)
	  at org.javarosa.xpath.XPathLazyNodeset.unpack(XPathLazyNodeset.java:103)
	  - locked <0x8910> (a java.lang.Object)
	  at org.javarosa.xpath.expr.FunctionUtils.unpack(FunctionUtils.java:429)
	  at org.javarosa.xpath.expr.FunctionUtils.toString(FunctionUtils.java:307)
	  at org.javarosa.xpath.expr.XPathStringFunc.evalBody(XPathStringFunc.java:22)
	  at org.javarosa.xpath.expr.XPathFuncExpr.evalRaw(XPathFuncExpr.java:55)
	  at org.javarosa.xpath.expr.XPathExpression.eval(XPathExpression.java:44)
	  at org.commcare.suite.model.Text.evaluate(Text.java:315)
	  at org.commcare.suite.model.Text.evaluate(Text.java:54)
	  at org.commcare.cases.entity.NodeEntityFactory.getEntity(NodeEntityFactory.java:68)
````

## Safety Assurance

I am a little concerned with the original code explicitly asking to lock the db before getting the async lock as a way to prevent deadlocks here. I am mostly relying on self testing, qa testing and reviewer's input here to be able to derisk and catch anything I might be missing here. 

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan

https://dimagi.atlassian.net/browse/QA-7864

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified internal cache access and synchronization for improved maintainability and thread safety.
	- Removed redundant locking and exception handling for more streamlined operations.

- **Style**
	- Minor formatting improvements for cleaner code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->