### PR TITLE
Inline Case Search Breadcrumb Display Bug Fix

### DIFF
--- a/src/cli/java/org/commcare/util/screen/EntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/EntityScreen.java
@@ -1,6 +1,7 @@
 package org.commcare.util.screen;
 
 import org.commcare.cases.entity.EntityUtil;
+import org.commcare.cases.model.Case;
 import org.commcare.cases.query.QueryContext;
 import org.commcare.cases.query.queryset.CurrentModelQuerySet;
 import org.commcare.core.interfaces.UserSandbox;
@@ -18,6 +19,7 @@ import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.model.trace.EvaluationTraceReporter;
 import org.javarosa.core.model.utils.InstrumentationUtils;
+import org.javarosa.core.services.storage.IStorageUtilityIndexed;
 import org.javarosa.core.util.NoLocalizedTextException;
 
 import java.util.Hashtable;
@@ -258,7 +260,9 @@ public class EntityScreen extends CompoundScreenHost {
 
     @Override
     public String getBreadcrumb(String input, UserSandbox sandbox, SessionWrapper session) {
-        String caseName = FormDataUtil.getCaseName(sandbox, input);
+        QueryScreen queryScreen = this.getQueryScreen();
+        IStorageUtilityIndexed<Case> caseSearchStorage = queryScreen != null ? queryScreen.getCaseSearchStorage() : null;
+        String caseName = FormDataUtil.getCaseName(sandbox, caseSearchStorage, input);
         return caseName == null ? ScreenUtils.getBestTitle(session) : caseName;
     }
 

--- a/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
+++ b/src/cli/java/org/commcare/util/screen/MultiSelectEntityScreen.java
@@ -5,6 +5,7 @@ import static org.commcare.xml.SessionDatumParser.DEFAULT_MAX_SELECT_VAL;
 
 import com.google.common.collect.ImmutableMap;
 
+import org.commcare.cases.model.Case;
 import org.commcare.core.interfaces.UserSandbox;
 import org.commcare.core.interfaces.VirtualDataInstanceStorage;
 import org.commcare.data.xml.VirtualInstances;
@@ -20,6 +21,7 @@ import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.ExternalDataInstanceSource;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.services.locale.Localization;
+import org.javarosa.core.services.storage.IStorageUtilityIndexed;
 import org.javarosa.core.util.NoLocalizedTextException;
 
 import javax.annotation.Nonnull;
@@ -230,7 +232,10 @@ public class MultiSelectEntityScreen extends EntityScreen {
             int caseCount = root.getNumChildren();
             if (caseCount > 0) {
                 String caseId = root.getChildAt(0).getValue().getDisplayText();
-                String caseName = FormDataUtil.getCaseName(sandbox, caseId);
+                String caseName = null;
+                QueryScreen queryScreen = this.getQueryScreen();
+                IStorageUtilityIndexed<Case> caseSearchStorage = queryScreen != null ? queryScreen.getCaseSearchStorage() : null;
+                caseName = FormDataUtil.getCaseName(sandbox, caseSearchStorage, caseId);
                 if (caseName != null) {
                     if (caseCount > 1) {
                         return "(" + caseCount + ") " + caseName + ", ...";

--- a/src/cli/java/org/commcare/util/screen/QueryScreen.java
+++ b/src/cli/java/org/commcare/util/screen/QueryScreen.java
@@ -26,7 +26,6 @@ import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.util.NoLocalizedTextException;
 import org.javarosa.core.util.OrderedHashtable;
 import org.javarosa.core.services.storage.IStorageUtilityIndexed;
-import org.commcare.cases.model.Case;
 
 import java.io.InputStream;
 import java.io.PrintStream;
@@ -66,6 +65,8 @@ public class QueryScreen extends Screen {
 
     private boolean dynamicSearch;
     private boolean searchOnClear;
+
+    private IStorageUtilityIndexed<Case> caseSearchStorage;
 
     public QueryScreen(String domainedUsername, String password, PrintStream out,
             VirtualDataInstanceStorage instanceStorage, SessionUtils sessionUtils) {

--- a/src/cli/java/org/commcare/util/screen/QueryScreen.java
+++ b/src/cli/java/org/commcare/util/screen/QueryScreen.java
@@ -9,6 +9,7 @@ import static org.commcare.suite.model.QueryPrompt.INPUT_TYPE_SELECT1;
 
 import com.google.common.collect.Multimap;
 
+import org.commcare.cases.model.Case;
 import org.commcare.core.encryption.CryptUtil;
 import org.commcare.core.interfaces.VirtualDataInstanceStorage;
 import org.commcare.data.xml.VirtualInstances;
@@ -24,6 +25,8 @@ import org.javarosa.core.model.instance.ExternalDataInstanceSource;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.util.NoLocalizedTextException;
 import org.javarosa.core.util.OrderedHashtable;
+import org.javarosa.core.services.storage.IStorageUtilityIndexed;
+import org.commcare.cases.model.Case;
 
 import java.io.InputStream;
 import java.io.PrintStream;
@@ -322,5 +325,13 @@ public class QueryScreen extends Screen {
     @Override
     public String toString() {
         return "QueryScreen[" + mTitle + "]";
+    }
+
+    public void setCaseSearchStorage(IStorageUtilityIndexed<Case> caseSearchStorage) {
+        this.caseSearchStorage = caseSearchStorage;
+    }
+
+    public IStorageUtilityIndexed<Case> getCaseSearchStorage() {
+        return caseSearchStorage;
     }
 }

--- a/src/main/java/org/commcare/util/FormDataUtil.java
+++ b/src/main/java/org/commcare/util/FormDataUtil.java
@@ -10,6 +10,7 @@ import org.commcare.suite.model.StackFrameStep;
 import org.commcare.suite.model.Text;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.core.services.storage.IStorageUtilityIndexed;
 
 /**
  * Use the session state descriptor attached to saved forms to load case
@@ -103,5 +104,25 @@ public class FormDataUtil {
         } catch (Exception e) {
             return null;
         }
+    }
+
+    public static String getCaseName(UserSandbox userSandbox, IStorageUtilityIndexed<Case> caseSearchStorage, String caseId) {
+        String caseName = getCaseName(userSandbox, caseId);
+        if (caseName != null) {
+            return caseName;
+        }
+
+        if (caseSearchStorage != null && caseSearchStorage.isStorageExists()) {
+            try {
+                Case ourCase = caseSearchStorage.getRecordForValue(Case.INDEX_CASE_ID, caseId);
+                if (ourCase != null) {
+                    return ourCase.getName();
+                }
+            } catch (Exception searchException) {
+                return null;
+            }
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->
This fixes a bug where when a module uses "inline case search", the breadcrumb would not display the selected case.

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
[Jira Ticket](https://dimagi.atlassian.net/browse/USH-5823)
[Formplayer PR](https://github.com/dimagi/formplayer/pull/1720)

The theory of why this bug happens is because in “Inline Case Search”, the <post> element is defined within form entry instead of the case list. As a result, case claiming is deferred until form entry, meaning the case is not yet available when trying to resolve the breadcrumb — leading to the exception and incorrect UI behavior.

This solution uses the `caseSearchStorage` to fetch the case name. `caseSearchStorage` is only populated if the app also uses `cc-index-case-search-results` ([docs](https://dimagi.atlassian.net/wiki/spaces/GS/pages/2146607335/Indexing+on+Case+Search+Results)). This means that the bug will continue to be present if the module uses "Inline Case Search" but the app does not use `cc-index-case-search-results`. However, this app property will likely be used with case search.

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
locally tested. It introduces logic to retrieve caseSearchStorage, but includes safeguards for scenarios where it does not exist. In those cases, it will fall back to the pre-existing behavior from before this PR. No changes are made to existing data, and the defect blast radius is limited by maintaining prior logic when new conditions aren't met.

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->
no automated test exists for checking displayed breadcrumb value.

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
[QA-7869](https://dimagi.atlassian.net/browse/QA-7869)

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [X] This PR can be deployed after merge with no further considerations.

### Rollback instructions
The FP PR depends on this so if this is reverted, the FP PR will also need to be reverted.

### Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).