### PR TITLE
Extend ICommCarePreferenceManager To Support Boolean Values

### DIFF
--- a/src/main/java/org/commcare/core/services/ICommCarePreferenceManager.java
+++ b/src/main/java/org/commcare/core/services/ICommCarePreferenceManager.java
@@ -8,4 +8,8 @@ public interface ICommCarePreferenceManager {
     void putLong(String key, long value);
 
     long getLong(String key, long defaultValue);
+
+    void putBoolean(String key, boolean value);
+
+    boolean getBoolean(String key, boolean defaultValue);
 }


### PR DESCRIPTION
### Supports [CCCT-2294](https://dimagi.atlassian.net/browse/CCCT-2294)

## Technical Summary

I extended ICommCarePreferenceManager to support boolean variables (for use in https://github.com/dimagi/commcare-android/pull/3677)

## Safety Assurance

### Safety story

This was dev tested successfully with the changes seen in https://github.com/dimagi/commcare-android/pull/3677


[CCCT-2294]: https://dimagi.atlassian.net/browse/CCCT-2294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to store and manage boolean settings in the preference system for enhanced configuration flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->