### PR TITLE
Bump Retrofit to version 2.9.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     implementation 'commons-cli:commons-cli:1.3.1'
     implementation 'joda-time:joda-time:2.12.1'
     implementation 'com.carrotsearch:hppc:0.9.1'
-    api 'com.squareup.retrofit2:retrofit:2.3.0'
+    api 'com.squareup.retrofit2:retrofit:2.9.0'
     api 'com.squareup.okhttp3:okhttp:4.11.0'
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
     implementation 'io.reactivex.rxjava2:rxjava:2.2.21'
@@ -89,7 +89,7 @@ dependencies {
     cliImplementation 'commons-cli:commons-cli:1.3.1'
     cliImplementation 'joda-time:joda-time:2.9.4'
     cliImplementation 'io.reactivex.rxjava2:rxjava:2.1.1'
-    cliImplementation 'com.squareup.retrofit2:retrofit:2.3.0'
+    cliImplementation 'com.squareup.retrofit2:retrofit:2.9.0'
     cliImplementation 'com.squareup.okhttp3:okhttp:4.11.0'
     cliImplementation 'com.google.guava:guava:31.1-jre'
     cliImplementation 'com.datadoghq:dd-trace-api:1.10.0'
@@ -102,7 +102,7 @@ dependencies {
     testImplementation 'org.json:json:20250517'
     testImplementation 'org.xerial:sqlite-jdbc:3.40.0.0'
     testImplementation 'joda-time:joda-time:2.9.4'
-    testImplementation 'com.squareup.retrofit2:retrofit:2.3.0'
+    testImplementation 'com.squareup.retrofit2:retrofit:2.9.0'
     testImplementation 'com.squareup.okhttp3:okhttp:4.11.0'
     testImplementation 'com.google.guava:guava:31.1-jre'
 
@@ -113,7 +113,7 @@ dependencies {
     ccapiImplementation 'joda-time:joda-time:2.9.4'
     ccapiImplementation 'com.carrotsearch:hppc:0.9.1'
     ccapiImplementation 'io.reactivex.rxjava2:rxjava:2.1.1'
-    ccapiImplementation "com.squareup.retrofit2:retrofit:2.3.0"
+    ccapiImplementation "com.squareup.retrofit2:retrofit:2.9.0"
     ccapiImplementation 'com.squareup.okhttp3:okhttp:4.11.0'
     ccapiImplementation 'com.google.guava:guava:31.1-jre'
     ccapiImplementation 'io.opentracing:opentracing-api:0.33.0'
@@ -127,7 +127,7 @@ dependencies {
     translateImplementation 'joda-time:joda-time:2.9.4'
     translateImplementation 'org.json:json:20250517'
     translateImplementation 'io.reactivex.rxjava2:rxjava:2.1.1'
-    translateImplementation "com.squareup.retrofit2:retrofit:2.3.0"
+    translateImplementation "com.squareup.retrofit2:retrofit:2.9.0"
     translateImplementation 'com.squareup.okhttp3:okhttp:4.11.0'
     translateImplementation 'com.google.guava:guava:31.1-jre'
 


### PR DESCRIPTION
## Product Description
To match the version used in `commcare-android`

## Safety Assurance

### Safety story
No breaking changes between versions 2.3.0 and 2.9.0.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations.

### Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change.

### Duplicate PR
Automatically duplicate this PR as defined in [contributing.md](https://github.com/dimagi/commcare-core/blob/master/.github/contributing.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the underlying networking dependency to a newer version across app modules (application, CLI, tests, and related components) for improved compatibility and reliability.
  - No user-facing changes or new functionality; existing behavior should remain unchanged.
  - Aligns build and test configurations for consistency and future maintainability.
  - Enhances support with modern tooling to reduce potential issues and improve long-term stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->