### PR TITLE
text change in contributing.md

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -21,11 +21,12 @@ To do this -
 
 ##### Duplicating A CommCare Android change to Formplayer
 
-1. If you are working on a CommCare Android change, you have to start by checking out `your_feature_branch` from `master` as the base branch. Make changes on `your_feature_branch` and create your original PR against `master` branch. Get it approved and not merge it.
+1. If you are working on a CommCare Android change, you have to start by checking out `your_feature_branch` from `master` as the base branch. Make changes on `your_feature_branch` and create your original PR against `master` branch. Get it approved and do not merge it.
 
 2. Now you will need to duplicate this PR by making another PR against `formplayer`. For this create the comment `duplicate this PR <starting-commit-id> <ending-commit-id>` of the `your_feature_branch`. The `ending-commit-id` should be the last non-merge commit in the PR. This should result in a Github Actions workflow duplicating your PR against `formplayer`. Go to the duplicate PR, close and re-open it to run the Github checks against it.
+3. After creating the successful duplicate PR we can merge the `your_feature_branch` to the `master` of Commcare.
 
-3. In order for us to test that your PR against `formplayer` doesn't break anything on Formplayer, we need to run formplayer side tests with your PR.
+4. In order for us to test that your PR against `formplayer` doesn't break anything on Formplayer, we need to run formplayer side tests with your PR.
 To do this - 
     - Check out a new branch say `test_cc_1189` from `master` in [Formplayer](https://github.com/dimagi/formplayer)
     - Point the submodule in `libs/commcare` to your CommCare Core `your_feature_branch_dupe` branch and push your formplayer branch - 

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -21,9 +21,9 @@ To do this -
 
 ##### Duplicating A CommCare Android change to Formplayer
 
-1. If you are working on a CommCare Android change, you will want to start by checking out `your_feature_branch` from `master` as the base branch. Make changes on `your_feature_branch` and create your original PR against `master` branch.
+1. If you are working on a CommCare Android change, you have to start by checking out `your_feature_branch` from `master` as the base branch. Make changes on `your_feature_branch` and create your original PR against `master` branch. Get it approved and not merge it.
 
-2. Now you will need to duplicate this PR by making another PR against `formplayer`. Make sure the branch for this PR is is merged and is not deleted. Then create the comment `duplicate this PR <starting-commit-id> <ending-commit-id>`. The `ending-commit-id` should be the last non-merge commit in the PR. This should result in a Github Actions workflow duplicating your PR against `formplayer`. Go to the duplicate PR, close and re-open it to run the Github checks against it.
+2. Now you will need to duplicate this PR by making another PR against `formplayer`. For this create the comment `duplicate this PR <starting-commit-id> <ending-commit-id>` of the `your_feature_branch`. The `ending-commit-id` should be the last non-merge commit in the PR. This should result in a Github Actions workflow duplicating your PR against `formplayer`. Go to the duplicate PR, close and re-open it to run the Github checks against it.
 
 3. In order for us to test that your PR against `formplayer` doesn't break anything on Formplayer, we need to run formplayer side tests with your PR.
 To do this - 


### PR DESCRIPTION
## Product Description
Change in the Contributing file with the updated text to create duplicate PR

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [ ] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations.

### Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified instructions for duplicating CommCare Android changes to Formplayer, specifying PR approval steps and updating the process for creating duplicate PRs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->