### PR TITLE
Only prime cache, if it is available

### DIFF
--- a/src/main/java/org/commcare/cases/entity/AsyncNodeEntityFactory.java
+++ b/src/main/java/org/commcare/cases/entity/AsyncNodeEntityFactory.java
@@ -172,13 +172,15 @@ public class AsyncNodeEntityFactory extends NodeEntityFactory {
     // Old cache and index pathway where we only cache sort fields
     @Deprecated
     protected void setUnCachedDataOld(List<Entity<TreeReference>> entities) {
-        for (int i = 0; i < entities.size(); i++) {
-            if (isCancelled) return;
-            AsyncEntity e = (AsyncEntity)entities.get(i);
-            for (int col = 0; col < e.getNumFields(); ++col) {
+        if (mEntityCache != null) {
+            for (int i = 0; i < entities.size(); i++) {
+                if (isCancelled) return;
+                AsyncEntity e = (AsyncEntity) entities.get(i);
+                for (int col = 0; col < e.getNumFields(); ++col) {
                     e.getSortField(col);
+                }
+                updateProgress(PHASE_UNCACHED_CALCULATION, i, entities.size());
             }
-            updateProgress(PHASE_UNCACHED_CALCULATION, i, entities.size());
         }
     }
 

--- a/src/test/java/org/commcare/cases/entity/AsyncNodeEntityFactoryTest.java
+++ b/src/test/java/org/commcare/cases/entity/AsyncNodeEntityFactoryTest.java
@@ -1,0 +1,77 @@
+package org.commcare.cases.entity;
+
+import org.commcare.suite.model.Detail;
+import org.commcare.suite.model.DetailField;
+import org.commcare.suite.model.Text;
+import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.core.util.OrderedHashtable;
+import org.javarosa.xpath.expr.XPathExpression;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Vector;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Regression test for USH-6551: sort field expressions must not be evaluated during the cache
+ * priming loop when no EntityStorageCache is present (formplayer always passes null).
+ *
+ * Before the fix, setUnCachedDataOld iterated every entity × every column and called
+ * getSortField unconditionally, evaluating expensive XPath even though there was nowhere to
+ * store the result.
+ */
+public class AsyncNodeEntityFactoryTest {
+
+    @Test
+    public void prepareEntities_doesNotCallGetSortField_whenCacheIsNull() {
+        Detail detail = buildDetailWithSortField();
+
+        AsyncNodeEntityFactory factory = new AsyncNodeEntityFactory(
+                detail, new EvaluationContext(null), null, false);
+
+        SpyAsyncEntity spy1 = new SpyAsyncEntity(detail);
+        SpyAsyncEntity spy2 = new SpyAsyncEntity(detail);
+        List<Entity<TreeReference>> entities = new ArrayList<>();
+        entities.add(spy1);
+        entities.add(spy2);
+
+        factory.prepareEntities(entities);
+
+        assertEquals("getSortField must not be called when cache is null", 0, spy1.getSortFieldCallCount);
+        assertEquals("getSortField must not be called when cache is null", 0, spy2.getSortFieldCallCount);
+    }
+
+    private static Detail buildDetailWithSortField() {
+        DetailField.Builder fieldBuilder = new DetailField.Builder();
+        fieldBuilder.setSortOrder(1);
+        fieldBuilder.setSort(Text.PlainText("sort_value"));
+
+        Vector<DetailField> fields = new Vector<>();
+        fields.add(fieldBuilder.build());
+
+        return new Detail("test_detail", null, null, null,
+                new Vector<>(), fields, new OrderedHashtable<>(),
+                null, null, null, null, null, null, null, null, null, null,
+                false, false, null);
+    }
+
+    private static class SpyAsyncEntity extends AsyncEntity {
+        int getSortFieldCallCount = 0;
+
+        SpyAsyncEntity(Detail detail) {
+            super(detail, new EvaluationContext(null), new TreeReference(),
+                    new Hashtable<String, XPathExpression>(), null, null, null);
+        }
+
+        @Override
+        public String getSortField(int i) {
+            getSortFieldCallCount++;
+            return super.getSortField(i);
+        }
+    }
+
+}

--- a/src/test/java/org/commcare/cases/entity/AsyncNodeEntityFactoryTest.java
+++ b/src/test/java/org/commcare/cases/entity/AsyncNodeEntityFactoryTest.java
@@ -17,7 +17,7 @@ import java.util.Vector;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Regression test for USH-6551: sort field expressions must not be evaluated during the cache
+ * Regression test: sort field expressions must not be evaluated during the cache
  * priming loop when no EntityStorageCache is present (formplayer always passes null).
  *
  * Before the fix, setUnCachedDataOld iterated every entity × every column and called


### PR DESCRIPTION
## Product Description

Add a check in the cache priming code. Only do the priming, if there is a cache set.

## Technical Summary

* https://dimagi.atlassian.net/browse/USH-6551 (Original Issue)
* https://dimagi.atlassian.net/browse/USH-6555 (fix implementation story)
* https://docs.google.com/document/d/1gwfS8snRbByB69vc-unPk30mOhB9vX6uNpkq_8yxaAs/edit?tab=t.0 (Write up)

## Safety Assurance

### Safety story

Deploy to staging and test variations:
* Web apps:
  * clickable icon ✅ 
  * sort defined, not defined ✅ 
* mobile app:
  * sort works for enum field
  * sort works for other fields.

### Automated test coverage

Added a test to check for future regressions which doubles as check on the fix.

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized entity data computation to conditionally process legacy data only when cache storage is available, reducing unnecessary processing and improving performance during data loading operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dimagi/commcare-core/pull/1538?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->