### PR TITLE
Appends info to crash messaging

### DIFF
--- a/src/main/java/org/javarosa/core/services/Logger.java
+++ b/src/main/java/org/javarosa/core/services/Logger.java
@@ -53,10 +53,15 @@ public class Logger {
 
     public static void exception(String info, Throwable e) {
         e.printStackTrace();
-        log(LogTypes.TYPE_EXCEPTION, (info != null ? info + ": " : "") + WrappedException.printException(e));
+        info = info != null ? info + ": " : "";
+        log(LogTypes.TYPE_EXCEPTION, info + WrappedException.printException(e));
         if (logger != null) {
             try {
-                logger.logException(e);
+                String message = e.getMessage();
+                if (message == null) {
+                    message = "";
+                }
+                logger.logException(new Exception(info + message, e));
             } catch (RuntimeException ex) {
                 logger.panic();
             }


### PR DESCRIPTION
## Product Description

We are loosing the extra info we log into `Logger.exception(info, e)` into Crashlytics messaging, which makes it quite hard to recognise where a particular non-fatal is being logged from in Crashlytics. 

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures exception messages in logs are consistently formatted, even when the original message is missing.
  * Preserves stack traces while improving how related causes are recorded for clearer diagnostics.

* **Refactor**
  * Streamlined error logging to reduce ambiguity in logged messages without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->