### PR TITLE
Add an optional storageCacheIdentifier

### DIFF
--- a/src/main/java/org/commcare/cases/instance/CaseInstanceTreeElement.java
+++ b/src/main/java/org/commcare/cases/instance/CaseInstanceTreeElement.java
@@ -56,19 +56,35 @@ public class CaseInstanceTreeElement extends StorageInstanceTreeElement<Case, Ca
     @Nullable
     private final CaseIndexTable caseIndexTable;
 
+    @Nullable
+    private final String storageCacheIdentifier;
+
     //We're storing this here for now because this is a safe lifecycle object that must represent
     //a single snapshot of the case database, but it could be generalized later.
     private Hashtable<String, LinkedHashSet<Integer>> mIndexCache = new Hashtable<>();
 
     public CaseInstanceTreeElement(AbstractTreeElement instanceRoot,
                                    IStorageUtilityIndexed<Case> storage){
-        this(instanceRoot, storage, null);
+        this(instanceRoot, storage, null, null);
     }
 
     public CaseInstanceTreeElement(AbstractTreeElement instanceRoot,
                                    IStorageUtilityIndexed<Case> storage, CaseIndexTable caseIndexTable) {
+        this(instanceRoot, storage, caseIndexTable, null);
+    }
+
+    /**
+     * @param storageCacheIdentifier Optional identifier to distinguish this instance's entries
+     *        in the shared RecordObjectCache from other CaseInstanceTreeElement instances
+     *        (e.g. the case search table name). When null, the cache name is just "casedb".
+     */
+    public CaseInstanceTreeElement(AbstractTreeElement instanceRoot,
+                                   IStorageUtilityIndexed<Case> storage,
+                                   CaseIndexTable caseIndexTable,
+                                   @Nullable String storageCacheIdentifier) {
         super(instanceRoot, storage, MODEL_NAME, "case");
         this.caseIndexTable = caseIndexTable;
+        this.storageCacheIdentifier = storageCacheIdentifier;
     }
 
     @Override
@@ -143,7 +159,10 @@ public class CaseInstanceTreeElement extends StorageInstanceTreeElement<Case, Ca
     }
 
     public String getStorageCacheName() {
-        return CaseInstanceTreeElement.MODEL_NAME;
+        if (storageCacheIdentifier == null || storageCacheIdentifier.isBlank()) {
+            return MODEL_NAME;
+        }
+        return MODEL_NAME + ":" + storageCacheIdentifier;
     }
 
     @Override

--- a/src/test/java/org/commcare/cases/instance/CaseInstanceTreeElementTest.java
+++ b/src/test/java/org/commcare/cases/instance/CaseInstanceTreeElementTest.java
@@ -1,0 +1,35 @@
+package org.commcare.cases.instance;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import org.javarosa.core.model.instance.InstanceBase;
+import org.junit.Test;
+
+
+public class CaseInstanceTreeElementTest {
+
+    @Test
+    public void testGetStorageCacheName() {
+        InstanceBase base = new InstanceBase("test");
+
+        // No identifier — returns plain model name
+        CaseInstanceTreeElement withoutId = new CaseInstanceTreeElement(base, null, null, null);
+        assertEquals("casedb", withoutId.getStorageCacheName());
+
+        // With identifier — returns model name + identifier
+        CaseInstanceTreeElement withId = new CaseInstanceTreeElement(base, null, null, "search_table_1");
+        assertEquals("casedb:search_table_1", withId.getStorageCacheName());
+
+        // Two instances with different identifiers don't collide
+        CaseInstanceTreeElement withId2 = new CaseInstanceTreeElement(base, null, null, "search_table_2");
+        assertNotEquals(withId.getStorageCacheName(), withId2.getStorageCacheName());
+
+        // Instance without identifier doesn't collide with one that has
+        assertNotEquals(withoutId.getStorageCacheName(), withId.getStorageCacheName());
+
+        // Legacy 2-arg constructor — same as null identifier
+        CaseInstanceTreeElement legacy = new CaseInstanceTreeElement(base, null);
+        assertEquals("casedb", legacy.getStorageCacheName());
+    }
+}


### PR DESCRIPTION
## Product Description

Add an optional storageCacheIdentifier constructor parameter. When set, getStorageCacheName() returns "casedb:<identifier>" instead of plain "casedb". Existing constructors pass null (backward compatible).

## Technical Summary

https://dimagi.atlassian.net/browse/USH-6370

## Safety Assurance

By itself this PR does nothing. If the constructor without the identifier is call the behavior is the same. The formplayer code that will use the new constructor will utilize a FF to limit the scope. The concern is more about the performance than functionality since making the cache key more specific might lead to more cache misses.

### Safety story

### Automated test coverage

None

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

### Special deploy instructions

This [formplayer PR](https://github.com/dimagi/formplayer/pull/1770) depends on the change and will have to be deployed together

### Rollback instructions

This [formplayer PR](https://github.com/dimagi/formplayer/pull/1770) depends on the change and will have to be rolled back as well.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved case storage cache infrastructure to support flexible cache configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->