### PR TITLE
[SAAS-19868] Add face capture widget

### DIFF
--- a/src/main/java/org/javarosa/core/model/Constants.java
+++ b/src/main/java/org/javarosa/core/model/Constants.java
@@ -80,6 +80,7 @@ public class Constants {
     public static final int CONTROL_AUDIO_CAPTURE = 12;
     public static final int CONTROL_VIDEO_CAPTURE = 13;
     public static final int CONTROL_DOCUMENT_UPLOAD = 14;
+    public static final int CONTROL_FACE_CAPTURE = 15;
 
     /**
      * constants for xform tags

--- a/src/main/java/org/javarosa/xform/parse/XFormParser.java
+++ b/src/main/java/org/javarosa/xform/parse/XFormParser.java
@@ -87,6 +87,7 @@ public class XFormParser {
     private static final String BIND_ATTR = "bind";
     private static final String REF_ATTR = "ref";
     private static final String EVENT_ATTR = "event";
+    private static final String MEDIA_TYPE_ATTR = "mediatype";
     private static final String SELECTONE = "select1";
     private static final String SELECT = "select";
     private static final String SORT = "sort";
@@ -885,12 +886,9 @@ public class XFormParser {
     }
 
     protected QuestionDef parseUpload(IFormElement parent, Element e, int controlUpload) {
-        Vector<String> usedAtts = new Vector<>();
-        usedAtts.addElement("mediatype");
+        QuestionDef question = parseControl(parent, e, controlUpload);
 
-        QuestionDef question = parseControl(parent, e, controlUpload, usedAtts);
-
-        String mediaType = e.getAttributeValue(null, "mediatype");
+        String mediaType = e.getAttributeValue(null, MEDIA_TYPE_ATTR);
         if ("image/*".equals(mediaType)) {
             // NOTE: this could be further expanded. 
             question.setControlType(Constants.CONTROL_IMAGE_CHOOSE);
@@ -919,6 +917,10 @@ public class XFormParser {
     protected QuestionDef parseControl(IFormElement parent, Element e, int controlType,
                                        Vector<String> usedAtts) {
         QuestionDef question = new QuestionDef();
+
+        if (e.getAttributeValue(null, MEDIA_TYPE_ATTR)!=null) {
+            usedAtts.addElement(MEDIA_TYPE_ATTR);
+        }
 
         // Go through all of the registered extension parsers, and if it is applicable to the
         // element we are currently parsing, add the parsed extension data to the QuestionDef

--- a/src/main/java/org/javarosa/xform/parse/XFormParser.java
+++ b/src/main/java/org/javarosa/xform/parse/XFormParser.java
@@ -923,7 +923,7 @@ public class XFormParser {
                                        Vector<String> usedAtts) {
         QuestionDef question = new QuestionDef();
 
-        if (e.getAttributeValue(null, MEDIA_TYPE_ATTR)!=null) {
+        if (e.getAttributeValue(null, MEDIA_TYPE_ATTR) != null) {
             usedAtts.addElement(MEDIA_TYPE_ATTR);
         }
 

--- a/src/main/java/org/javarosa/xform/parse/XFormParser.java
+++ b/src/main/java/org/javarosa/xform/parse/XFormParser.java
@@ -91,6 +91,7 @@ public class XFormParser {
     private static final String SELECTONE = "select1";
     private static final String SELECT = "select";
     private static final String SORT = "sort";
+    private static final String FACE_CAPTURE_APPEARANCE_ATTR = "face";
 
     public static final String NAMESPACE_JAVAROSA = "http://openrosa.org/javarosa";
     public static final String NAMESPACE_HTML = "http://www.w3.org/1999/xhtml";
@@ -890,8 +891,12 @@ public class XFormParser {
 
         String mediaType = e.getAttributeValue(null, MEDIA_TYPE_ATTR);
         if ("image/*".equals(mediaType)) {
-            // NOTE: this could be further expanded. 
-            question.setControlType(Constants.CONTROL_IMAGE_CHOOSE);
+            String appearance = e.getAttributeValue(null, APPEARANCE_ATTR);
+            if (FACE_CAPTURE_APPEARANCE_ATTR.equals(appearance)) {
+                question.setControlType(Constants.CONTROL_FACE_CAPTURE);
+            } else {
+                question.setControlType(Constants.CONTROL_IMAGE_CHOOSE);
+            }
         } else if ("audio/*".equals(mediaType)) {
             question.setControlType(Constants.CONTROL_AUDIO_CAPTURE);
         } else if ("video/*".equals(mediaType)) {


### PR DESCRIPTION
## Summary
Adds a dedicated face-capture control type to the form engine, so the Android client can route `<upload>` questions to the new face-capture widget.

- New `Constants.CONTROL_FACE_CAPTURE` (= 15).
- `XFormParser.parseUpload` now maps `mediatype="image/*"` **with** `appearance="face"` to `CONTROL_FACE_CAPTURE`; plain `image/*` still maps to `CONTROL_IMAGE_CHOOSE`.
- Moved the `mediatype` `usedAtts` registration into `parseControl` so it's tracked whenever the attribute is present.

## Notes
This is the core-side dependency for the Android face-capture widget (`saas-19868`); the android PR builds on this control type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new face-capture option in upload controls.
  * Upload controls can now better distinguish image uploads from face-capture uploads based on available settings.

* **Bug Fixes**
  * Improved handling of media-related upload settings so image, audio, video, and document uploads are recognized more consistently.
  * Reduced unnecessary warnings for valid upload attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->