### PR TITLE
Fix case search date ranges being a day early in the Americas

### DIFF
--- a/src/main/java/org/commcare/util/DateRangeUtils.java
+++ b/src/main/java/org/commcare/util/DateRangeUtils.java
@@ -6,6 +6,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
+import java.util.TimeZone;
 
 import javax.annotation.Nullable;
 
@@ -74,8 +75,12 @@ public class DateRangeUtils {
         return DATE_RANGE_ANSWER_PREFIX + startDate + DATE_RANGE_ANSWER_DELIMITER + endDate;
     }
 
-    // Convers given time as yyyy-mm-dd
+    // Converts given time as yyyy-mm-dd
     public static String getDateFromTime(Long time) {
-        return new SimpleDateFormat(DATE_FORMAT, Locale.US).format(new Date(time));
+        SimpleDateFormat sdf = new SimpleDateFormat(DATE_FORMAT, Locale.US);
+        // Date range times are held as UTC midnight (see getTimeFromDateOffsettingTz), so the
+        // local zone would report the wrong day for anywhere west of Greenwich.
+        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return sdf.format(new Date(time));
     }
 }

--- a/src/test/java/org/commcare/util/DateRangeUtilsTest.java
+++ b/src/test/java/org/commcare/util/DateRangeUtilsTest.java
@@ -5,14 +5,29 @@ import junit.framework.TestCase;
 import org.junit.Test;
 
 import java.text.ParseException;
+import java.util.TimeZone;
 
 public class DateRangeUtilsTest extends TestCase {
 
     @Test
     public void testDateConversion() throws ParseException {
-        String dateRange = "2020-02-15 to 2021-03-18";
-        String formattedDateRange = DateRangeUtils.formatDateRangeAnswer(dateRange);
-        assertEquals("__range__2020-02-15__2021-03-18", formattedDateRange);
-        assertEquals(dateRange, DateRangeUtils.getHumanReadableDateRange(formattedDateRange));
+        // The conversion passes through UTC, so the day it lands on depends on which side of
+        // Greenwich you are. Pin the zone rather than inheriting the runner's.
+        assertRoundTrip("UTC");
+        assertRoundTrip("America/Chicago");
+        assertRoundTrip("Asia/Kolkata");
+    }
+
+    private void assertRoundTrip(String timeZoneId) throws ParseException {
+        TimeZone originalTimeZone = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone(timeZoneId));
+        try {
+            String dateRange = "2020-02-15 to 2021-03-18";
+            String formattedDateRange = DateRangeUtils.formatDateRangeAnswer(dateRange);
+            assertEquals(timeZoneId, "__range__2020-02-15__2021-03-18", formattedDateRange);
+            assertEquals(timeZoneId, dateRange, DateRangeUtils.getHumanReadableDateRange(formattedDateRange));
+        } finally {
+            TimeZone.setDefault(originalTimeZone);
+        }
     }
 }


### PR DESCRIPTION
## Product Description

This is a live product bug, not a test-only fix. For users whose device timezone is behind UTC — in practice, the Americas — every date range on a case search came out a day early. Picking 15 Feb in the calendar recorded 14 Feb, and the wrong date was shown back in the field straight away; prefilled defaults were shifted the same way. Web Apps is unaffected, since those servers run on UTC.

## Technical Summary

The date range code converts to UTC when it reads a date and is supposed to convert back when it writes one, but the writing half used the local timezone instead — which is still the previous day anywhere behind UTC. This makes the two halves agree.

## Safety Assurance

### Safety story

Small formatting change in one utility, nothing stored or migrated. The dates it produced before were simply wrong.

I checked the commcare-android caller, which is the only one outside this repo. It hands the date picker a UTC value and reads that same selection back out, so UTC is the right frame on both ends. Confirmed the behaviour directly in a US timezone: before this change picking 15 Feb recorded 14 Feb, after it records 15 Feb.

### Automated test coverage

A test for this already existed, but it only failed if you happened to run it in an affected timezone, which is why CI never caught it. It now sets the timezone explicitly and checks both sides of UTC; I confirmed it fails without the fix.

### QA Plan

Covered by the test. Worth a spot check on a device set to a US timezone: pick a date range on a case search and confirm the dates that come back are the ones you picked.

### Special deploy instructions

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change.
