### PR TITLE
Add a function that gets the menu title for screen

### DIFF
--- a/src/cli/java/org/commcare/util/screen/ScreenUtils.java
+++ b/src/cli/java/org/commcare/util/screen/ScreenUtils.java
@@ -2,14 +2,18 @@ package org.commcare.util.screen;
 
 import org.commcare.modern.session.SessionWrapper;
 import org.commcare.session.SessionFrame;
+import org.commcare.suite.model.Menu;
 import org.commcare.suite.model.StackFrameStep;
+import org.commcare.suite.model.Suite;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.condition.IFunctionHandler;
 import org.javarosa.core.model.data.GeoPointData;
 import org.javarosa.core.services.locale.Localization;
+import org.javarosa.core.services.locale.Localizer;
 import org.javarosa.core.util.NoLocalizedTextException;
 import org.javarosa.xpath.XPathException;
 
+import java.util.Hashtable;
 import java.util.Vector;
 
 /**
@@ -72,6 +76,33 @@ public class ScreenUtils {
             return getAppTitle();
         }
         return bestTitle;
+    }
+
+    public static String getMenuTitle(SessionWrapper session) {
+        Hashtable<String, String> menus = new Hashtable<>();
+        for (Suite s : session.getPlatform().getInstalledSuites()) {
+            for (Menu m : s.getMenus()) {
+                menus.put(m.getId(), m.getName().evaluate());
+            }
+        }
+
+        String menuTitle = null;
+
+        for (StackFrameStep step : session.getFrame().getSteps()) {
+            if (SessionFrame.STATE_COMMAND_ID.equals(step.getType())) {
+                if (menus.containsKey(step.getId())) {
+                    menuTitle = menus.get(step.getId());
+                }
+            }
+        }
+
+        if (menuTitle != null) {
+            //Menus contain a potential argument listing where that value is on the screen,
+            //clear it out if it exists
+            return Localizer.processArguments(menuTitle, new String[]{""}).trim();
+        }
+
+        return menuTitle;
     }
 
     public static String getAppTitle() {

--- a/src/cli/java/org/commcare/util/screen/ScreenUtils.java
+++ b/src/cli/java/org/commcare/util/screen/ScreenUtils.java
@@ -5,6 +5,7 @@ import org.commcare.session.SessionFrame;
 import org.commcare.suite.model.Menu;
 import org.commcare.suite.model.StackFrameStep;
 import org.commcare.suite.model.Suite;
+import org.commcare.suite.model.Text;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.condition.IFunctionHandler;
 import org.javarosa.core.model.data.GeoPointData;
@@ -13,7 +14,7 @@ import org.javarosa.core.services.locale.Localizer;
 import org.javarosa.core.util.NoLocalizedTextException;
 import org.javarosa.xpath.XPathException;
 
-import java.util.Hashtable;
+import java.util.List;
 import java.util.Vector;
 
 /**
@@ -79,30 +80,39 @@ public class ScreenUtils {
     }
 
     public static String getMenuTitle(SessionWrapper session) {
-        Hashtable<String, String> menus = new Hashtable<>();
-        for (Suite s : session.getPlatform().getInstalledSuites()) {
-            for (Menu m : s.getMenus()) {
-                menus.put(m.getId(), m.getName().evaluate());
+        // Walk backwards looking for the most recent step that is an actual menu
+        Vector<StackFrameStep> steps = session.getFrame().getSteps();
+        for (int i = steps.size() - 1; i >= 0; i--) {
+            StackFrameStep step = steps.elementAt(i);
+            if (!SessionFrame.STATE_COMMAND_ID.equals(step.getType())) {
+                continue;
             }
-        }
 
-        String menuTitle = null;
-
-        for (StackFrameStep step : session.getFrame().getSteps()) {
-            if (SessionFrame.STATE_COMMAND_ID.equals(step.getType())) {
-                if (menus.containsKey(step.getId())) {
-                    menuTitle = menus.get(step.getId());
+            for (Suite s : session.getPlatform().getInstalledSuites()) {
+                List<Menu> menus = s.getMenusWithId(step.getId());
+                if (menus == null) {
+                    continue;
+                }
+                for (Menu m : menus) {
+                    Text name = m.getName();
+                    if (name == null) {
+                        continue;
+                    }
+                    try {
+                        // Menus contain a potential argument listing where that value is on the screen,
+                        // clear it out if it exists
+                        return Localizer.processArguments(name.evaluate(), new String[]{""}).trim();
+                    } catch (NoLocalizedTextException | XPathException e) {
+                        // localization resources may not be installed while in the middle of an update,
+                        // or the menu's title may reference session state unavailable here; either way
+                        // this is just for logging, so fall back to no title instead of blowing up.
+                        return null;
+                    }
                 }
             }
         }
 
-        if (menuTitle != null) {
-            //Menus contain a potential argument listing where that value is on the screen,
-            //clear it out if it exists
-            return Localizer.processArguments(menuTitle, new String[]{""}).trim();
-        }
-
-        return menuTitle;
+        return null;
     }
 
     public static String getAppTitle() {

--- a/src/main/java/org/commcare/session/CommCareSession.java
+++ b/src/main/java/org/commcare/session/CommCareSession.java
@@ -328,33 +328,6 @@ public class CommCareSession {
         return returnVal;
     }
 
-    public String getClosestMenuTitle() {
-        Hashtable<String, String> menus = new Hashtable<>();
-        for (Suite s : platform.getInstalledSuites()) {
-            for (Menu m : s.getMenus()) {
-                menus.put(m.getId(), m.getName().evaluate());
-            }
-        }
-
-        String returnVal = null;
-
-        for (StackFrameStep step : frame.getSteps()) {
-            if (SessionFrame.STATE_COMMAND_ID.equals(step.getType())) {
-                if (menus.containsKey(step.getId())) {
-                    returnVal = menus.get(step.getId());
-                }
-            }
-        }
-
-        if (returnVal != null) {
-            //Menus contain a potential argument listing where that value is on the screen,
-            //clear it out if it exists
-            return Localizer.processArguments(returnVal, new String[]{""}).trim();
-        }
-
-        return returnVal;
-    }
-
     /**
      * @return The next relevant datum for the current entry. Requires there to be
      * an entry on the stack

--- a/src/main/java/org/commcare/session/CommCareSession.java
+++ b/src/main/java/org/commcare/session/CommCareSession.java
@@ -346,6 +346,12 @@ public class CommCareSession {
             }
         }
 
+        if (returnVal != null) {
+            //Menus contain a potential argument listing where that value is on the screen,
+            //clear it out if it exists
+            return Localizer.processArguments(returnVal, new String[]{""}).trim();
+        }
+
         return returnVal;
     }
 

--- a/src/main/java/org/commcare/session/CommCareSession.java
+++ b/src/main/java/org/commcare/session/CommCareSession.java
@@ -328,6 +328,27 @@ public class CommCareSession {
         return returnVal;
     }
 
+    public String getClosestMenuTitle() {
+        Hashtable<String, String> menus = new Hashtable<>();
+        for (Suite s : platform.getInstalledSuites()) {
+            for (Menu m : s.getMenus()) {
+                menus.put(m.getId(), m.getName().evaluate());
+            }
+        }
+
+        String returnVal = null;
+
+        for (StackFrameStep step : frame.getSteps()) {
+            if (SessionFrame.STATE_COMMAND_ID.equals(step.getType())) {
+                if (menus.containsKey(step.getId())) {
+                    returnVal = menus.get(step.getId());
+                }
+            }
+        }
+
+        return returnVal;
+    }
+
     /**
      * @return The next relevant datum for the current entry. Requires there to be
      * an entry on the stack

--- a/src/test/java/org/commcare/backend/session/test/MenuTests.java
+++ b/src/test/java/org/commcare/backend/session/test/MenuTests.java
@@ -2,6 +2,7 @@ package org.commcare.backend.session.test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import org.commcare.modern.session.SessionWrapper;
@@ -11,6 +12,7 @@ import org.commcare.suite.model.Menu;
 import org.commcare.suite.model.Suite;
 import org.commcare.suite.model.Text;
 import org.commcare.test.utilities.MockApp;
+import org.commcare.util.screen.ScreenUtils;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.junit.Before;
 import org.junit.Test;
@@ -54,5 +56,26 @@ public class MenuTests {
         assertEquals(2, instanceIds.size());
         assertTrue(instanceIds.contains("my_instance"));
         assertTrue(instanceIds.contains("casedb"));
+    }
+
+    @Test
+    public void testGetMenuTitle_ReturnsCurrentMenuName() {
+        SessionWrapper currentSession = appWithMenuAssertions.getSession();
+        currentSession.setCommand("m0");
+        assertEquals("Menu", ScreenUtils.getMenuTitle(currentSession));
+    }
+
+    @Test
+    public void testGetMenuTitle_SkipsNonMenuCommandSteps() {
+        SessionWrapper currentSession = appWithMenuAssertions.getSession();
+        currentSession.setCommand("m0");
+        currentSession.setCommand("m0-f0");
+        assertEquals("Menu", ScreenUtils.getMenuTitle(currentSession));
+    }
+
+    @Test
+    public void testGetMenuTitle_NoCommandStep_ReturnsNull() {
+        SessionWrapper currentSession = appWithMenuAssertions.getSession();
+        assertNull(ScreenUtils.getMenuTitle(currentSession));
     }
 }


### PR DESCRIPTION
## Product Description

getBestTitle is not always the menu title. Add a function that returns exactly that for logging to datadog and google analytics (https://github.com/dimagi/formplayer/pull/1794)

## Technical Summary

https://dimagi.atlassian.net/browse/USH-6605

## Safety Assurance

### Safety story

Tested on staging

### Automated test coverage

Added tests

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

-  This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- The formplayer PR https://github.com/dimagi/formplayer/pull/1794 depends on this change and needs to reverted as well.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for identifying the title of the most recently selected menu in the current session.
  * Returns no menu title when the session does not contain a matching menu selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->