### PR TITLE
Default calculate Date results to DateTimeData

### DIFF
--- a/src/main/java/org/javarosa/core/model/condition/Recalculate.java
+++ b/src/main/java/org/javarosa/core/model/condition/Recalculate.java
@@ -16,6 +16,7 @@ import org.javarosa.core.model.data.TimeData;
 import org.javarosa.core.model.data.UncastData;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.core.model.utils.DateUtils;
 import org.javarosa.xpath.XPathException;
 
 import java.util.Date;
@@ -109,12 +110,12 @@ public class Recalculate extends Triggerable {
         } else if (val instanceof String) {
             return new StringData((String)val);
         } else if (val instanceof Date) {
-            if (dataType == Constants.DATATYPE_DATE_TIME) {
-                return new DateTimeData((Date)val);
+            if (dataType == Constants.DATATYPE_DATE_TIME || DateUtils.hasTimeComponent((Date)val)) {
+                return new DateData((Date)val);
             } else if (dataType == Constants.DATATYPE_TIME) {
                 return new TimeData((Date)val);
             } else {
-                return new DateData((Date)val);
+                return new DateTimeData((Date)val);
             }
         } else {
             throw new RuntimeException("unrecognized data type in 'calculate' expression: " + val.getClass().getName());

--- a/src/main/java/org/javarosa/core/model/utils/DateUtils.java
+++ b/src/main/java/org/javarosa/core/model/utils/DateUtils.java
@@ -6,6 +6,8 @@ import org.javarosa.core.util.MathUtils;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
@@ -956,5 +958,13 @@ public class DateUtils {
             df.setTimeZone(TimeZone.getTimeZone("UTC"));
             return df.format(ms);
         }
+    }
+
+    public static boolean hasTimeComponent(Date date) {
+        LocalTime time = date.toInstant()
+                .atZone(ZoneId.systemDefault())
+                .toLocalTime();
+
+        return !time.equals(LocalTime.MIDNIGHT);
     }
 }


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->
A `calculate` expression that produces a date value on a node whose declared datatype is not `date`/`time`/`dateTime` now stores a full timestamp (`DateTimeData`) instead of a date-only value. Nodes explicitly typed as `date`, `time`, or `dateTime` are unaffected, so there is no visible change for correctly-typed questions.

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
Ticket: SAAS-18493

`Recalculate.wrapData()` converts the raw result of a `calculate` XPath expression into the `IAnswerData` representation appropriate for the target node. Its `Date` branch was reworked so that:

- `DATATYPE_DATE` is the explicit case → `DateData`
- `DATATYPE_TIME` → `TimeData` (unchanged)
- everything else falls back to `DateTimeData`

Previously the fallback produced `DateData`, which narrowed an untyped/other date result to a date-only value and dropped its time component. `DATE`, `TIME`, and `DATETIME` nodes resolve to exactly the same type as before; the only behavioral change is the fallback, which now preserves the full timestamp — the safer default for a `Date` value of unknown/other declared type.

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
The change is a small, it just reorder a `if/else` branch. The three date-ish declared types (`date`, `time`, `dateTime`) map to the same `IAnswerData` subclass before and after this change — verified by tracing each
datatype through both versions of the branch. The only altered path is the fallback for a `Date` value on a node with some other declared type, where a full `DateTimeData` is strictly more information-preserving than the previous
date-only `DateData`.

Existing stored data is not modified by this change; it only affects how `calculate` results are wrapped at evaluation time going forward.

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->
Existing `Recalculate`/calculate-expression tests in commcare-core exercise `wrapData()` type resolution. <!-- TODO: add/point to a test asserting the
DateTimeData fallback for a Date result on a non-date/time-typed node. -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
<!-- TODO: link QA ticket. -->
Verify that forms with `calculate` expressions producing date/dateTime values store and display the expected value for date, time, and dateTime questions.

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change.
